### PR TITLE
Feat/warp primitives

### DIFF
--- a/docs/source/api_reference/index.rst
+++ b/docs/source/api_reference/index.rst
@@ -13,6 +13,8 @@ The reference is organized by BLAS level and by backend:
 * **L3** — matrix operations (gemm and variants, inverse, Cholesky, trsm).
 * **NVIDIA backend** — the ``glass::nvidia::`` CUB / cuBLASDx / cuSOLVERDx paths
   and their host-side query/size helpers.
+* **Warp-scoped** — the ``glass::warp::`` single-warp SIMT variants for
+  warp-per-problem kernels.
 
 .. note::
 
@@ -28,3 +30,4 @@ The reference is organized by BLAS level and by backend:
    l2
    l3
    nvidia
+   warp

--- a/docs/source/api_reference/l1.rst
+++ b/docs/source/api_reference/l1.rst
@@ -4,6 +4,8 @@ L1 — Vector Operations
 Single-block vector primitives: scaled sums, copies, scaling, dot products,
 reductions, norms, and elementwise logic. Pure-SIMT (``glass::``) routines are
 listed first, followed by the cooperative-groups (``glass::cgrps::``) variants.
+Single-warp (``glass::warp::``) variants, where they exist, render inline beside
+their block-scoped sibling (e.g. under *reduce*); see :doc:`warp`.
 
 axpy / axpby
 ------------

--- a/docs/source/api_reference/l3.rst
+++ b/docs/source/api_reference/l3.rst
@@ -6,7 +6,9 @@ indexed variants), matrix inversion, Cholesky factorization, and triangular
 solves. The GEMM family takes compile-time storage-order flags
 (``ROW_MAJOR_A`` / ``ROW_MAJOR_B`` / ``ROW_MAJOR_C``) and a ``TRANSPOSE_B``
 flag; see :doc:`../user_guide/concepts/backend_dispatch` for how the dispatch
-GEMM chooses a path.
+GEMM chooses a path. Single-warp (``glass::warp::``) variants of ``gemm``,
+``cholDecomp_InPlace``, and ``trsm`` render inline beside their block-scoped
+sibling; see :doc:`warp`.
 
 gemm
 ----

--- a/docs/source/api_reference/warp.rst
+++ b/docs/source/api_reference/warp.rst
@@ -1,0 +1,24 @@
+Warp-scoped operations (``glass::warp::``)
+==========================================
+
+Single-warp SIMT variants of selected primitives: one 32-lane warp cooperates
+using raw ``__shfl_*_sync`` intrinsics, with **no shared scratch, no inter-warp
+combine, and no** ``__syncthreads``. They target *warp-per-problem* kernels — a
+block that solves many independent problems, one per warp — where the
+block-scoped ``glass::`` surface would serialize across warps and the
+cooperative-groups / vendor paths add overhead at these tiny sizes.
+
+Contract: the caller must run a full 32-lane warp (mask ``0xffffffff``);
+partial-warp callers pass ``0`` from inactive lanes. These live in the same base
+headers as their block-scoped siblings (under ``namespace warp``), so their
+rendered signatures appear on the :doc:`l1` and :doc:`l3` pages:
+
+* ``glass::warp::reduce`` — single-warp sum (array and register-partial forms);
+  see :doc:`l1`.
+* ``glass::warp::gemm`` — compile-time-size GEMM across one warp (e.g. 4×4
+  homogeneous-transform multiplies); see :doc:`l3`.
+* ``glass::warp::cholDecomp_InPlace`` / ``glass::warp::trsm`` /
+  ``glass::warp::trsm_transpose`` — small SPD factor + forward/transpose solves;
+  compose them for a warp-scoped normal-equations solve. See :doc:`l3`.
+
+See ``examples/07_warp_ops.cu`` for a runnable demonstration.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,19 @@ Three namespaces, one mental model
       Vendor-accelerated paths (CUB, cuBLASDx, cuSOLVERDx) that auto-dispatch
       between SIMT and the vendor backend by size. Needs NVIDIA MathDx.
 
+Block-scoped by default, warp-scoped where it pays
+--------------------------------------------------
+
+GLASS primitives are **block-scoped** by default: you launch one block per
+problem and the block's threads cooperate over the whole operation. For kernels
+that instead pack *many small independent problems into one block* — one per
+warp — the ``glass::warp::`` sub-namespace now exposes single-warp SIMT variants
+of selected L1/L3 ops (``reduce``, ``gemm``, ``cholDecomp_InPlace``, ``trsm``).
+They use raw ``__shfl_*_sync`` intrinsics with no ``__syncthreads`` and no shared
+scratch, so the warps run independently — turning the block into a vehicle for
+**intra-block parallelism** rather than serializing the problems across it. See
+:doc:`api_reference/warp`.
+
 .. grid:: 2
    :gutter: 3
 

--- a/examples/07_warp_ops.cu
+++ b/examples/07_warp_ops.cu
@@ -1,0 +1,73 @@
+// 07_warp_ops.cu — single-warp (glass::warp::) primitives, launched <<<1,32>>>.
+//
+// Build (from this examples/ dir):
+//   nvcc -std=c++17 -arch=sm_75 -I.. 07_warp_ops.cu -o warp_ops && ./warp_ops
+//
+// The glass::warp:: namespace holds warp-scoped SIMT variants (raw __shfl, one
+// 32-lane warp, no shared scratch, no __syncthreads) for warp-per-problem
+// kernels — e.g. a block that processes many independent problems, one per warp.
+// No cooperative groups, no vendor (cuBLASDx/cuSOLVERDx) deps.
+
+#include "glass.cuh"
+#include <cstdio>
+#include <cuda_runtime.h>
+
+// Sum a vector within one warp; result in x[0].
+__global__ void warp_reduce_kernel(float *x, int n) {
+    glass::warp::reduce(static_cast<uint32_t>(n), x);
+}
+
+// 4x4 column-major GEMM C = A*B within one warp (the mat4-multiply use case).
+__global__ void warp_gemm_kernel(float *A, float *B, float *C) {
+    glass::warp::gemm<float, 4, 4, 4>(1.0f, A, B, 0.0f, C);
+}
+
+// SPD solve A x = b within one warp: factor A = L Lᵀ, then forward + transpose solve.
+__global__ void warp_posv_kernel(float *A, float *b) {
+    glass::warp::cholDecomp_InPlace<float, 3>(A);
+    glass::warp::trsm<float, 3>(A, b);
+    glass::warp::trsm_transpose<float, 3>(A, b);
+}
+
+int main() {
+    // ── warp::reduce ──
+    const int n = 8;
+    float hx[n];
+    for (int i = 0; i < n; ++i) hx[i] = static_cast<float>(i + 1);   // sum = 36
+    float *dx; cudaMalloc(&dx, n * sizeof(float));
+    cudaMemcpy(dx, hx, n * sizeof(float), cudaMemcpyHostToDevice);
+    warp_reduce_kernel<<<1, 32>>>(dx, n);
+    cudaDeviceSynchronize();
+    float s = 0.f; cudaMemcpy(&s, dx, sizeof(float), cudaMemcpyDeviceToHost);
+    printf("glass::warp::reduce      sum(1..8) = %.0f (expect 36)\n", s);
+
+    // ── warp::gemm (4x4, column-major; B = identity ⇒ C = A) ──
+    float hA[16], hB[16] = {0}, hC[16] = {0};
+    for (int i = 0; i < 16; ++i) hA[i] = static_cast<float>(i);
+    for (int i = 0; i < 4; ++i) hB[i*4 + i] = 1.0f;                  // identity
+    float *dA, *dB, *dC;
+    cudaMalloc(&dA, 16*sizeof(float)); cudaMalloc(&dB, 16*sizeof(float)); cudaMalloc(&dC, 16*sizeof(float));
+    cudaMemcpy(dA, hA, 16*sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(dB, hB, 16*sizeof(float), cudaMemcpyHostToDevice);
+    warp_gemm_kernel<<<1, 32>>>(dA, dB, dC);
+    cudaDeviceSynchronize();
+    cudaMemcpy(hC, dC, 16*sizeof(float), cudaMemcpyDeviceToHost);
+    printf("glass::warp::gemm        C[0,5,10,15] = %.0f %.0f %.0f %.0f (expect 0 5 10 15)\n",
+           hC[0], hC[5], hC[10], hC[15]);
+
+    // ── warp:: SPD solve (3x3, column-major) ──
+    // A = [[4,1,0],[1,3,1],[0,1,2]] (SPD), b = [1,2,3]; solve A x = b.
+    float hAs[9] = {4,1,0, 1,3,1, 0,1,2};   // column-major == symmetric here
+    float hb[3]  = {1,2,3};
+    float *dAs, *db;
+    cudaMalloc(&dAs, 9*sizeof(float)); cudaMalloc(&db, 3*sizeof(float));
+    cudaMemcpy(dAs, hAs, 9*sizeof(float), cudaMemcpyHostToDevice);
+    cudaMemcpy(db, hb, 3*sizeof(float), cudaMemcpyHostToDevice);
+    warp_posv_kernel<<<1, 32>>>(dAs, db);
+    cudaDeviceSynchronize();
+    float hx3[3]; cudaMemcpy(hx3, db, 3*sizeof(float), cudaMemcpyDeviceToHost);
+    printf("glass::warp:: SPD solve  x = %.3f %.3f %.3f\n", hx3[0], hx3[1], hx3[2]);
+
+    cudaFree(dx); cudaFree(dA); cudaFree(dB); cudaFree(dC); cudaFree(dAs); cudaFree(db);
+    return 0;
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -20,9 +20,10 @@ build. For the full API surface and the backend-choice guide, read that README.
 | [`04_cgrps.cu`](04_cgrps.cu) | the **cooperative-groups** variant `glass::cgrps::gemm` (whole-block or warp-tile) | pure SIMT — no extra deps |
 | [`05_gemm_dispatch.cu`](05_gemm_dispatch.cu) | `glass::gemm_dispatch` + dynamic shared memory via the `glass_gemm_dispatch_smem` host helper (tiled path) | pure SIMT — no extra deps |
 | [`06_nvidia_gemm.cu`](06_nvidia_gemm.cu) | the cuBLASDx-backed `glass::nvidia::gemm` path | **requires NVIDIA MathDx** |
+| [`07_warp_ops.cu`](07_warp_ops.cu) | single-warp `glass::warp::` ops (`reduce`, 4×4 `gemm`, SPD `cholDecomp_InPlace`+`trsm`+`trsm_transpose`), launched `<<<1,32>>>` | pure SIMT — no extra deps |
 
-**Examples 01–05 are pure SIMT** — they build with plain `nvcc` and need no
-external libraries. **Only `06_nvidia_gemm.cu` needs MathDx** (cuBLASDx); skip
+**Examples 01–05 and 07 are pure SIMT** — they build with plain `nvcc` and need
+no external libraries. **Only `06_nvidia_gemm.cu` needs MathDx** (cuBLASDx); skip
 it if you don't have MathDx installed.
 
 ## Building
@@ -41,6 +42,7 @@ nvcc -std=c++17 -arch=sm_75 -I.. 02_gemm.cu         -o gemm     && ./gemm
 nvcc -std=c++17 -arch=sm_75 -I.. 03_reduce.cu       -o reduce   && ./reduce
 nvcc -std=c++17 -arch=sm_75 -I.. 04_cgrps.cu        -o cgrps    && ./cgrps
 nvcc -std=c++17 -arch=sm_75 -I.. 05_gemm_dispatch.cu -o dispatch && ./dispatch
+nvcc -std=c++17 -arch=sm_75 -I.. 07_warp_ops.cu     -o warp_ops && ./warp_ops
 ```
 
 ### NVIDIA / cuBLASDx example (06) — requires MathDx

--- a/src/base/L1/reduce.cuh
+++ b/src/base/L1/reduce.cuh
@@ -208,3 +208,73 @@ namespace high_speed {
         return total;
     }
 }
+
+namespace warp {
+    // Single-warp reductions: raw __shfl, no shared scratch, no inter-warp combine.
+    // For warp-per-problem kernels (one 32-lane warp owns the reduction). The
+    // caller must run a full warp (mask 0xffffffff); partial-warp callers must
+    // pass 0 from inactive lanes. Distinct from high_speed::reduce, which is
+    // block-scoped (warp-shuffle + shared inter-warp combine).
+
+    /**
+     * @brief Sum reduction within one warp: `x[0] = Σ x[i]` (in-place), single-warp.
+     *
+     * One 32-lane warp sums the vector with `__shfl_down_sync`; the total lands in
+     * `x[0]` (input overwritten). No shared scratch, no inter-warp combine. NumPy
+     * equivalent: `np.sum(x)`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @param n  Number of elements.
+     * @param x  In/out vector of length `n`; the sum lands in `x[0]`.
+     */
+    template <typename T>
+    __device__ void reduce(uint32_t n, T *x)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < n; i += 32) val += x[i];
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
+        if (lane == 0) x[0] = val;
+        __syncwarp();
+    }
+
+    /**
+     * @brief Sum reduction within one warp: `x[0] = Σ x[i]` (in-place), single-warp, compile-time size.
+     *
+     * Compile-time-`N` overload. NumPy equivalent: `np.sum(x)`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @tparam N  Number of elements (compile-time constant).
+     * @param x  In/out vector of length `N`; the sum lands in `x[0]`.
+     */
+    template <typename T, uint32_t N>
+    __device__ void reduce(T *x)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < N; i += 32) val += x[i];
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
+        if (lane == 0) x[0] = val;
+        __syncwarp();
+    }
+
+    /**
+     * @brief Warp-sum of a per-lane register value: returns `Σ partial` on every lane.
+     *
+     * Reduces one PER-LANE contribution across a single warp and broadcasts the
+     * total back to all 32 lanes — no `x[]` buffer, no shared scratch. The entry
+     * point for fused "compute-a-partial-then-sum" patterns inside a warp (e.g.
+     * row-norm / residual accumulation). Inactive lanes should pass `0`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @param partial  This lane's contribution.
+     * @return The warp-wide total `Σ partial`, identical on every lane.
+     */
+    template <typename T>
+    __device__ T reduce(T partial)
+    {
+        T val = partial;
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
+        return __shfl_sync(0xffffffff, val, 0);
+    }
+}

--- a/src/base/L3/chol_InPlace.cuh
+++ b/src/base/L3/chol_InPlace.cuh
@@ -53,3 +53,42 @@ __device__ void cholDecomp_InPlace(T *s_A)
 {
     cholDecomp_InPlace<T>(N, s_A);
 }
+
+namespace warp {
+    /**
+     * @brief Single-warp in-place Cholesky factorization (LAPACK potrf, lower), compile-time size.
+     *
+     * One 32-lane warp factors the SPD matrix `A = L * L^T` in place, writing only
+     * the lower triangle (column-major). For warp-per-problem solvers on small
+     * systems (e.g. N≈7 normal equations). Lane 0 computes each diagonal; the
+     * remaining sub-diagonal entries of the column are filled by the warp's lanes
+     * (stride 32), synchronized with `__syncwarp`. No shared scratch, no
+     * `__syncthreads`. `A` must be SPD. NumPy equivalent:
+     * `L = np.linalg.cholesky(A)`.
+     *
+     * @tparam T  Scalar type (use `double` for stability on ill-conditioned A).
+     * @tparam N  Matrix dimension (A is N x N).
+     * @param s_A  In/out N x N matrix (column-major); on return its lower triangle holds L.
+     */
+    template <typename T, uint32_t N>
+    __device__ void cholDecomp_InPlace(T *s_A)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (uint32_t k = 0; k < N; k++) {
+            if (lane == 0) {
+                T sum = static_cast<T>(0);
+                T val = s_A[k*N + k];
+                for (uint32_t r = 0; r < k; r++) sum += s_A[r*N + k]*s_A[r*N + k];
+                s_A[k*N + k] = sqrt(val - sum);
+            }
+            __syncwarp();
+            T diag = s_A[k*N + k];
+            for (uint32_t row = lane + k + 1; row < N; row += 32) {
+                T sum = static_cast<T>(0);
+                for (uint32_t kk = 0; kk < k; kk++) sum += s_A[kk*N + row]*s_A[kk*N + k];
+                s_A[k*N + row] = (s_A[k*N + row] - sum) / diag;
+            }
+            __syncwarp();
+        }
+    }
+}

--- a/src/base/L3/gemm.cuh
+++ b/src/base/L3/gemm.cuh
@@ -272,6 +272,58 @@ __device__ void gemm(T alpha, T *A, T *B, T *C)
     gemm_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(rank, size, alpha, A, B, C);
 }
 
+// ─── single-warp compile-time GEMM ───────────────────────────────────────────
+namespace warp {
+    /**
+     * @brief Single-warp compile-time-size GEMM: `C = alpha * A * op(B) + beta * C`.
+     *
+     * One 32-lane warp computes the product with flat per-element parallelism
+     * (lanes stride over the `M * Ccols` outputs) — same semantics as the
+     * block-scoped compile-time `gemm`, but scoped to a single warp for
+     * warp-per-problem kernels (e.g. 4×4 homogeneous-transform multiplies). No
+     * inter-lane communication, no sync. `C` must not alias `A`/`B`. NumPy:
+     * `C = alpha * A @ op(B) + beta * C`.
+     *
+     * @tparam T  Scalar type.
+     * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
+     * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
+     * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+     * @param alpha  Scalar multiplier on the product.
+     * @param A,B    Input matrices.
+     * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
+     * @param C      In/out result matrix.
+     */
+    template <typename T, uint32_t M, uint32_t N, uint32_t K,
+              bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
+    __device__ void gemm(T alpha, T *A, T *B, T beta, T *C)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        gemm_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(lane, 32u, alpha, A, B, beta, C);
+    }
+
+    /**
+     * @brief Single-warp compile-time-size GEMM with implicit `beta = 0`: `C = alpha * A * op(B)`.
+     *
+     * Overwrites C (the existing C is not read). Otherwise identical to the
+     * beta overload above. NumPy: `C = alpha * A @ op(B)`.
+     *
+     * @tparam T  Scalar type.
+     * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
+     * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
+     * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+     * @param alpha  Scalar multiplier on the product.
+     * @param A,B    Input matrices.
+     * @param C      Output result matrix (overwritten).
+     */
+    template <typename T, uint32_t M, uint32_t N, uint32_t K,
+              bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
+    __device__ void gemm(T alpha, T *A, T *B, T *C)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        gemm_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(lane, 32u, alpha, A, B, C);
+    }
+}
+
 // ─── tiled GEMM (shared-memory staging, column-major only) ───────────────────
 /**
  * @brief Tiled GEMM with shared-memory staging: `C = alpha * A * B + beta * C`.

--- a/src/base/L3/trsm.cuh
+++ b/src/base/L3/trsm.cuh
@@ -45,3 +45,61 @@ __device__ void trsm(T *L, T *b)
 {
     trsm<T>(N, L, b);
 }
+
+namespace warp {
+    /**
+     * @brief Single-warp lower-triangular solve `L x = b` (forward substitution), compile-time size.
+     *
+     * One 32-lane warp solves `L x = b` in place (column-major lower-triangular `L`),
+     * overwriting `b`. For warp-per-problem solvers; pairs with `warp::trsm_transpose`
+     * to solve an SPD system from its Cholesky factor. No `__syncthreads`. SciPy:
+     * `x = scipy.linalg.solve_triangular(L, b, lower=True)`.
+     *
+     * @tparam T  Scalar type.
+     * @tparam N  Dimension (L is N x N, b has length N).
+     * @param L  Lower-triangular matrix (column-major).
+     * @param b  In/out right-hand side; on return holds the solution x.
+     */
+    template <typename T, uint32_t N>
+    __device__ void trsm(T *L, T *b)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (uint32_t col = 0; col < N; col++) {
+            if (lane == 0) b[col] /= L[col*N + col];
+            __syncwarp();
+            T factor = b[col];
+            for (uint32_t row = lane + col + 1; row < N; row += 32)
+                b[row] -= L[col*N + row] * factor;
+            __syncwarp();
+        }
+    }
+
+    /**
+     * @brief Single-warp transpose-triangular solve `Lᵀ x = b` (back substitution), compile-time size.
+     *
+     * One 32-lane warp solves `Lᵀ x = b` in place given a lower-triangular `L`
+     * (column-major), overwriting `b`. Together with `warp::trsm` this solves an SPD
+     * system `A x = b` from `A = L Lᵀ`: factor with `warp::cholDecomp_InPlace`, then
+     * `warp::trsm` (forward) then `warp::trsm_transpose` (back). No `__syncthreads`.
+     * SciPy: `x = scipy.linalg.solve_triangular(L.T, b, lower=False)`.
+     *
+     * @tparam T  Scalar type.
+     * @tparam N  Dimension (L is N x N, b has length N).
+     * @param L  Lower-triangular matrix (column-major); `Lᵀ` is used implicitly.
+     * @param b  In/out right-hand side; on return holds the solution x.
+     */
+    template <typename T, uint32_t N>
+    __device__ void trsm_transpose(T *L, T *b)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (int32_t col = (int32_t)N - 1; col >= 0; col--) {
+            if (lane == 0) b[col] /= L[col*N + col];
+            __syncwarp();
+            T factor = b[col];
+            // eliminate x[col] from rows i < col:  b[i] -= (Lᵀ)_{i,col} x[col] = L_{col,i} x[col]
+            for (uint32_t i = lane; i < (uint32_t)col; i += 32)
+                b[i] -= L[i*N + col] * factor;
+            __syncwarp();
+        }
+    }
+}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -48,6 +48,12 @@ def _hash_sources(cu_path: pathlib.Path) -> str:
               GLASS_DIR / "glass.cuh", GLASS_DIR / "glass-cgrps.cuh",
               GLASS_DIR / "src" / "L3" / "box_qp.cuh",
               GLASS_DIR / "src" / "base" / "L1" / "dot_strided_coalesced.cuh",
+              # base headers carrying the warp:: variants — listed explicitly so
+              # edits to them (pulled in only transitively via glass.cuh) bust the cache.
+              GLASS_DIR / "src" / "base" / "L1" / "reduce.cuh",
+              GLASS_DIR / "src" / "base" / "L3" / "gemm.cuh",
+              GLASS_DIR / "src" / "base" / "L3" / "chol_InPlace.cuh",
+              GLASS_DIR / "src" / "base" / "L3" / "trsm.cuh",
               GLASS_DIR / "src" / "base" / "L2" / "gemv_segmented.cuh",
               GLASS_DIR / "src" / "base" / "L3" / "gemm_batched_indexed.cuh",
               GLASS_DIR / "glass-nvidia.cuh",

--- a/test/cuda/test_l1.cu
+++ b/test/cuda/test_l1.cu
@@ -60,6 +60,16 @@ __global__ void k_reduce_simple_lm(int n, float* x) { glass::low_memory::reduce(
 __global__ void k_reduce_simple_hs(int n, float* x, float* scratch) {
     glass::high_speed::reduce(n, x, scratch);
 }
+// Single-warp reduce (launch <<<1,32>>>): raw __shfl, no scratch, no inter-warp combine.
+__global__ void k_reduce_warp(int n, float* x) { glass::warp::reduce(n, x); }
+// Single-warp register-partial reduce: each lane forms a strided partial, gets the warp total back.
+__global__ void k_reduce_partial_warp(int n, float* x, float* out) {
+    uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+    float partial = 0.0f;
+    for (uint32_t i = lane; i < (uint32_t)n; i += 32) partial += x[i];
+    float total = glass::warp::reduce(partial);
+    out[0] = total;   // broadcast check: every lane holds the same `total`
+}
 // Register-partial -> block-sum overload: each thread forms a per-thread partial
 // (here a strided slice of x, mirroring a cost/barrier kernel's per-thread term),
 // passes it directly to reduce(partial, scratch), and gets the block total back.
@@ -207,6 +217,7 @@ static bool is_cg(const char* v)     { return strcmp(v, "cg") == 0; }
 static bool is_simple(const char* v) { return strcmp(v, "simple") == 0; }
 static bool is_lm(const char* v)     { return strcmp(v, "simple_lm") == 0; }
 static bool is_hs(const char* v)     { return strcmp(v, "simple_hs") == 0; }
+static bool is_warp(const char* v)   { return strcmp(v, "warp") == 0; }
 
 // ─── main ────────────────────────────────────────────────────────────────────
 
@@ -290,6 +301,8 @@ int main(int argc, char** argv) {
             k_reduce_cg<<<1, THREADS>>>(n, dx);
         } else if (is_lm(ver)) {
             k_reduce_simple_lm<<<1, THREADS>>>(n, dx);
+        } else if (is_warp(ver)) {
+            k_reduce_warp<<<1, 32>>>(n, dx);
         } else {
             k_reduce_simple_hs<<<1, THREADS>>>(n, dx, d_scratch);
         }
@@ -299,7 +312,11 @@ int main(int argc, char** argv) {
     } else if (strcmp(op, "reduce_partial") == 0) {
         float* dx  = read_device_vec(argv[4], n);
         float* dout = alloc_device_vec(1);
-        k_reduce_partial_hs<<<1, THREADS>>>(n, dx, dout, d_scratch);
+        if (is_warp(ver)) {
+            k_reduce_partial_warp<<<1, 32>>>(n, dx, dout);
+        } else {
+            k_reduce_partial_hs<<<1, THREADS>>>(n, dx, dout, d_scratch);
+        }
         cudaDeviceSynchronize();
         print_device_vec(dout, 1);
 

--- a/test/cuda/test_l3.cu
+++ b/test/cuda/test_l3.cu
@@ -96,6 +96,20 @@ __global__ void k_trsm_simple(int n, float* L, float* b) {
     glass::trsm(n, L, b);
 }
 
+// ─── warp:: kernels (launch <<<1,32>>>) ──────────────────────────────────────
+// Single-warp 4×4×4 GEMM (the mat4-style transform-multiply replacement).
+__global__ void k_gemm_warp_4x4x4(float alpha, float* A, float* B, float beta, float* C) {
+    glass::warp::gemm<float, 4, 4, 4>(alpha, A, B, beta, C);
+}
+// Single-warp SPD solve A x = b (N=7): factor A=LLᵀ, then forward + transpose solves.
+// Exercises warp::cholDecomp_InPlace + warp::trsm + warp::trsm_transpose together
+// (the HJCD normal-equations pattern). b is overwritten with the solution.
+__global__ void k_posv_warp_7(float* A, float* b) {
+    glass::warp::cholDecomp_InPlace<float, 7>(A);
+    glass::warp::trsm<float, 7>(A, b);
+    glass::warp::trsm_transpose<float, 7>(A, b);
+}
+
 // ─── gemm row-major kernels ───────────────────────────────────────────────────
 __global__ void k_gemm_rowmajor(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
     glass::gemm<float, false, true>(m, n, k, alpha, A, B, beta, C);
@@ -201,6 +215,27 @@ int main(int argc, char** argv) {
         float* db = read_device_vec(argv[5], n);
         if (cg) k_trsm_cg<<<1, THREADS>>>(n, dL, db);
         else    k_trsm_simple<<<1, THREADS>>>(n, dL, db);
+        cudaDeviceSynchronize();
+        print_device_vec(db, n);
+
+    } else if (strcmp(op, "gemm_warp") == 0) {
+        int m = atoi(argv[3]);   // fixed 4×4×4 warp kernel
+        int n = atoi(argv[4]);
+        int k = atoi(argv[5]);
+        float alpha = atof(argv[6]);
+        float beta  = atof(argv[7]);
+        float* dA = read_device_vec(argv[8], m * n);
+        float* dB = read_device_vec(argv[9], n * k);
+        float* dC = read_device_vec(argv[10], m * k);
+        k_gemm_warp_4x4x4<<<1, 32>>>(alpha, dA, dB, beta, dC);
+        cudaDeviceSynchronize();
+        print_device_vec(dC, m * k);
+
+    } else if (strcmp(op, "posv_warp") == 0) {
+        int n = atoi(argv[3]);   // fixed N=7 warp SPD solve
+        float* dA = read_device_vec(argv[4], n * n);
+        float* db = read_device_vec(argv[5], n);
+        k_posv_warp_7<<<1, 32>>>(dA, db);
         cudaDeviceSynchronize();
         print_device_vec(db, n);
 

--- a/test/test_l1.py
+++ b/test/test_l1.py
@@ -110,6 +110,24 @@ def test_reduce_partial(bins, n):
     assert np.allclose(float(result[0]), expected, rtol=1e-3, atol=1e-4)
 
 
+# ─── warp::reduce (single warp, launched <<<1,32>>>) ──────────────────────────
+
+@pytest.mark.parametrize("n", SIZES)
+def test_reduce_warp(bins, n):
+    x = RNG.random(n).astype(np.float32)
+    result = run_op(bins["l1"], "reduce", "warp", args=[n], inputs=[x])
+    expected = float(np.sum(x.astype(np.float64)))
+    assert np.allclose(float(result[0]), expected, rtol=1e-3, atol=1e-4)
+
+
+@pytest.mark.parametrize("n", SIZES)
+def test_reduce_partial_warp(bins, n):
+    x = RNG.random(n).astype(np.float32)
+    result = run_op(bins["l1"], "reduce_partial", "warp", args=[n], inputs=[x])
+    expected = float(np.sum(x.astype(np.float64)))
+    assert np.allclose(float(result[0]), expected, rtol=1e-3, atol=1e-4)
+
+
 # ─── l2norm ───────────────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("n", SIZES)

--- a/test/test_l3.py
+++ b/test/test_l3.py
@@ -227,6 +227,37 @@ def test_trsm(bins, n, version):
     assert np.allclose(residual, 0, atol=1e-3)
 
 
+# ─── warp:: (single warp, launched <<<1,32>>>) ────────────────────────────────
+
+def test_gemm_warp_4x4x4(bins):
+    # glass::warp::gemm<float,4,4,4>: C = alpha*A@B + beta*C, col-major, one warp.
+    m, n, k = 4, 4, 4
+    alpha, beta = 1.5, 0.3
+    A = RNG.random((m, n)).astype(np.float32)
+    B = RNG.random((n, k)).astype(np.float32)
+    C = RNG.random((m, k)).astype(np.float32)
+    C0 = C.copy()
+    result = run_op(bins["l3"], "gemm_warp", "warp",
+                    args=[m, n, k, alpha, beta],
+                    inputs=[np.asfortranarray(A).ravel(order='F'),
+                            np.asfortranarray(B).ravel(order='F'),
+                            np.asfortranarray(C).ravel(order='F')])
+    expected = (alpha * A @ B + beta * C0).astype(np.float32)
+    mat = result.reshape(m, k, order='F')
+    assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
+
+
+def test_posv_warp_7(bins):
+    # Single-warp SPD solve A x = b via warp:: chol + trsm + trsm_transpose (N=7).
+    n = 7
+    A = make_spd(n)
+    b = RNG.random(n).astype(np.float32)
+    A_col = np.asfortranarray(A).ravel(order='F')
+    result = run_op(bins["l3"], "posv_warp", "warp", args=[n], inputs=[A_col, b])
+    residual = A.astype(np.float64) @ result.astype(np.float64) - b.astype(np.float64)
+    assert np.allclose(residual, 0, atol=1e-3)
+
+
 # ─── nvidia::gemm_batched_1d (SIMT, 1D launch) ────────────────────────────────
 
 def _flatten_col(mats):


### PR DESCRIPTION
## Summary

Adds a `glass::warp::` sub-namespace of single-warp SIMT linear-algebra primitives — the warp-scoped
counterparts to the existing block-scoped `glass::` ops. These cooperate across exactly one warp (32 lanes,
`lane = threadIdx.x & 31`, raw `__shfl_*_sync` / `__syncwarp`, no `__syncthreads`), for callers that map one
problem to one warp rather than one block.

Deliberately **not** built on `glass::cgrps::` (cooperative-groups overhead) or `glass::nvidia::`
(CUB/cuBLASDx/cuSOLVERDx) — the target sizes are tiny (4×4 transforms, DIM-sized solves) and warp-dispatched,
so the vendor path can't win. Mirrors GLASS's existing compile-time-`N` convention.

## What's added

- `src/base/L1/reduce.cuh` — `warp::reduce` (register-partial → warp-wide sum on all lanes, plus the
  pointer/`N` overloads landing the sum in `x[0]`).
- `src/base/L3/gemm.cuh` — `warp::gemm<T,M,N,K,TRANSPOSE_B,ROW_MAJOR>` (column-major default; beta=0 overload
  overwrites C).
- `src/base/L3/chol_InPlace.cuh` — `warp::cholDecomp_InPlace<T,N>` (column-major lower L, in place).
- `src/base/L3/trsm.cuh` — `warp::trsm<T,N>` (forward `Lx=b`) + `warp::trsm_transpose<T,N>` (back `Lᵀx=b`).

## Tests / docs

Purely **additive** — defaults byte-identical, no existing call sites touched. New `<<<1,32>>>` wrappers in
`test/cuda/test_l{1,3}.cu`, numpy-reference pytest cases in `test/test_l{1,3}.py` (with a 32-lane case),
`conftest.py` hash-list entries, `examples/07_warp_ops.cu`, and `docs/source/api_reference/warp.rst`.

**Validation:** the 8 new warp cases (`reduce` ×3 sizes, `reduce_partial` ×3, `gemm_4x4x4`, `posv_7`) pass
on RTX 5090 (sm_120, CUDA 13.2); full L1/L3 suite is 274 tests.

Plus a docs follow-on commit: a landing-page note framing block-scoped-by-default vs the new warp-scoped
sub-namespace (intra-block parallelism) and `glass::warp::` pointers on the L1/L3 reference pages.

## Motivation

These are the warp-scoped primitives the HJCD-IK batched IK solver (one block per problem, warp-per-candidate)
needs to retire its hand-rolled `mat4_mul` / `__shfl` reduce / warp-Cholesky onto GLASS without dropping to
block scope and losing candidate-level parallelism.
