### PR TITLE
Clean-break API uniformity wave (TRAILING_SYNC, naming, const, cgrps dedup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ but is not part of the public surface (see `docs/open-tasks/qp_solver_scope.md`)
 
 Recent L1/L2/L3 additions (all single-block, thread-count invariant): `iamax`
 (L1, BLAS i_amax pivot primitive); `trsv` / `trmv` (L2 triangular solve / matvec,
-`LOWER`/`UNIT`/`TRANS` template flags); `syrk` / `syr2k` (L3 symmetric rank-k/2k,
-both `AAᵀ` and `AᵀA` via a `TRANS` flag, `FillMode` Lower/Upper/Full); `ldlt` /
+`LOWER`/`UNIT`/`TRANSPOSE` template flags); `syrk` / `syr2k` (L3 symmetric rank-k/2k,
+both `AAᵀ` and `AᵀA` via a `TRANSPOSE` flag, `FillMode` Lower/Upper/Full); `ldlt` /
 `ldlt_solve` (L3 symmetric-indefinite LDLᵀ, non-pivoted, signature reserves
 `bool pivot`/`piv` for a future Bunch-Kaufman path); `posv` / `potrs` (L3 SPD
 solve = chol + 2×`trsv`); and **K-way fused** `invertMatrix` / `cholDecomp_InPlace`

--- a/README.md
+++ b/README.md
@@ -1,883 +1,134 @@
 # GLASS
 
-**GPU Linear Algebra Simple Subroutines.** Composable `__device__` BLAS/LAPACK-style subroutines that run inside a single CUDA block. Now expanding to warp-level primitives for packing many small problems into one block.
+**GPU Linear Algebra Simple Subroutines.** Composable `__device__` BLAS/LAPACK-style
+subroutines that run inside a single CUDA block, plus warp-level primitives for packing
+many small problems into one block.
+
+📖 **Full documentation: <https://a2r-lab.github.io/GLASS/>** (source under [`docs/source/`](docs/source/)).
 
 ## Overview
 
-GLASS functions are `__device__` helpers that operate on data in shared or device memory. Every function assumes it runs within **one CUDA block** — the caller is responsible for launching one block per independent data item. This design enables composable GPU kernels for applications like model-predictive control and rigid-body dynamics.
+GLASS functions are `__device__` helpers that operate on data already in shared or device
+memory. Every function assumes it runs within **one CUDA block** — the caller launches one
+block per independent data item — which makes GLASS a composable layer for kernels in
+model-predictive control, trajectory optimization, and rigid-body dynamics. It is the
+linear-algebra layer underneath [GRiD](https://github.com/A2R-Lab/GRiD).
 
-GLASS started as a small set of hand-rolled SIMT subroutines (`glass::`, `glass::cgrps::`) tuned for very small matrices where the launch and dispatch overhead of a vendor library would dominate the actual work. It has since grown into a **unified single-block linear-algebra surface** that wraps NVIDIA's state-of-the-art device-side libraries — CUB (L1 reductions), cuBLASDx (L2/L3 GEMV/GEMM, including batched), and cuSOLVERDx (LAPACK: Cholesky, LU, QR, triangular and least-squares solves) — under the same `__device__` calling convention. The intent is to give callers one consistent API across the full block-size compute scale: pure-SIMT for tiny matrices where the vendor path can't beat unrolled SIMT, and tensor-core-tuned vendor kernels for everything large enough to benefit from them.
+It began as hand-rolled SIMT subroutines tuned for the very small matrices where vendor
+launch/dispatch overhead dominates, and has grown into a unified single-block surface that
+also wraps NVIDIA's device-side libraries — CUB (L1), cuBLASDx (L2/L3), cuSOLVERDx (LAPACK) —
+under one `__device__` calling convention, so one kernel can mix hand-rolled and vendor-backed
+primitives without leaving the block.
 
 ### Call surfaces
 
-GLASS primitives are **block-scoped** by default — one block per problem — and come in three numerically-interchangeable backends, plus a **warp-scoped** surface for kernels that pack many small independent problems into one block (one per warp):
+GLASS primitives are **block-scoped** by default (one block per problem) across three
+numerically-interchangeable backends, plus a **warp-scoped** surface for packing many tiny
+problems into one block (one per warp):
 
 | Namespace | Scope | Backend | Header |
 |-----------|-------|---------|--------|
-| `glass::` | block | Hand-rolled SIMT, `threadIdx.{x,y,z}` / `blockDim.*` — no cgrps dep | `glass.cuh` |
-| `glass::cgrps::` | block | Hand-rolled SIMT, `g.thread_rank()` / `g.size()` — cooperative groups | `glass-cgrps.cuh` |
-| `glass::nvidia::` | block | CUB (L1) + cuBLASDx (L2/L3, batched) + cuSOLVERDx (LAPACK) — compile-time sizes only | `glass-nvidia.cuh` |
-| `glass::warp::` | **warp** | Single-warp SIMT via `__shfl_*_sync` — *selected* L1/L2/L3 ops, no `__syncthreads`/shared | inline in the base L1/L2/L3 headers (via `glass.cuh`) |
+| `glass::` | block | Hand-rolled SIMT, `threadIdx` / `blockDim` — no deps | `glass.cuh` |
+| `glass::cgrps::` | block | Same SIMT loop indexed via a `cooperative_groups::thread_group` — a numerically-identical convenience alias, **not** a separately-tuned backend | `glass-cgrps.cuh` |
+| `glass::nvidia::` | block | CUB + cuBLASDx + cuSOLVERDx, auto-dispatched against SIMT by size (compile-time sizes) | `glass-nvidia.cuh` |
+| `glass::warp::` | **warp** | Single-warp SIMT via `__shfl_*_sync` — *selected* L1/L2/L3 ops, no `__syncthreads` | inline in the base headers (via `glass.cuh`) |
 
-The three **block-scoped** backends provide the full L1/L2/L3 surface and are interchangeable — switch by changing the namespace prefix when profiling shows one is faster at a given size. They preserve the same one-block, `__device__` calling convention, so a single kernel can mix hand-rolled and vendor-backed primitives without leaving the block. `glass::cgrps::` is a thin **convenience alias** of `glass::` — *numerically identical* (the same SIMT loop, indexed via a `cooperative_groups::thread_group` instead of `threadIdx`), offered for callers already working in cooperative-groups terms or who want to drive a primitive with an arbitrary sub-block tile. It is **not** a separately-tuned or perf-timed backend; backend-selection guidance ranks only `glass::` (block), `glass::warp::`, and `glass::nvidia::`. `glass::warp::` is a **warp-per-problem** variant covering a selected set (`dot`, `axpy`, `copy`, `scal`, `reduce`, `gemv`, `gemm`, `cholDecomp_InPlace`, `trsv`/`trsm`, and the composed `posv` SPD solve): the warps run independently (no block barrier), turning the block into a vehicle for intra-block parallelism. It requires a full 32-lane warp.
-
-Both `glass::` and `glass::cgrps::` offer **runtime** (size as function arg) and **compile-time** (size as template arg) overloads for every function. Reduction operations additionally offer `glass::low_memory::` (no scratch, thread 0 accumulates) and `glass::high_speed::` (warp-shuffle + shared-memory inter-warp reduction) sub-namespaces.
-
-The dense BLAS/LAPACK surface includes, alongside `gemm`/`gemv`/`ger`: `iamax` (index of max-abs, the pivot primitive); `trsv`/`trmv` (triangular solve / matvec, `LOWER`/`UNIT`/`TRANS` flags); `syrk`/`syr2k` (symmetric rank-k/2k — both `AAᵀ` and `AᵀA` via a `TRANS` flag, writing a `Lower`/`Upper`/`Full` triangle); `inv` and `cholDecomp_InPlace` (single-matrix **and K-way fused** multi-matrix, for packing many small factorizations into one block); `ldlt`/`ldlt_solve` (symmetric-indefinite LDLᵀ for KKT/saddle systems); and `posv`/`potrs` (SPD solve = Cholesky + two triangular solves).
+Both `glass::` and `glass::cgrps::` offer **runtime** (size as arg) and **compile-time** (size
+as template arg) overloads. Reductions additionally offer `glass::low_memory::` (no scratch)
+and `glass::high_speed::` (warp-shuffle) forms. The dense surface covers `gemm`/`gemv`/`ger`,
+`iamax`, `trsv`/`trmv`, `syrk`/`syr2k`, `inv`/`cholDecomp_InPlace` (single **and K-way fused**),
+`ldlt`/`ldlt_solve`, and `posv`/`potrs`; plus contraction-parallel `*_reduced`, `tensor_*`, and
+`congruence_*` families. See the [namespace & naming guide](docs/source/user_guide/concepts/namespaces.rst).
 
 ### Higher-level solvers
 
-Built on the primitives above (and likewise single-block) for the block-tridiagonal SPD systems of trajectory optimization / MPC:
+Built on the primitives above (single-block) for the block-tridiagonal SPD systems of
+trajectory optimization / MPC:
 
 | Function | What | Header |
 |----------|------|--------|
 | `glass::bdmv` | block-tridiagonal matvec (`[L\|D\|R]` strips, padded vectors) | `src/base/banded/bdmv.cuh` |
 | `glass::pcg` | single-block preconditioned conjugate gradient (`S x = b`) | `src/base/pcg/solve.cuh` |
 
-An internal box-constrained QP solver, `glass::internal::box_qp` (`src/L3/box_qp.cuh`), also lives in the tree but is **not** part of the public surface — QP is optimization rather than linear algebra; see `docs/open-tasks/qp_solver_scope.md`.
+An internal box-constrained QP solver, `glass::internal::box_qp`, also lives in the tree but is
+**not** part of the public surface (QP is optimization, not linear algebra).
 
----
-
-## Choosing the right backend
-
-First pick the **execution scope**: one block per problem (the default `glass::` /
-`glass::cgrps::` / `glass::nvidia::` surface) or one warp per problem
-(`glass::warp::`, when you're packing many tiny independent problems into a block).
-### Measured defaults (batched throughput)
-
-From the three-contender scaling sweep (`bench/MEGA_SWEEP_RESULTS.md`, **RTX 5090 /
-sm_120** — breakevens shift on other GPUs, so re-run `bench/run_mega_sweep.sh` on yours).
-
-**Most builds don't link MathDx — start here (warp vs block, no dependency):**
-
-| op | default | block `TB` | warp `WPB` | why |
-|----|---------|-----------|-----------|-----|
-| **dot** | **warp** at every N | 64 | 8–16 | a reduction can't use a block; warp wins 2–6× |
-| **gemv** | **warp** ≤ N≈32, **block** ≥ N≈48 | 64–128 | 2–4 | |
-| **gemm** | **warp** ≤ N≈8, else **block** | scale 64→256 with N | 2–4 | block's extra threads earn their keep once N≥12 |
-| **chol / trsv / posv** | **warp**, block fallback **TB=32** | **32** | 2–4 | extra threads idle on the serial pivot — TB>32 *hurts* |
-
-One rule: **warp-per-problem by default**; gemv → block past N≈48, gemm → block once
-it's non-tiny. Pack **2–4 warps/block** (8–16 for dot).
-
-**If you link MathDx** (`glass::nvidia::`), the vendor path wins a *middle band* (f32):
-gemm **N≈16–64** (block above — cuBLASDx is smem-capped past 64 here), chol/posv
-**N≥16 through 128** (cuSOLVERDx, 1.5–2.7×), trsv only **N≈16–32** (warp wins above —
-cuSOLVERDx's triangular solve scales poorly). **f64** is narrower (≈ N=16–64; the double
-descriptors hit the smem cap at 64). For a *single* large problem (batch≈1), the vendor
-path wins factor/solve/gemm from N≈32 (up to ~8×). Full per-op × per-precision tables:
-[`bench/MEGA_SWEEP_RESULTS.md`](bench/MEGA_SWEEP_RESULTS.md).
-
-**Query it from code.** These defaults are also exposed as `constexpr` helpers in
-`glass-defaults.cuh`, so callers (and codegen) can pick a backend + launch config without
-hand-copying the table:
-
-```cpp
-#include "glass.cuh"
-#include "glass-defaults.cuh"   // include after glass-nvidia.cuh too, to allow the nvidia tier
-
-constexpr auto be = glass::suggested_backend<glass::op::chol, N, float>();
-if      constexpr (be == glass::backend::nvidia) { /* cuSOLVERDx launch */ }
-else if constexpr (be == glass::backend::warp)   { /* <<<ceil(P/WPB), {32,WPB}>>> */ }
-else /* block */ { constexpr int TB = glass::suggested_block_threads<glass::op::chol, N, float>(); /* <<<P, TB>>> */ }
-```
-
-The pick is host-/codegen-side (warp/block/nvidia need different launches, so it can't be a
-device function). With only `glass.cuh` (no MathDx), the `nvidia` tier collapses to its
-warp/block runner-up. Numbers are sm_120-seeded; regenerate for your GPU with `bench/autotune.py`.
-
-### Decision procedure
-
-For the block-scoped backends, three questions decide which to call:
-
-1. **Are sizes known at compile time?**
-2. **Is matrix size large enough that vendor-tuned tensor-core kernels matter?**
-3. **Can you launch with the thread count the backend wants?**
-
-| Scenario | Use | Reason |
-|----------|-----|--------|
-| Sizes only known at runtime | `glass::gemm(m, n, k, ...)` | Pure-SIMT, accepts dynamic args |
-| Compile-time sizes, small matrices (≤ ~8×8), simple kernel | `glass::gemm<float, M, N, K>(...)` | Compiler unrolls inner loops; ~1 µs/op overhead is hard to beat for tiny sizes |
-| Compile-time sizes, larger matrices, tensor-core hardware | `glass::nvidia::gemm<float, M, N, K>(...)` | cuBLASDx generates SM-specific tensor-core code |
-| Compile-time sizes inside an existing kernel that uses a different thread count (e.g. GRiD's 352-thread launches) | `glass::nvidia::gemm<float, M, N, K, TC>(...)` with `DEFINE_NVIDIA_GEMM_BLOCKDIM(M,N,K,TC)` | Pins cuBLASDx's `BlockDim<TC,1,1>`; lets you launch with any thread count ≥ TC (see the [Batched-1D concept guide](docs/source/user_guide/concepts/batched_1d.rst)) |
-| Need a transposed B (or row-major A/B/C) in the NVIDIA path | `glass::nvidia::gemm<...,LA,LB,LC>` with `DEFINE_NVIDIA_GEMM_BLOCKDIM_LAYOUT(...)` or `_TRANSB` alias | cuBLASDx Arrangement; pure-SIMT fallback no longer needed |
-| Linear solve (`Mx = b` for SPD `M`) | `glass::nvidia::posv<float, N, NRHS>(...)` | cuSOLVERDx fused factor + solve; faster than chol+trsm at N ≥ 8 |
-| Cholesky alone (factor only, custom solve) | `glass::nvidia::cholDecomp_InPlace<float, N>(...)` | cuSOLVERDx potrf |
-| General linear solve (non-SPD) | `glass::nvidia::gesv_no_pivot<float, N, NRHS>(...)` | cuSOLVERDx LU + solve |
-| Least-squares / over- or under-determined | `glass::nvidia::gels<float, M, N, NRHS>(...)` | cuSOLVERDx QR (or LQ for under-det) + solve |
-| `BATCH` independent GEMMs of the same shape, want to amortize launch | `glass::nvidia::gemm_batched<...,BATCH,TC>` | Single block, all batches active via `threadIdx.y` |
-
-**Auto-dispatch.** `glass::nvidia::gemm<>`, `gemv<>`,
-`row_strided_*`, and `gemm_batched_1d<>` are **auto-dispatching primary
-templates** that route to the pure-SIMT path (`::glass::*`) for shapes
-where SIMT wins, and to cuBLASDx via the `DEFINE_NVIDIA_*` macros for
-shapes where the vendor library wins. The decision is made at compile
-time by `should_use_cublasdx*<T,M,N,K,SM>()` (see `src/nvidia/query.cuh`),
-which consults — in order — a per-build local table, the shipped global
-table (`src/nvidia/tuning_table.cuh`), and a fallback static heuristic.
-
-This means: calling `glass::nvidia::gemm<float, 6, 6, 6>(...)` "just works"
-without any DEFINE macro — small shapes route to SIMT automatically.
-Calling `glass::nvidia::gemm<float, 32, 32, 32>(...)` still requires a
-`DEFINE_NVIDIA_GEMM(32, 32, 32)` in scope, but produces a clean
-compile-time message when missing.
-
-**Heuristic baseline** (when no tuning-table entry matches): for `gemm`,
-`max(M,N,K) >= 16 AND min(M,N,K) >= 4` → cuBLASDx; otherwise SIMT. For
-`gemv`, `max(M,N) >= 32` → cuBLASDx. For `gemm_batched_1d`,
-`BATCH >= 8 AND max(M,N,K) >= 8` → cuBLASDx. The benchmark suite
-(`bench/run_bench.py`) measures both side by side on your hardware so
-you can override these defaults via the tuning table — see
-"Tuning your local build" below.
-
-> You can always write
-> `glass::nvidia::gemm<float, M, N, K>(...)` regardless of size. The primary
-> template consults `should_use_cublasdx<T,M,N,K,SM>()` (see [Backend dispatch](#backend-dispatch--when-does-glassnvidiagemm-run-cublasdx-vs-simt)
-> below) and silently falls through to `glass::gemm<...>` for shapes the
-> heuristic flags as SIMT territory. Only larger shapes still need a
-> `DEFINE_NVIDIA_GEMM*` macro.
-
-**Precision (`float` / `double`).** The `glass::nvidia::` wrappers — `gemm`, `gemv`,
-`cholDecomp_InPlace`, `trsm`, `posv` — support both `float` and `double`. The plain
-`DEFINE_NVIDIA_*(...)` macros instantiate the `float` path (back-compat); the
-`DEFINE_NVIDIA_*_PREC(..., double)` variants instantiate the double path
-(`cublasdx`/`cusolverdx` `Precision<double>`). Note that double descriptors use 2× the
-shared memory, so the largest `N` that fits the per-block opt-in cap is smaller than for
-`float` (e.g. on RTX 5090 / sm_120 the f64 `nvidia` band is roughly `N ≈ 16–64`).
-
-**When NOT to use `glass::nvidia`**:
-- Sizes only known at runtime (the templates require compile-time `M`, `N`, `K`).
-- You can't add a `DEFINE_NVIDIA_GEMM*` macro for the size you need (e.g. you want every conceivable `(M, N, K)` triple — the macro instantiation cost grows fast).
-- You're stuck on an SM cuBLASDx doesn't tune for (it falls back to a generic config; the pure-SIMT compile-time path is often competitive there).
-
----
-
-## Backend dispatch — when does `glass::nvidia::gemm` run cuBLASDx vs SIMT?
-
-The primary `glass::nvidia::gemm<T,M,N,K,...>` template auto-dispatches:
-
-```
-                  caller writes:  glass::nvidia::gemm<float, M, N, K>(...)
-                                         │
-                                         ▼
-                       should_use_cublasdx<float, M, N, K, SMS>()
-                                         │
-                  ┌──────────────────────┴──────────────────────┐
-                  ▼                                             ▼
-                false                                          true
-                  │                                             │
-       ────────── ▼ ──────────              ────────── ▼ ──────────
-       SIMT fallback:                       Need a DEFINE_NVIDIA_GEMM*
-       ::glass::gemm<T,M,N,K>(...)          to specialize for cuBLASDx;
-       (no DEFINE needed; no smem)          else: static_assert error.
-```
-
-**The decision lives in `src/nvidia/tuning_table.cuh`.** The shipped table covers `sm_86` (Ampere consumer) and `sm_120` (Blackwell-class) for square shapes from 3×3×3 up to 64×64×64. For unmeasured shapes a conservative heuristic kicks in:
-
-```
-should_use_cublasdx = (T == float) && (max(M,N,K) >= 16) && (min(M,N,K) >= 4)
-```
-
-#### Inspecting at runtime
-
-```cpp
-glass::nvidia::print_dispatch<float, 4, 4, 4>();
-// → glass::nvidia::gemm<T,4,4,4,SM=860>: SIMT fallback
-
-glass::nvidia::print_dispatch<float, 32, 32, 32>();
-// → glass::nvidia::gemm<T,32,32,32,SM=860>: cuBLASDx (needs DEFINE_NVIDIA_GEMM*)
-```
-
-#### Overriding the dispatch
-
-| Goal | How |
-|------|-----|
-| Force cuBLASDx for a shape the heuristic puts in SIMT | Add `DEFINE_NVIDIA_GEMM(M,N,K)` in your `.cu` file. The explicit specialization always overrides the primary template. |
-| Force SIMT for a shape the heuristic puts in cuBLASDx | Call `::glass::gemm<T,M,N,K>(...)` directly (skip the `nvidia::` path). |
-| Per-host tuning without editing source | Run `python bench/autotune.py` to generate `bench/tuning/<hostname>.cuh`, then compile with `-DGLASS_TUNING_TABLE_LOCAL='"bench/tuning/<hostname>.cuh"'`. See `bench/TUNING.md`. |
-| Different SM in-tree (for a PR) | `python bench/autotune.py --in-tree` rewrites the marker-delimited specializations section inside `src/nvidia/tuning_table.cuh`, preserving the auto-dispatching primaries above it. |
-
-#### Auto-tune for your hardware
-
-The shipped values are sensible defaults but small-GEMM perf is highly SM-dependent. The autotune covers all five auto-dispatching primaries (`gemm`, `gemv`, `row_strided_gemv`, `row_strided_gemm`, `gemm_batched_1d`).
-
-```bash
-# Detect SM, measure all default shapes for all 5 APIs, write per-host
-# overrides to bench/tuning/<hostname>.cuh. Does NOT modify src/.
-python bench/autotune.py --sm AUTO
-
-# Restrict to one API + custom shapes; --dry-run reports without writing
-python bench/autotune.py --apis gemv --shapes '6,6;14,14;32,32' --iters 20000 --dry-run
-
-# Update the in-tree shipped table (for upstream PRs only)
-python bench/autotune.py --sm AUTO --in-tree
-```
-
-The script compiles and runs a small SIMT-vs-cuBLASDx microbench per (API, shape), times each leg over `--iters` iterations, and emits one `template <> constexpr bool ...` specialization per measured combination plus a human-readable `*_results.md` alongside. Ties (within `--margin`, default ±5 %) default to SIMT. Requires `MATHDX_ROOT` set. Per-host outputs under `bench/tuning/` are gitignored.
-
-See `bench/TUNING.md` for the full contributor workflow including how the override mechanism layers on top of the in-tree table.
-
----
-
-## Trailing synchronization (`TRAILING_SYNC`)
-
-GLASS L3 functions (`gemm`, `gemv`, `row_strided_*`, `gemm_batched_1d`,
-`gemm_strided_batched_1d`, ...) take a final boolean template parameter
-**`TRAILING_SYNC` that defaults to `true`** and controls whether the function
-emits a `__syncthreads()` before returning:
-
-```cpp
-// Default — function returns with all threads at a block-wide barrier.
-// Safe to read the result from any thread in the block immediately after.
-glass::nvidia::gemm_strided_batched_1d<float, 4, 4, 4, BATCH, TC>(
-    1.f, A, B, 0.f, C);
-
-// Opt-out — caller is responsible for syncing before reading any output
-// not written by the current thread. Pass false when fusing the GEMM with
-// subsequent block-wide work that ALREADY does its own barrier (e.g. a
-// `parallel_loop` that begins with `__syncthreads()`), so two back-to-back
-// syncs collapse to one.
-glass::nvidia::gemm_strided_batched_1d<
-    float, 4, 4, 4, BATCH, TC,
-    /*B_STRIDE=*/N*K, /*C_STRIDE=*/M*K,
-    layout::col_major, layout::col_major, layout::col_major,
-    /*TRAILING_SYNC=*/false>(1.f, A, B, 0.f, C);
-__syncthreads();  // emit your own here, fused with any other barrier
-```
-
-The default of `true` makes the common case correct without thinking —
-GLASS functions act as if they were standalone kernels. The opt-out exists
-for hot kernels (e.g. GRiD's `end_effector_pose_gradient_inner`) that chain
-a GEMM with a SIMT `parallel_loop` and want to collapse the two syncs.
-
-Where it applies (full surface as of 2026-05):
-
-- **L1** (`l1.cuh`): `reduce`, `dot`, `l2norm`. The leading sync that
-  protects CUB BlockReduce TempStorage from prior writes is **not**
-  gated — it's required for correctness. Only the trailing barrier
-  (after the thread-0 write of the reduction result) is.
-- **L2** (`l2.cuh`): `gemv`, `row_strided_gemv` — primary templates and
-  every `_GLASS_GEMV_NO_BD` / `_GLASS_GEMV_BD` macro-emitted
-  specialization. The cuBLASDx-backed specializations emit BOTH
-  `TRAILING_SYNC=true` and `=false` variants from a single
-  `DEFINE_NVIDIA_GEMV*` invocation.
-- **L3** (`l3.cuh`): `gemm`, `gemm_batched`, `row_strided_gemm` — same
-  dual-specialization pattern via `_GLASS_GEMM_NO_BD` /
-  `_GLASS_GEMM_BD` / `_GLASS_GEMM_BATCHED_BD`.
-- **L3 SIMT** (`l3_simt.cuh`): `gemm_batched_1d`,
-  `gemm_strided_batched_1d`.
-- **LAPACK** (`lapack.cuh`): `posv`, `cholDecomp_InPlace`, `gesv_no_pivot`,
-  `gels`, `trsm` — primary templates and macro-emitted
-  specializations. Interior factor / solve / writeback syncs are NOT
-  gated; only the final barrier before return is.
-
-The interior `__syncthreads()` inside `gemm` / `gemm_batched` / LAPACK
-factor-solve flows (between phases) is required for correctness and is
-**not** gated on `TRAILING_SYNC` — only the final trailing barrier is.
-
-Tests for the surface live at
-`test/cuda/test_trailing_sync.cu` + `test/test_trailing_sync.py`. They
-verify (a) both `TRAILING_SYNC=true` and `=false` specializations
-compile + link, and (b) the two variants produce numerically identical
-output when the `=false` caller emits its own trailing
-`__syncthreads()`. The cuBLASDx-backed L3 case is covered (gated on
-`GLASS_BENCH_CUBLASDX` / `MATHDX_ROOT`).
-
----
-
-## Quick Start
+## Quick start
 
 ```cpp
 #include "glass.cuh"
 
 __global__ void my_kernel(float* A, float* B, float* C, int m, int n, int k) {
-    // Runtime size: all threads in the block cooperate
-    glass::gemm(m, n, k, 1.f, A, B, 0.f, C);
-}
-```
-
-Launch with one block per data item:
-```cpp
-my_kernel<<<num_items, 256>>>(A, B, C, m, n, k);
-```
-
----
-
-## Usage Examples
-
-### 1. Runtime sizes — default `glass::` (threadIdx-based)
-
-```cpp
-#include "glass.cuh"
-
-__global__ void k(float* A, float* B, float* C, int m, int n, int k) {
-    glass::gemm(m, n, k, 1.f, A, B, 0.f, C);         // GEMM
-    glass::gemv(m, n, 1.f, A, B, 0.f, C);             // GEMV
-    glass::axpy(n, 1.5f, A, B);                        // y = alpha*x + y
-}
-```
-
-### 2. Compile-time sizes — loop unrolling via template args
-
-```cpp
-#include "glass.cuh"
-
-__global__ void k(float* A, float* B, float* C) {
-    // Sizes baked in as template params — compiler can unroll loops
-    glass::gemm<float, 6, 6, 6>(1.f, A, B, 0.f, C);
-    glass::gemv<float, 6, 6>(1.f, A, B, 0.f, C);
-    glass::axpy<float, 36>(1.5f, A, B);
-}
-```
-
-### 3. Cooperative groups — sub-block tiling with `glass::cgrps::`
-
-```cpp
-#include "glass-cgrps.cuh"
-#include <cooperative_groups.h>
-namespace cgrps = cooperative_groups;
-
-__global__ void k(float* A, float* B, float* C) {
-    // Whole block (default)
-    glass::cgrps::gemm<float, 6, 6, 6>(1.f, A, B, 0.f, C);
-
-    // Warp-level tiling: each warp independently computes a 4×4×4 GEMM
-    auto warp = cgrps::tiled_partition<32>(cgrps::this_thread_block());
-    glass::cgrps::gemm<float, 4, 4, 4>(1.f, A, B, 0.f, C, warp);
-}
-```
-
-### 4. High-speed reductions (warp-shuffle)
-
-```cpp
-#include "glass.cuh"
-
-__global__ void k(float* x, int n) {
-    // Scratch: ceil(blockDim.x / 32) * sizeof(float) bytes
-    extern __shared__ float scratch[];
-    glass::high_speed::reduce(n, x, scratch);     // result in x[0]
-    glass::high_speed::l2norm(n, x, scratch);     // ‖x‖₂ in x[0]
-}
-```
-
-### 5. NVIDIA-optimized path (`glass::nvidia::`)
-
-#### 5a. Default — let cuBLASDx pick the thread count
-
-```cpp
-#include "glass-nvidia.cuh"
-
-// Host: query required smem and thread count (both constexpr)
-constexpr auto smem    = glass::nvidia::gemm_smem_size<float, 6, 6, 6>();
-constexpr auto threads = glass::nvidia::gemm_threads<float, 6, 6, 6>();
-
-__global__ void k(float* A, float* B, float* C) {
-    extern __shared__ __align__(16) char smem_buf[];
-    glass::nvidia::gemm<float, 6, 6, 6>(1.f, A, B, 0.f, C, smem_buf);
+    glass::gemm(m, n, k, 1.f, A, B, 0.f, C);   // all block threads cooperate on one problem
 }
 
-// Launch with the EXACT thread count cuBLASDx wants — mismatch deadlocks.
-k<<<1, threads, smem>>>(dA, dB, dC);
+my_kernel<<<num_items, 256>>>(A, B, C, m, n, k);   // one block per data item
 ```
 
-#### 5b. Caller-pinned `BlockDim<TC>` — launch with any TC ≥ what cuBLASDx needs
-
-The default form forces every kernel that touches `glass::nvidia::gemm` to launch with the exact thread count cuBLASDx picked for that GEMM size. When the rest of your kernel needs a different launch (e.g. GRiD codegen launches with 352 threads for the surrounding RNEA/CRBA work), use the BlockDim form:
-
-```cpp
-namespace glass { namespace nvidia {
-    DEFINE_NVIDIA_GEMM_BLOCKDIM(6, 6, 6, 352)   // pin BlockDim<352,1,1>
-}}
-
-__global__ void k(float* A, float* B, float* C) {
-    extern __shared__ __align__(16) char smem_buf[];
-    // OK to launch with 352 threads — extras go idle inside the GEMM.
-    glass::nvidia::gemm<float, 6, 6, 6, 352>(1.f, A, B, 0.f, C, smem_buf);
-}
-
-constexpr auto smem = glass::nvidia::gemm_smem_size<float, 6, 6, 6, 352>();
-k<<<1, 352, smem>>>(dA, dB, dC);
-```
-
-The query API tells you the smallest TC cuBLASDx will accept for a `(T, M, N, K, SM)` tuple:
-
-```cpp
-static_assert(glass::nvidia::gemm_block_threads_valid<float, 6, 6, 6, 352>(),
-              "352 threads should be enough for 6x6x6 on this SM");
-
-constexpr uint32_t MIN = glass::nvidia::gemm_min_block_threads<float, 6, 6, 6>();
-// MIN is the natural BlockDim cuBLASDx picks; pin TC >= MIN.
-```
-
-#### 5c. Layout / transpose (NVIDIA path)
-
-`glass::nvidia::gemm` accepts `layout LA`, `LB`, `LC` template parameters — these mirror cuBLASDx's `Arrangement<>` and let you express transpose / row-major storage without falling back to the pure-SIMT path:
-
-```cpp
-namespace glass { namespace nvidia {
-    // A · Bᵀ  (B is row-major, equivalent to "transposed col-major")
-    DEFINE_NVIDIA_GEMM_BLOCKDIM_TRANSB(6, 6, 6, 352)        // alias for LB=row_major
-    // Or fully explicit (LA=row, LB=col, LC=col):
-    DEFINE_NVIDIA_GEMM_BLOCKDIM_LAYOUT(6, 6, 6, 352, 1, 0, 0)
-}}
-
-__global__ void k(float* A, float* B, float* C) {
-    extern __shared__ __align__(16) char smem_buf[];
-    using L = glass::nvidia::layout;
-    glass::nvidia::gemm<float, 6, 6, 6, 352,
-                        L::col_major, L::row_major, L::col_major>(
-        1.f, A, B, 0.f, C, smem_buf);
-}
-```
-
-#### 5d. Multi-arch builds (per-SM dispatch)
-
-Pin the SM at the call site so a single fatbinary can ship tuned code for multiple architectures:
-
-```cpp
-namespace glass { namespace nvidia {
-    DEFINE_NVIDIA_GEMM_BLOCKDIM_SM(6, 6, 6, 352, 890)
-    DEFINE_NVIDIA_GEMM_BLOCKDIM_SM(6, 6, 6, 352, 1200)
-}}
-
-__global__ void k(float* A, float* B, float* C) {
-    extern __shared__ __align__(16) char smem_buf[];
-    using L = glass::nvidia::layout;
-    glass::nvidia::gemm<float, 6, 6, 6, 352,
-        L::col_major, L::col_major, L::col_major,
-        #if __CUDA_ARCH__ >= 1200
-            1200
-        #else
-            890
-        #endif
-    >(1.f, A, B, 0.f, C, smem_buf);
-}
-```
-
-#### 5e. Linear solvers (cuSOLVERDx — `cholDecomp_InPlace`, `trsm`, `posv`, …)
-
-```cpp
-#include "glass-nvidia.cuh"
-
-namespace glass { namespace nvidia {
-    DEFINE_NVIDIA_POSV_BLOCKDIM(7, 1, 256)   // 7×7 SPD, 1 RHS, BlockDim<256>
-}}
-
-__global__ void k(float* A, float* b) {
-    extern __shared__ __align__(16) char smem_buf[];
-    // Solves A·x = b in place: A := L (lower Cholesky), b := x
-    glass::nvidia::posv<float, 7, 1, 256>(A, b, smem_buf);
-}
-
-constexpr auto smem = glass::nvidia::posv_smem_size<float, 7, 1, 256>();
-k<<<1, 256, smem>>>(dA, db);
-```
-
-Available cuSOLVERDx wrappers (all follow the same `DEFINE_NVIDIA_<NAME>` / `_BLOCKDIM` / `_SM` / `_BLOCKDIM_SM` macro pattern):
-
-| Function | Signature | NumPy / SciPy equivalent |
-|----------|-----------|--------------------------|
-| `cholDecomp_InPlace<T, N>` | `(A, smem)` | `np.linalg.cholesky(A)` (lower) |
-| `trsm<T, M, N>` | `(alpha, L, B, smem)` | `scipy.linalg.solve_triangular(L, alpha*B, lower=True)` |
-| `posv<T, N, NRHS>` | `(A, B, smem)` | `np.linalg.solve(A, B)` (SPD A; A is destroyed) |
-| `potrs<T, N, NRHS>` | `(L, B, smem)` | `scipy.linalg.cho_solve((L, True), B)` |
-| `getrf_no_pivot<T, N>` | `(A, smem)` | `scipy.linalg.lu_factor(A)` (no pivoting; A := LU) |
-| `getrs_no_pivot<T, N, NRHS>` | `(LU, B, smem)` | `scipy.linalg.lu_solve((LU, ...), B)` |
-| `gesv_no_pivot<T, N, NRHS>` | `(A, B, smem)` | `np.linalg.solve(A, B)` (general A; A is destroyed) |
-| `geqrf<T, M, N>` | `(A, tau, smem)` | `scipy.linalg.qr(A, mode='raw')` |
-| `gels<T, M, N, NRHS>` | `(A, tau, B, smem)` | `np.linalg.lstsq(A, B)` |
-
-Linking note: cuSOLVERDx ships a precompiled device library. Add `-rdc=true -dlto -L$MATHDX_ROOT/lib -lcusolverdx -lcublas -lcusolver -lcudart` to your nvcc command (the `bench/run_bench.py` driver does this automatically when `cusolverdx.hpp` is present).
-
-#### 5f. Batched GEMM (single block, BATCH GEMMs in parallel)
-
-```cpp
-namespace glass { namespace nvidia {
-    DEFINE_NVIDIA_GEMM_BATCHED_BLOCKDIM(6, 6, 6, /*BATCH=*/16, /*TC=*/64)
-}}
-
-__global__ void k(float* const* A, float* const* B, float* const* C) {
-    extern __shared__ __align__(16) char smem_buf[];
-    glass::nvidia::gemm_batched<float, 6, 6, 6, 16, 64>(
-        1.f, A, B, 0.f, C, smem_buf);
-}
-
-constexpr auto smem = glass::nvidia::gemm_batched_smem_size<float, 6, 6, 6, 16, 64>();
-k<<<1, dim3(64, 16), smem>>>(dA_ptrs, dB_ptrs, dC_ptrs);
-```
-
-Each batch element is identified by `threadIdx.y`; each per-batch GEMM uses TC threads in `threadIdx.x`. Total launch is `dim3(TC, BATCH)`. See `bench/bench_gemm_batched.cu` for a full working example with `T**` pointer arrays.
-
-#### 5g. Batched GEMM with **1D launch** (`gemm_batched_1d`)
-
-If the surrounding kernel was launched 1D (e.g. `dim3(TC*BATCH, 1, 1)` because every other block-level helper uses `threadIdx.x`), the cuBLASDx-backed `gemm_batched` above won't work — it requires the 2D launch. The SIMT-only `gemm_batched_1d` (and the shared-A variant `gemm_strided_batched_1d`) partition a single 1D block of `TC*BATCH` threads into BATCH groups of TC threads each:
-
-```cpp
-__global__ void k(float* const* A, float* const* B, float* const* C) {
-    // No DEFINE macro needed — fully templated on T.
-    glass::nvidia::gemm_batched_1d<float, 4, 4, 4, /*BATCH=*/8, /*TC=*/32>(
-        1.f, A, B, 0.f, C);
-}
-k<<<1, dim3(32 * 8, 1, 1)>>>(dA_ptrs, dB_ptrs, dC_ptrs);   // no smem
-
-// Shared-A variant: one A applied to BATCH packed (B,C) pairs.
-__global__ void k_shared(float* A_shared, float* B_base, float* C_base) {
-    glass::nvidia::gemm_strided_batched_1d<float, 4, 4, 4, 8, 32>(
-        1.f, A_shared, B_base, 0.f, C_base);   // tightly packed: B_STRIDE=N*K, C_STRIDE=M*K
-}
-```
-
-These run pure SIMT; they need no shared memory and no `DEFINE_NVIDIA_GEMM_BATCHED_*` macro. Best for the small shapes (`max(M,N,K) ≲ 8`) where cuBLASDx's tile-load overhead dominates anyway. See `bench/bench_gemm_batched_1d.cu`.
-
-### 6. Tiled GEMM (scratch in shared memory)
-
-```cpp
-#include "glass.cuh"
-
-__global__ void k(float* A, float* B, float* C, int m, int n, int k) {
-    extern __shared__ float smem[];
-    float* s_A = smem;
-    float* s_B = smem + m * 8;
-    glass::gemm_tiled<float, 8>(m, n, k, 1.f, A, B, 0.f, C, s_A, s_B);
-}
-
-// Host:
-size_t smem = (m * 8 + 8 * k) * sizeof(float);
-k<<<1, 256, smem>>>(A, B, C, m, n, k);
-```
-
----
-
-## Requirements
-
-| Component | C++ Standard | Optional deps |
-|-----------|-------------|---------------|
-| `glass.cuh`, `glass-cgrps.cuh` | C++17 (`nvcc -std=c++17`) | — |
-| `glass-nvidia.cuh` (L1 only) | C++17 | CUB (bundled with CUDA 11+) |
-| `glass-nvidia.cuh` (L2/L3 GEMM/GEMV/batched) | C++17 + `--expt-relaxed-constexpr` | cuBLASDx |
-| `glass-nvidia.cuh` (LAPACK: chol/trsm/posv/getrf/gesv/geqrf/gels) | C++17 + `--expt-relaxed-constexpr` + `-rdc=true -dlto -lcusolverdx -lcublas -lcusolver -lcudart` | cuSOLVERDx |
-| Test suite | C++17 | — |
-| Benchmark suite | C++17 | (matches the variants you opt in) |
-
-The wrappers gate themselves with `GLASS_HAVE_CUBLASDX` / `GLASS_HAVE_CUSOLVERDX`, both auto-detected from include order. To force-enable when including `glass-nvidia.cuh` from a TU that hasn't pre-included the headers, define `GLASS_BENCH_CUBLASDX` and/or `GLASS_BENCH_CUSOLVERDX` (the bench harness sets these). See [`bench/INSTALL.md`](bench/INSTALL.md) for download + linking instructions.
-
----
-
-## API Reference
-
-### L1 — Vector Operations
-
-All L1 functions accept `uint32_t n` (runtime) **or** `<T, N>` template args (compile-time).
-
-| Function | Description | NumPy equivalent | Scratch |
-|----------|-------------|------------------|---------|
-| `axpy(n, alpha, x, y)` | `y = alpha*x + y` | `y += alpha*x` | none |
-| `axpy(n, alpha, x, y, z)` | `z = alpha*x + y` | `z = alpha*x + y` | none |
-| `axpby(n, alpha, x, beta, y, z)` | `z = alpha*x + beta*y` | `z = alpha*x + beta*y` | none |
-| `copy(n, x, y)` | `y = x` | `y = x.copy()` | none |
-| `copy(n, alpha, x, y)` | `y = alpha*x` | `y = alpha*x` | none |
-| `scal(n, alpha, x)` | `x = alpha*x` (in-place) | `x *= alpha` | none |
-| `scal(n, alpha, x, y)` | `y = alpha*x` | `y = alpha*x` | none |
-| `swap(n, x, y)` | swap `x` and `y` | — | none |
-| `dot(n, x, y)` | `y[0] = x·y` (in-place, uses `y` as scratch) | `np.dot(x,y)` | none |
-| `iamax(n, x, out)` | `out[0] = argmax\|xᵢ\|` (index of max-abs; pivot primitive) | `np.argmax(np.abs(x))` | none |
-| `reduce(n, x)` | `x[0] = sum(x)` (in-place) | `np.sum(x)` | none |
-| `l2norm(n, x)` | `x[0] = ‖x‖₂` (in-place, destructive) | `np.linalg.norm(x)` | none |
-| `infnorm(n, x)` | `x[0] = ‖x‖∞` (in-place) | `np.max(np.abs(x))` | none |
-| `asum(n, x, out)` | `out[0] = Σ|xᵢ|` | `np.sum(np.abs(x))` | `n*sizeof(T)` |
-| `clip(n, x, l, u)` | `x = clamp(x, l, u)` | `np.clip(x, l, u)` | none |
-| `set_const(n, alpha, x)` | `x = [alpha, …]` | `np.full(n, alpha)` | none |
-| `loadIdentity(n, A)` | `A = I_n` (column-major) | `np.eye(n)` | none |
-| `addI(n, A, alpha)` | `A += alpha*I` | `A += alpha*np.eye(n)` | none |
-| `transpose(N, M, a, b)` | `b = aᵀ` (col-major) | `b = a.T` | none |
-| `transpose(N, a)` | in-place transpose `N×N` | — | none |
-| `elementwise_add(N, a, b, c)` | `c = a + b` | `c = a + b` | none |
-| `elementwise_sub(N, a, b, c)` | `c = a - b` | `c = a - b` | none |
-| `elementwise_mult(N, a, b, c)` | `c = a ⊙ b` | `c = a * b` | none |
-| `elementwise_abs(N, a, b)` | `b = |a|` | `b = np.abs(a)` | none |
-| `elementwise_max(N, a, b, c)` | `c = max(a,b)` | `np.maximum(a,b)` | none |
-| `elementwise_min(N, a, b, c)` | `c = min(a,b)` | `np.minimum(a,b)` | none |
-| `prefix_sum_exclusive(x, out, n)` | exclusive scan | — | none |
-| `prefix_sum_inclusive(x, out, n)` | inclusive scan | `np.cumsum(x)` | none |
-
-#### Reduction sub-namespaces
-
-```cpp
-glass::reduce(n, x);                         // default: halving reduce
-glass::low_memory::reduce(n, x);             // thread 0 accumulates; no scratch
-glass::high_speed::reduce(n, x, scratch);    // warp-shuffle; faster for large n
-```
-
-Scratch required for `high_speed`: `ceil(blockDim.x / 32) * sizeof(T)` bytes.
-
-#### `glass::nvidia::` L1 (CUB BlockReduce)
-
-```cpp
-#include "glass-nvidia.cuh"
-extern __shared__ float scratch[];  // sizeof(cub::BlockReduce<T,THREADS>::TempStorage)
-
-glass::nvidia::reduce<float, N, THREADS>(x, scratch);
-glass::nvidia::dot<float, N, THREADS>(x, y, out, scratch);
-glass::nvidia::l2norm<float, N, THREADS>(x, out, scratch);
-
-// Query scratch size (host-callable):
-constexpr auto bytes = glass::nvidia::reduce_smem_size<float, THREADS>();
-```
-
----
-
-### L2 — Matrix-Vector Operations
-
-Matrices default to **column-major** order. Pass `ROW_MAJOR=true` to use row-major (C-style).
-
-| Function | Description | NumPy equivalent |
-|----------|-------------|------------------|
-| `gemv<T>(m, n, alpha, A, x, beta, y)` | `y = alpha*A*x + beta*y` (col-major A) | `y = alpha*A@x + beta*y` |
-| `gemv<T,true>(m, n, alpha, A, x, beta, y)` | `y = alpha*Aᵀ*x + beta*y` | `y = alpha*A.T@x + beta*y` |
-| `gemv<T,false,true>(m, n, alpha, A, x, beta, y)` | same, but A is row-major | `y = alpha*A@x + beta*y` |
-| `gemv_ex<T,TRANSPOSE,ROW_MAJOR_A>(...)` | per-matrix layout control | |
-| `ger(m, n, alpha, x, y, A)` | `A += alpha*x*yᵀ` | `A += alpha*np.outer(x,y)` |
-| `trsv<T,LOWER,UNIT,TRANS>(n, A, x)` | triangular solve `A*x = b` in-place (`LOWER`/`UNIT`/`TRANS` flags) | `scipy.linalg.solve_triangular(A,x,lower=...)` |
-| `trmv<T,LOWER,UNIT,TRANS>(n, A, x)` | triangular matvec `x = A*x` (`LOWER`/`UNIT`/`TRANS` flags) | `A @ x` (triangular A) |
-
-Compile-time overloads omit the `m, n` args:
-```cpp
-glass::gemv<float, 6, 6>(1.f, A, x, 0.f, y);           // runtime: glass::gemv(6, 6, 1.f, A, x, 0.f, y)
-glass::cgrps::gemv<float, 6, 6>(1.f, A, x, 0.f, y, g); // with explicit group
-```
-
----
-
-### L3 — Matrix Operations
-
-Matrices default to **column-major** order.
-
-| Function | Description | NumPy equivalent | Scratch |
-|----------|-------------|------------------|---------|
-| `gemm<T>(m,n,k, alpha, A, B, beta, C)` | `C = alpha*A*B + beta*C` (col-major) | `C = alpha*A@B + beta*C` | none |
-| `gemm<T,true>(m,n,k, alpha, A, B, beta, C)` | `C = alpha*A*Bᵀ + beta*C` | — | none |
-| `gemm<T,false,true>(m,n,k, alpha, A, B, beta, C)` | same, all matrices row-major | | none |
-| `gemm_ex<T,TRANSPOSE_B,ROW_A,ROW_B,ROW_C>(...)` | per-matrix layout control | | none |
-| `gemm_tiled<T,TILE>(m,n,k, alpha, A, B, beta, C, s_A, s_B)` | tiled gemm using shared memory | | `(m*TILE + TILE*k)*sizeof(T)` |
-| `gemm_dispatch<T>(m,n,k, alpha, A, B, beta, C, s_A, s_B)` | auto-selects tiled or plain | | see below |
-| `invertMatrix(n, A, s_temp)` | `A = A⁻¹` in-place (Gauss-Jordan) | `np.linalg.inv(A)` | `(2n+1)*sizeof(T)` |
-| `invertMatrix_pivoted(n, A, s_temp)` | `A = A⁻¹` in-place, partial (row) pivoting (robust on small/zero leading pivots) | `np.linalg.inv(A)` | `(3n+1)*sizeof(T)` |
-| `invertMatrix(K, ns, As, s_temp)` | K-way fused: invert K independent matrices interleaved over one block | `[np.linalg.inv(A) for A in As]` | per-matrix `(2n+1)` |
-| `cholDecomp_InPlace(n, A)` | Cholesky `A → L` (lower triangular) | `np.linalg.cholesky(A)` | none |
-| `cholDecomp_InPlace(K, ns, As)` | K-way fused: factor K independent matrices interleaved over one block | `[np.linalg.cholesky(A) for A in As]` | none |
-| `syrk<T,TRANS,FILL>(n, k, alpha, A, beta, C)` | symmetric rank-k: `C = alpha*A*Aᵀ + beta*C` (or `AᵀA` with `TRANS`); `FILL` Lower/Upper/Full | `C = alpha*A@A.T + beta*C` | none |
-| `syr2k<T,TRANS,FILL>(n, k, alpha, A, B, beta, C)` | symmetric rank-2k: `C = alpha*(A*Bᵀ + B*Aᵀ) + beta*C` (or `AᵀB+BᵀA`) | `C = alpha*(A@B.T+B@A.T) + beta*C` | none |
-| `ldlt(n, A)` | symmetric-indefinite `A → L·D·Lᵀ` in-place (no sqrt; KKT/saddle systems) | `scipy.linalg.ldl(A)` | `(n+1)*sizeof(T)` |
-| `ldlt_solve(n, A, b)` | solve `A*x = b` from a prior `ldlt` factorization | — | `(n+1)*sizeof(T)` |
-| `posv(n, A, b)` | SPD solve `A*x = b` in-place (Cholesky + two triangular solves); multi-RHS `(n, nrhs, A, B)` | `np.linalg.solve(A, b)` (SPD A) | none |
-| `potrs(n, L, b)` | solve `A*x = b` from a prior Cholesky `L`; multi-RHS `(n, nrhs, L, B)` | `scipy.linalg.cho_solve((L,True), b)` | none |
-| `trsm(n, L, b)` | Solve `Lx=b` in-place (forward substitution) | `scipy.linalg.solve_triangular(L,b,lower=True)` | none |
-
-Compile-time overloads omit the `m, n, k` args:
-```cpp
-glass::gemm<float, 6, 6, 6>(1.f, A, B, 0.f, C);
-glass::cgrps::gemm<float, 6, 6, 6>(1.f, A, B, 0.f, C, g);
-```
-
-#### Auto-dispatch: `gemm_dispatch`
-
-`glass::gemm_dispatch` selects tiled or plain gemm at runtime based on whether scratch pointers are provided and `m*k ≤ blockDim`:
-
-```cpp
-extern __shared__ float scratch[];
-float *s_A = scratch, *s_B = scratch + m * 8;
-glass::gemm_dispatch(m, n, k, 1.f, A, B, 0.f, C,
-                     (smem > 0) ? s_A : nullptr,
-                     (smem > 0) ? s_B : nullptr);
-```
-
-Use the host helper to compute required scratch at launch:
-```cpp
-#include "glass.cuh"
-std::size_t smem = glass_gemm_dispatch_smem(m, k, /*block_threads=*/256);
-my_kernel<<<grid, 256, smem>>>(m, n, k, A, B, C);
-```
-
-#### Row-Major Storage Order
-
-```cpp
-// Column-major (default): A[row + col*m]
-glass::gemm<float>(m, n, k, 1.f, A, B, 0.f, C);
-
-// Row-major (all matrices): A[row*cols + col]
-glass::gemm<float, false, true>(m, n, k, 1.f, A, B, 0.f, C);
-
-// Mixed layouts (row-major A and C, column-major B):
-glass::gemm_ex<float, false, true, false, true>(m, n, k, 1.f, A, B, 0.f, C);
-```
-
----
-
-### `glass::nvidia::` L2/L3 (cuBLASDx + cuSOLVERDx)
-
-cuBLASDx computes at warp/tensor-core level and requires compile-time matrix sizes. cuSOLVERDx (factorizations + solves) likewise requires compile-time sizes and additionally requires linking against a precompiled device library. Include `glass-nvidia.cuh` to get pre-instantiated sizes; both backends are auto-detected.
-
-**Pre-instantiated GEMM/GEMV sizes** (square): `4, 6, 8, 12, 14, 24, 64`. cuSOLVERDx wrappers are not pre-instantiated; you must call the appropriate `DEFINE_NVIDIA_*` macro per size in your `.cu` file (inside `namespace glass::nvidia`).
-
-#### Public template parameters
-
-```cpp
-// Common parameter pack for gemm / gemv (and gemm_batched, with extra BATCH):
-template <typename T,
-          uint32_t M, uint32_t N, uint32_t K,
-          uint32_t BLOCK_THREADS = 0,                      // 0 = let cuBLASDx pick
-          layout LA = layout::col_major,                   // arrangement of A
-          layout LB = layout::col_major,                   // arrangement of B
-          layout LC = layout::col_major,                   // arrangement of C
-          uint32_t SM_VAL = SMS>                            // SM arch (default = SMS macro)
-__device__ void gemm(T alpha, T* A, T* B, T beta, T* C, char* smem);
-```
-
-`SMS` defaults to `860` and may be overridden with `-DSMS=XXX` at compile time. See sections 5b–5d above for usage examples (BlockDim, layout, multi-arch).
-
-#### DEFINE-macro family (cuBLASDx wrappers)
-
-Every wrapper exposes the same family of compile-time DEFINE macros. Substitute `GEMM` / `GEMV` / `GEMM_BATCHED` / `CHOL` / `TRSM` / `POSV` / `POTRS` / `GETRF` / `GETRS` / `GESV` / `GEQRF` / `GELS`:
-
-| Macro form | Specializes |
-|------------|------------|
-| `DEFINE_NVIDIA_<NAME>(...)` | default block_dim, all `col_major`, SM = `SMS` |
-| `DEFINE_NVIDIA_<NAME>_BLOCKDIM(..., TC)` | pinned `BlockDim<TC,1,1>`, all `col_major`, SM = `SMS` |
-| `DEFINE_NVIDIA_<NAME>_LAYOUT(..., LA, LB, LC)` *(GEMM only)* | default block_dim, custom layouts, SM = `SMS` |
-| `DEFINE_NVIDIA_<NAME>_BLOCKDIM_LAYOUT(..., TC, LA, LB, LC)` | pinned + custom layouts |
-| `DEFINE_NVIDIA_<NAME>_SM(..., SM)` | explicit SM, default block_dim, all `col_major` |
-| `DEFINE_NVIDIA_<NAME>_BLOCKDIM_SM(..., TC, SM)` | pinned + explicit SM |
-| `DEFINE_NVIDIA_<NAME>_LAYOUT_SM(..., LA, LB, LC, SM)` *(GEMM only)* | custom layouts + explicit SM |
-| `DEFINE_NVIDIA_<NAME>_BLOCKDIM_LAYOUT_SM(..., TC, LA, LB, LC, SM)` | every parameter explicit |
-
-Layout arguments (`LA, LB, LC`) are integer literals: `0` = `col_major`, `1` = `row_major`. GRiD-flag aliases for the common transpose case:
-
-```cpp
-#define DEFINE_NVIDIA_GEMM_TRANSB(M, N, K)               // alias for LAYOUT(M, N, K, 0, 1, 0)
-#define DEFINE_NVIDIA_GEMM_BLOCKDIM_TRANSB(M, N, K, TC)  // alias for BLOCKDIM_LAYOUT(M, N, K, TC, 0, 1, 0)
-```
-
-To add a custom size, place the macro inside `namespace glass::nvidia` in your `.cu` file:
-
-```cpp
-#include "glass-nvidia.cuh"
-namespace glass { namespace nvidia {
-    DEFINE_NVIDIA_GEMM(16, 16, 16)
-    DEFINE_NVIDIA_GEMV(16, 16)
-    DEFINE_NVIDIA_GEMM_BLOCKDIM(16, 16, 16, 256)         // pinned thread count
-    DEFINE_NVIDIA_GEMM_BLOCKDIM_TRANSB(16, 16, 16, 256)  // pinned + B is row-major
-    DEFINE_NVIDIA_POSV_BLOCKDIM(16, 4, 256)              // SPD solve, 4 RHS
-}}
-```
-
-#### Host-side query API
-
-```cpp
-// Smallest BlockDim cuBLASDx accepts for (T, M, N, K, SM). All constexpr.
-template <typename T, uint32_t M, uint32_t N, uint32_t K, uint32_t SM_VAL = SMS>
-constexpr uint32_t glass::nvidia::gemm_min_block_threads();
-
-// True iff BLOCK_THREADS >= the minimum.
-template <typename T, uint32_t M, uint32_t N, uint32_t K, uint32_t BT, uint32_t SM_VAL = SMS>
-constexpr bool glass::nvidia::gemm_block_threads_valid();
-
-// Same for gemv (Size<M, 1, N>):
-constexpr uint32_t glass::nvidia::gemv_min_block_threads<T, M, N, SM_VAL>();
-constexpr bool     glass::nvidia::gemv_block_threads_valid<T, M, N, BT, SM_VAL>();
-```
-
-These do **not** require a `DEFINE_NVIDIA_*` macro — they construct the GEMM type inline and read `block_dim` directly. Useful for codegen that wants to pick `MAX_PERF_LEVEL_THREADS` at generation time.
-
-#### Debug assertions
-
-Compile without `-DNDEBUG` and the wrappers `assert(blockDim >= GEMM::block_dim)` inside every `run()`. Misconfigured launches now fail with a clean assertion message rather than silently deadlocking. The assertions compile out under `-DNDEBUG`.
-
----
-
-## Running Tests
+Runnable, self-contained programs (one concept each) live in [`examples/`](examples/). GEMM
+follows the **standard BLAS convention** — `C` is M×N, contraction K (`A` is M×K, `B` is K×N) —
+with `TRANSPOSE_A` / `TRANSPOSE_B` operand flags and a single `ROW_MAJOR_C` output flag; a
+row-major operand is just a transpose. See [`examples/10_gemm_basics.cu`](examples/10_gemm_basics.cu)
+and [`examples/MIGRATION.md`](examples/MIGRATION.md).
+
+## Installation
+
+GLASS is **header-only** — add the repo root to your include path and `#include "glass.cuh"`.
+The pure-SIMT surface needs only `nvcc -std=c++17`. The `glass::nvidia::` paths additionally
+need NVIDIA MathDx (cuBLASDx / cuSOLVERDx) and extra flags:
+
+| Surface | Build requirements |
+|---------|--------------------|
+| `glass.cuh`, `glass-cgrps.cuh` | C++17 — no extra deps |
+| `glass-nvidia.cuh` (L1) | C++17 + CUB (bundled with CUDA 11+) |
+| `glass-nvidia.cuh` (L2/L3 GEMM/GEMV/batched) | C++17 + `--expt-relaxed-constexpr` + cuBLASDx |
+| `glass-nvidia.cuh` (LAPACK) | C++17 + `--expt-relaxed-constexpr` + `-rdc=true -dlto -lcusolverdx -lcublas -lcusolver -lcudart` + cuSOLVERDx |
+
+The nvidia wrappers auto-detect availability (`GLASS_HAVE_CUBLASDX` / `GLASS_HAVE_CUSOLVERDX`).
+Full setup, linking, and the MathDx download are in [`bench/INSTALL.md`](bench/INSTALL.md) and
+the [installation guide](docs/source/user_guide/getting_started/installation.rst).
+
+## Build & test
 
 ```bash
-cd test
-pip install -r requirements.txt
-pytest -v
+pip install -r test/requirements.txt
+pytest test/                 # compiles test/cuda/*.cu once, caches by source hash
 ```
 
-The first run compiles the CUDA test binaries using `nvcc`. Subsequent runs skip recompilation unless source files have changed (cached by content hash). Compiled binaries are placed in `test/build/`.
+`rm -rf test/build` forces a clean rebuild. Details in
+[`docs/source/user_guide/tutorials/running_tests.rst`](docs/source/user_guide/tutorials/running_tests.rst).
 
-```bash
-pytest test_l1.py -v
-pytest test_l1.py -k "simple"      # glass:: threadIdx variants only
-pytest test_l1.py -k "cg"          # glass::cgrps:: cooperative groups variants
-pytest test_l1.py -k "simple_hs"   # high_speed warp-shuffle variants
-```
+## Documentation map
 
----
+The README is a landing page; the deep reference lives in the
+[hosted docs](https://a2r-lab.github.io/GLASS/) (sources in [`docs/source/`](docs/source/)):
 
-## Benchmarks
+| Topic | Page |
+|-------|------|
+| API reference (L1 / L2 / L3 / nvidia / warp / banded) | [`api_reference/`](docs/source/api_reference/) |
+| Namespaces, naming rules, and the two-axis taxonomy | [`concepts/namespaces.rst`](docs/source/user_guide/concepts/namespaces.rst) |
+| Choosing a backend + tuning for your hardware | [`concepts/tuning.rst`](docs/source/user_guide/concepts/tuning.rst) |
+| `glass::nvidia::gemm` cuBLASDx-vs-SIMT dispatch | [`concepts/backend_dispatch.rst`](docs/source/user_guide/concepts/backend_dispatch.rst) |
+| `TRAILING_SYNC` and barrier conventions | [`concepts/trailing_sync.rst`](docs/source/user_guide/concepts/trailing_sync.rst) |
+| Contraction-parallel (`*_reduced`) family | [`concepts/contraction_parallel.rst`](docs/source/user_guide/concepts/contraction_parallel.rst) |
+| Block-tridiagonal layout (`bdmv` / `pcg`) | [`concepts/block_tridiagonal.rst`](docs/source/user_guide/concepts/block_tridiagonal.rst) |
+| Worked examples + quickstart | [`tutorials/`](docs/source/user_guide/tutorials/) · [`examples/`](examples/) |
+| Benchmarks + measured sweep results | [`tutorials/benchmarks.rst`](docs/source/user_guide/tutorials/benchmarks.rst) · [`tutorials/sweep_results.rst`](docs/source/user_guide/tutorials/sweep_results.rst) |
 
-The benchmark suite compares GLASS variants against block-level CUDA library baselines AND against each other:
+## Notes / gotchas
 
-| File | Comparison |
-|------|-----------|
-| `bench_reduce.cu` | `glass::*::reduce/dot/l2norm` (plain, low_memory, high_speed, compile-time) vs CUB `BlockReduce` vs `glass::nvidia::reduce` (CUB-backed) |
-| `bench_gemv.cu` | `glass::gemv` (runtime + compile-time) vs raw cuBLASDx vs `glass::nvidia::gemv` (default block_dim + caller-pinned `BlockDim<256>`) |
-| `bench_gemm.cu` | `glass::gemm` (plain, tiled, compile-time) vs raw cuBLASDx vs `glass::nvidia::gemm` (default + caller-pinned) |
-| `bench_blockdim.cu` | `glass::nvidia::gemm` with cuBLASDx-chosen block_dim vs caller-pinned `BlockDim<128>` vs `BlockDim<352>` (the GRiD iiwa14 launch that pre-fix would have deadlocked) |
-| `bench_gemm_batched.cu` | `glass::nvidia::gemm_batched<...,BATCH>` vs naive `for(b)` loop calling `gemm` BATCH times, for BATCH ∈ {4, 8, 16, 32} |
-| `bench_gemm_batched_1d.cu` | New 1D-launch `glass::nvidia::gemm_batched_1d` (SIMT vs cuBLASDx), for BATCH ∈ {4, 8, 16, 32} — feeds the autotune table |
-| `bench_lapack.cu` *(needs cuSOLVERDx)* | pure-SIMT `glass::cholDecomp_InPlace` / `glass::trsm` vs `glass::nvidia::cholDecomp_InPlace` / `trsm` / `posv` (fused) |
-
-CUB is bundled with CUDA 11+. cuBLASDx and cuSOLVERDx ship together in NVIDIA MathDx (see [`bench/INSTALL.md`](bench/INSTALL.md)).
-
-```bash
-# Set MATHDX_ROOT to your MathDx installation, then:
-python3 bench/run_bench.py
-
-# Custom iteration count (default: 10000):
-python3 bench/run_bench.py --iters 50000
-
-# Skip cuBLASDx (bench_gemv/gemm/blockdim/batched/lapack will not run):
-python3 bench/run_bench.py --no-cublasdx
-```
-
-`bench_lapack` is automatically skipped if `cusolverdx.hpp` is not present under `$MATHDX_ROOT/include/`.
-
-**Anti-optimization safeguards** are baked into every bench loop: per-iteration writes to a `volatile` sink defeat dead-store elimination; destructive inputs (Cholesky, LU, QR all overwrite their input) are reloaded from a master copy each iteration; `nvcc -Xptxas -O1` is enforced. Numbers below ~0.1 µs/op for a non-trivial kernel almost always indicate the bench was elided — recheck the safeguards if you see that.
-
-### Tuning your local build
-
-The `glass::nvidia::*` auto-dispatch picks SIMT-vs-cuBLASDx per shape via
-the heuristic in `should_use_cublasdx*<>()`. To override that heuristic
-with **actual measurements on your hardware**:
-
-```bash
-python3 bench/autotune.py
-# → measures all 5 auto-dispatching primaries, writes bench/tuning/<hostname>.cuh.
-# → does NOT modify src/nvidia/tuning_table.cuh.
-#
-# Compile your project with:
-#   nvcc ... -DGLASS_TUNING_TABLE_LOCAL='"bench/tuning/<hostname>.cuh"' ...
-#
-# Per-host files are gitignored — only the shipped global table is
-# tracked in version control. Want to PR your measurements upstream?
-# See bench/TUNING.md (covers --in-tree mode for shipped-table updates).
-```
-
-The shipped global table (`src/nvidia/tuning_table.cuh`) is grown
-collaboratively — contributions are welcomed via PR. See
-[`bench/TUNING.md`](bench/TUNING.md) for the contributor workflow,
-including `autotune.py --in-tree` (writes specializations directly
-into the shipped table, preserving the auto-dispatching primaries above it).
-
-Timing uses the GRiD pattern — the iteration loop runs inside the kernel to amortize launch overhead. Results are printed as a Markdown table and saved to `bench/results/bench_<hostname>.json`.
-
----
-
-## Notes
-
-- Matrices default to **column-major** (Fortran) order, consistent with cuBLAS. Pure-SIMT `glass::` uses a `ROW_MAJOR=true` template parameter; `glass::nvidia::` uses the `layout` enum (`col_major` / `row_major`) per matrix via `LA`, `LB`, `LC` template arguments.
-- `dot` and reduction variants modify the input array in-place (result in `x[0]`); `l2norm` squares elements before reducing.
-- `cholDecomp_InPlace` only fills the **lower triangle** of the matrix; the upper triangle retains input values.
-- `glass::gemm` (pure-SIMT) with `TRANSPOSE_B=true` currently requires B to be square (n×n). The `glass::nvidia::gemm` path has no such restriction — use `LB = layout::row_major` (or `DEFINE_NVIDIA_GEMM_BLOCKDIM_TRANSB`).
-- `glass::nvidia::*` (default form) requires exactly the thread count returned by `gemm_threads<T,M,N,K>()`. Use the `BLOCK_THREADS` template parameter (with `DEFINE_NVIDIA_<NAME>_BLOCKDIM`) to launch with any thread count `≥ gemm_min_block_threads<T,M,N,K>()` — extras go idle inside the GEMM. Compile without `-DNDEBUG` to get a clean assertion if the launch is too small instead of a silent deadlock.
-- `glass::nvidia::trsm` does not accept a non-1.0 `alpha` natively (cuSOLVERDx's `trsm` has no alpha); the wrapper pre-multiplies `B` by `alpha` in shared memory before calling execute.
+- **One block per problem.** Every function runs inside a single block; launch `<<<num_items, threads>>>`.
+- **Column-major by default** (Fortran order, matching cuBLAS). GEMM uses `TRANSPOSE_A` /
+  `TRANSPOSE_B` + `ROW_MAJOR_C` (a row-major operand is just a transpose); GEMV keeps a
+  per-matrix `ROW_MAJOR` flag (its transpose changes the math op); `glass::nvidia::` uses the
+  `layout` enum per matrix (`LA`/`LB`/`LC`).
+- **Reductions are destructive.** `dot` / `nrm2` / reduction variants write the result to `x[0]`
+  and may consume the input as scratch; `nrm2` squares elements before reducing. The
+  `glass::warp::` forms return the value instead.
+- `cholDecomp_InPlace` fills only the **lower triangle**; the upper retains input values.
+- `glass::nvidia::*` (default form) requires exactly `gemm_threads<T,M,N,K>()` threads; use the
+  `BLOCK_THREADS` template parameter (with `DEFINE_NVIDIA_<NAME>_BLOCKDIM`) to launch any count
+  `≥ gemm_min_block_threads<T,M,N,K>()`. Compile without `-DNDEBUG` for a clean assertion instead
+  of a silent deadlock if the launch is too small.
+- `glass::nvidia::trsm` has no native non-1.0 `alpha` (cuSOLVERDx limitation); the wrapper
+  pre-scales `B` in shared memory before `execute`.

--- a/bench/TUNING.md
+++ b/bench/TUNING.md
@@ -12,7 +12,7 @@ compile time. The decision lives in
 3. A static per-API heuristic for unmeasured shapes.
 
 Five per-API decision templates live in `_glass_tuning` (gemm, gemv,
-gemm_batched_1d, row_strided_gemm, row_strided_gemv). Each can be
+gemm_batched_1d, gemm_strided, gemv_strided). Each can be
 specialized independently for a given (shape, SM).
 
 ## Why bother?
@@ -35,8 +35,8 @@ specialize it and either keep it local or PR upstream.
 ```bash
 cd GLASS
 python3 bench/autotune.py
-# → measures all 5 round-2 primaries (gemm, gemv, row_strided_gemv,
-#   row_strided_gemm, gemm_batched_1d) across each one's default shape grid
+# → measures all 5 round-2 primaries (gemm, gemv, gemv_strided,
+#   gemm_strided, gemm_batched_1d) across each one's default shape grid
 # → writes bench/tuning/<hostname>.cuh with the per-host specializations
 ```
 
@@ -80,15 +80,15 @@ heuristics reflect the API's arithmetic intensity:
 | `cublasdx_wins<M, N, K, SM>`                                        | `max(M,N,K)>=16 AND min(M,N,K)>=4` |
 | `cublasdx_wins_gemv<M, N, SM>`                                      | `max(M,N) >= 32` |
 | `cublasdx_wins_batched<M, N, K, BATCH, SM>`                         | `BATCH>=8 AND max(M,N,K)>=8` |
-| `cublasdx_wins_row_strided_gemm<M, N, K, A_RS, B_RS, SM>`           | delegates to `cublasdx_wins<>` |
-| `cublasdx_wins_row_strided_gemv<M, N, ROW_STRIDE, SM>`              | delegates to `cublasdx_wins_gemv<>` |
+| `cublasdx_wins_gemm_strided<M, N, K, A_RS, B_RS, SM>`           | delegates to `cublasdx_wins<>` |
+| `cublasdx_wins_gemv_strided<M, N, ROW_STRIDE, SM>`              | delegates to `cublasdx_wins_gemv<>` |
 
 `bench/autotune.py` (round-2 rewrite) covers all five. To restrict to a
 subset:
 
 ```bash
 python3 bench/autotune.py --apis gemm,gemv
-python3 bench/autotune.py --apis row_strided_gemv --shapes "6,6,8;14,14,16"
+python3 bench/autotune.py --apis gemv_strided --shapes "6,6,8;14,14,16"
 ```
 
 The `--shapes` flag passes a `;`-separated tuple list; the arity has to

--- a/bench/autotune.py
+++ b/bench/autotune.py
@@ -5,7 +5,7 @@ file consumed via `GLASS_TUNING_TABLE_LOCAL`.
 
 Usage:
     python3 bench/autotune.py [--sm AUTO|<sm>]
-                              [--apis gemm,gemv,row_strided_gemv,row_strided_gemm,gemm_batched_1d]
+                              [--apis gemm,gemv,gemv_strided,gemm_strided,gemm_batched_1d]
                               [--iters 10000]
                               [--out PATH]
                               [--margin 0.05]
@@ -121,7 +121,7 @@ _GEMM_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
         cudaMalloc(&dSink, 256 * sizeof(float));
 
         struct timespec t0, t1;
-        constexpr size_t smem = glass::nvidia::gemm_smem_size<float, M, N, K, TC>();
+        constexpr size_t smem = glass::nvidia::gemm_scratch_bytes<float, M, N, K, TC>();
 
         k_simt<<<1, TC>>>(dA, dB, dC, dSink, 100); cudaDeviceSynchronize();
         k_cublasdx<<<1, TC, smem>>>(dA, dB, dC, dSink, 100); cudaDeviceSynchronize();
@@ -179,7 +179,7 @@ _GEMV_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
         cudaMalloc(&dSink, 256 * sizeof(float));
 
         struct timespec t0, t1;
-        constexpr size_t smem = glass::nvidia::gemv_smem_size<float, M, N, TC>();
+        constexpr size_t smem = glass::nvidia::gemv_scratch_bytes<float, M, N, TC>();
 
         k_simt<<<1, TC>>>(dA, dx, dy, dSink, 100); cudaDeviceSynchronize();
         k_cublasdx<<<1, TC, smem>>>(dA, dx, dy, dSink, 100); cudaDeviceSynchronize();
@@ -200,9 +200,9 @@ _GEMV_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 """)
 
 
-# ───── row_strided_gemv ─────────────────────────────────────────────────────
+# ───── gemv_strided ─────────────────────────────────────────────────────
 # ROW_STRIDE is sized to be > N so the strided pack pass is exercised on the
-# cuBLASDx leg. SIMT path is glass::row_strided_gemv (base SIMT impl).
+# cuBLASDx leg. SIMT path is glass::gemv_strided (base SIMT impl).
 _ROW_STRIDED_GEMV_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 
     static const int M = {M}, N = {N}, ROW_STRIDE = {ROW_STRIDE};
@@ -213,7 +213,7 @@ _ROW_STRIDED_GEMV_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 
     __global__ void k_simt(float* A, float* x, float* y, volatile float* sink, int iters) {{
         for (int rep = 0; rep < iters; rep++) {{
-            glass::row_strided_gemv<float, M, N, ROW_STRIDE>(A, x, y, 1.f, 0.f);
+            glass::gemv_strided<float, M, N, ROW_STRIDE>(A, x, y, 1.f, 0.f);
             __syncthreads();
             if (threadIdx.x == 0) sink[rep & 0xFF] = y[0];
             __syncthreads();
@@ -223,7 +223,7 @@ _ROW_STRIDED_GEMV_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
     __global__ void k_cublasdx(float* A, float* x, float* y, volatile float* sink, int iters) {{
         extern __shared__ __align__(16) char smem[];
         for (int rep = 0; rep < iters; rep++) {{
-            glass::nvidia::row_strided_gemv<float, M, N, ROW_STRIDE, TC>(1.f, A, x, 0.f, y, smem);
+            glass::nvidia::gemv_strided<float, M, N, ROW_STRIDE, TC>(1.f, A, x, 0.f, y, smem);
             __syncthreads();
             if (threadIdx.x == 0) sink[rep & 0xFF] = y[0];
             __syncthreads();
@@ -240,7 +240,7 @@ _ROW_STRIDED_GEMV_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 
         struct timespec t0, t1;
         constexpr size_t smem =
-            glass::nvidia::row_strided_gemv_smem_size<float, M, N, ROW_STRIDE, TC>();
+            glass::nvidia::gemv_strided_scratch_bytes<float, M, N, ROW_STRIDE, TC>();
 
         k_simt<<<1, TC>>>(dA, dx, dy, dSink, 100); cudaDeviceSynchronize();
         k_cublasdx<<<1, TC, smem>>>(dA, dx, dy, dSink, 100); cudaDeviceSynchronize();
@@ -261,9 +261,9 @@ _ROW_STRIDED_GEMV_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 """)
 
 
-# ───── row_strided_gemm ─────────────────────────────────────────────────────
+# ───── gemm_strided ─────────────────────────────────────────────────────
 # A_RS sized > M; B_RS sized > N. The strided pack pass is exercised on both
-# legs (SIMT does it inside ::glass::row_strided_gemm; cuBLASDx does it inside
+# legs (SIMT does it inside ::glass::gemm_strided; cuBLASDx does it inside
 # the nvidia wrapper before the cuBLASDx execute).
 _ROW_STRIDED_GEMM_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 
@@ -276,7 +276,7 @@ _ROW_STRIDED_GEMM_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 
     __global__ void k_simt(float* A, float* B, float* C, volatile float* sink, int iters) {{
         for (int rep = 0; rep < iters; rep++) {{
-            glass::row_strided_gemm<float, M, N, K, A_RS, B_RS>(A, B, C, 1.f, 0.f);
+            glass::gemm_strided<float, M, N, K, A_RS, B_RS>(A, B, C, 1.f, 0.f);
             __syncthreads();
             if (threadIdx.x == 0) sink[rep & 0xFF] = C[0];
             __syncthreads();
@@ -286,7 +286,7 @@ _ROW_STRIDED_GEMM_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
     __global__ void k_cublasdx(float* A, float* B, float* C, volatile float* sink, int iters) {{
         extern __shared__ __align__(16) char smem[];
         for (int rep = 0; rep < iters; rep++) {{
-            glass::nvidia::row_strided_gemm<float, M, N, K, A_RS, B_RS, TC>(1.f, A, B, 0.f, C, smem);
+            glass::nvidia::gemm_strided<float, M, N, K, A_RS, B_RS, TC>(1.f, A, B, 0.f, C, smem);
             __syncthreads();
             if (threadIdx.x == 0) sink[rep & 0xFF] = C[0];
             __syncthreads();
@@ -303,7 +303,7 @@ _ROW_STRIDED_GEMM_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 
         struct timespec t0, t1;
         constexpr size_t smem =
-            glass::nvidia::row_strided_gemm_smem_size<float, M, N, K, A_RS, B_RS, TC>();
+            glass::nvidia::gemm_strided_scratch_bytes<float, M, N, K, A_RS, B_RS, TC>();
 
         k_simt<<<1, TC>>>(dA, dB, dC, dSink, 100); cudaDeviceSynchronize();
         k_cublasdx<<<1, TC, smem>>>(dA, dB, dC, dSink, 100); cudaDeviceSynchronize();
@@ -388,7 +388,7 @@ _GEMM_BATCHED_MICROBENCH = _BENCH_PREAMBLE + textwrap.dedent("""
 
         struct timespec t0, t1;
         constexpr size_t smem =
-            glass::nvidia::gemm_batched_smem_size<float, M, N, K, BATCH, TC>();
+            glass::nvidia::gemm_batched_scratch_bytes<float, M, N, K, BATCH, TC>();
 
         // SIMT batched_1d launches 1D with TC*BATCH threads, ptr-array args.
         k_simt<<<1, TC * BATCH>>>(dAs, dBs, dCs, dSink, 100); cudaDeviceSynchronize();
@@ -428,12 +428,12 @@ def _spec_gemv(m, n, sms):
     return f"cublasdx_wins_gemv<{m:>2},{n:>3},{sms:>5}>"
 
 
-def _spec_row_strided_gemv(m, n, rs, sms):
-    return f"cublasdx_wins_row_strided_gemv<{m:>2},{n:>3},{rs:>3},{sms:>5}>"
+def _spec_gemv_strided(m, n, rs, sms):
+    return f"cublasdx_wins_gemv_strided<{m:>2},{n:>3},{rs:>3},{sms:>5}>"
 
 
-def _spec_row_strided_gemm(m, n, k, a_rs, b_rs, sms):
-    return (f"cublasdx_wins_row_strided_gemm<"
+def _spec_gemm_strided(m, n, k, a_rs, b_rs, sms):
+    return (f"cublasdx_wins_gemm_strided<"
             f"{m:>2},{n:>3},{k:>3},{a_rs:>3},{b_rs:>3},{sms:>5}>")
 
 
@@ -456,20 +456,20 @@ API_CONFIGS = {
         "spec_fmt": _spec_gemv,
         "label_fmt": lambda s: f"{s[0]}x{s[1]}",
     },
-    "row_strided_gemv": {
+    "gemv_strided": {
         "shape_keys": ("M", "N", "ROW_STRIDE"),
         # Stride a few elements wider than N to exercise the pack pass.
         "default_shapes": [(m, m, m + 2) for m in (4, 6, 8, 12, 14, 16, 24, 32)],
         "microbench": _ROW_STRIDED_GEMV_MICROBENCH,
-        "spec_fmt": _spec_row_strided_gemv,
+        "spec_fmt": _spec_gemv_strided,
         "label_fmt": lambda s: f"{s[0]}x{s[1]} rs={s[2]}",
     },
-    "row_strided_gemm": {
+    "gemm_strided": {
         "shape_keys": ("M", "N", "K", "A_RS", "B_RS"),
         "default_shapes": [(m, m, m, m + 2, m + 2)
                            for m in (4, 6, 8, 12, 14, 16, 24, 32)],
         "microbench": _ROW_STRIDED_GEMM_MICROBENCH,
-        "spec_fmt": _spec_row_strided_gemm,
+        "spec_fmt": _spec_gemm_strided,
         "label_fmt": lambda s: f"{s[0]}x{s[1]}x{s[2]} A_rs={s[3]} B_rs={s[4]}",
     },
     "gemm_batched_1d": {

--- a/bench/bench_blockdim.cu
+++ b/bench/bench_blockdim.cu
@@ -81,7 +81,7 @@ static void bench_one(int iters) {
     struct timespec t0, t1;
 
     // default (cuBLASDx-chosen block_dim)
-    constexpr auto smem_def = glass::nvidia::gemm_smem_size<float, M, N, K>();
+    constexpr auto smem_def = glass::nvidia::gemm_scratch_bytes<float, M, N, K>();
     constexpr auto thr_def  = glass::nvidia::gemm_threads<float, M, N, K>();
     cudaMemset(dC, 0, M*K*sizeof(float));
     clock_gettime(CLOCK_MONOTONIC, &t0);
@@ -92,7 +92,7 @@ static void bench_one(int iters) {
            M, N, K, thr_def, elapsed_us(t0, t1) / iters);
 
     // pinned 128
-    constexpr auto smem_128 = glass::nvidia::gemm_smem_size<float, M, N, K, 128>();
+    constexpr auto smem_128 = glass::nvidia::gemm_scratch_bytes<float, M, N, K, 128>();
     cudaMemset(dC, 0, M*K*sizeof(float));
     clock_gettime(CLOCK_MONOTONIC, &t0);
     k_pinned<M, N, K, 128><<<1, 128, smem_128>>>(dA, dB, dC, dSink, iters);
@@ -102,7 +102,7 @@ static void bench_one(int iters) {
            M, N, K, elapsed_us(t0, t1) / iters);
 
     // pinned 352 (GRiD iiwa14 MAX_PERF_LEVEL_THREADS — the value that deadlocked pre-P0-1)
-    constexpr auto smem_352 = glass::nvidia::gemm_smem_size<float, M, N, K, 352>();
+    constexpr auto smem_352 = glass::nvidia::gemm_scratch_bytes<float, M, N, K, 352>();
     cudaMemset(dC, 0, M*K*sizeof(float));
     clock_gettime(CLOCK_MONOTONIC, &t0);
     k_pinned<M, N, K, 352><<<1, 352, smem_352>>>(dA, dB, dC, dSink, iters);

--- a/bench/bench_gemm.cu
+++ b/bench/bench_gemm.cu
@@ -278,7 +278,7 @@ __global__ void k_nv_gemm_blockdim(float* A, float* B, float* C, volatile float*
 
 #define RUN_NVIDIA_GEMM(M, N, K, dA, dB, dC, sink, iters, t0, t1)                            \
     {                                                                                         \
-        constexpr auto smem_def = glass::nvidia::gemm_smem_size<float, M, N, K>();           \
+        constexpr auto smem_def = glass::nvidia::gemm_scratch_bytes<float, M, N, K>();           \
         constexpr auto thr_def  = glass::nvidia::gemm_threads<float, M, N, K>();             \
         cudaMemset(dC, 0, (size_t)M*K*sizeof(float));                                         \
         clock_gettime(CLOCK_MONOTONIC, &(t0));                                                 \
@@ -287,7 +287,7 @@ __global__ void k_nv_gemm_blockdim(float* A, float* B, float* C, volatile float*
         clock_gettime(CLOCK_MONOTONIC, &(t1));                                                 \
         printf("glass::nvidia gemm (default) m=%2d n=%2d k=%2d  %.3f us/op\n",               \
                M, N, K, elapsed_us(t0, t1) / iters);                                          \
-        constexpr auto smem_bd = glass::nvidia::gemm_smem_size<float, M, N, K, THREADS>();   \
+        constexpr auto smem_bd = glass::nvidia::gemm_scratch_bytes<float, M, N, K, THREADS>();   \
         cudaMemset(dC, 0, (size_t)M*K*sizeof(float));                                         \
         clock_gettime(CLOCK_MONOTONIC, &(t0));                                                 \
         k_nv_gemm_blockdim<M, N, K, THREADS><<<1, THREADS, smem_bd>>>(dA, dB, dC, sink, iters); \

--- a/bench/bench_gemm_batched.cu
+++ b/bench/bench_gemm_batched.cu
@@ -100,7 +100,7 @@ static void bench_batch(int iters) {
     struct timespec t0, t1;
 
     // Naive loop (one block, sequential per batch).
-    constexpr size_t naive_smem = glass::nvidia::gemm_smem_size<float, M, N, K, THREADS>();
+    constexpr size_t naive_smem = glass::nvidia::gemm_scratch_bytes<float, M, N, K, THREADS>();
     clock_gettime(CLOCK_MONOTONIC, &t0);
     k_naive_loop<BATCH><<<1, THREADS, naive_smem>>>(dA_ptrs, dB_ptrs, dC_ptrs, dSink, iters);
     cudaDeviceSynchronize();
@@ -110,7 +110,7 @@ static void bench_batch(int iters) {
            elapsed_us(t0, t1) / iters / BATCH);
 
     // Batched (one block, dim3(TC, BATCH)).
-    constexpr size_t batch_smem = glass::nvidia::gemm_batched_smem_size<float, M, N, K, BATCH, THREADS>();
+    constexpr size_t batch_smem = glass::nvidia::gemm_batched_scratch_bytes<float, M, N, K, BATCH, THREADS>();
     dim3 batch_block(THREADS, BATCH);
     clock_gettime(CLOCK_MONOTONIC, &t0);
     k_batched<BATCH><<<1, batch_block, batch_smem>>>(dA_ptrs, dB_ptrs, dC_ptrs, dSink, iters);

--- a/bench/bench_gemv.cu
+++ b/bench/bench_gemv.cu
@@ -241,7 +241,7 @@ __global__ void k_nv_gemv_blockdim(float* A, float* x, float* y, volatile float*
 
 #define RUN_NVIDIA_GEMV(M, N, dA, dx, dy, sink, iters, t0, t1)                          \
     {                                                                                    \
-        constexpr auto smem_def = glass::nvidia::gemv_smem_size<float, M, N>();         \
+        constexpr auto smem_def = glass::nvidia::gemv_scratch_bytes<float, M, N>();         \
         constexpr auto thr_def  = glass::nvidia::gemv_threads<float, M, N>();           \
         cudaMemset(dy, 0, (size_t)M*sizeof(float));                                      \
         clock_gettime(CLOCK_MONOTONIC, &(t0));                                            \
@@ -250,7 +250,7 @@ __global__ void k_nv_gemv_blockdim(float* A, float* x, float* y, volatile float*
         clock_gettime(CLOCK_MONOTONIC, &(t1));                                            \
         printf("glass::nvidia gemv (default) m=%2d n=%2d  %.3f us/op\n",                \
                M, N, elapsed_us(t0, t1) / iters);                                        \
-        constexpr auto smem_bd = glass::nvidia::gemv_smem_size<float, M, N, THREADS>(); \
+        constexpr auto smem_bd = glass::nvidia::gemv_scratch_bytes<float, M, N, THREADS>(); \
         cudaMemset(dy, 0, (size_t)M*sizeof(float));                                      \
         clock_gettime(CLOCK_MONOTONIC, &(t0));                                            \
         k_nv_gemv_blockdim<M, N, THREADS><<<1, THREADS, smem_bd>>>(dA, dx, dy, sink, iters); \

--- a/bench/bench_lapack.cu
+++ b/bench/bench_lapack.cu
@@ -219,7 +219,7 @@ static void bench_size_ct(int iters) {
            N, elapsed_us(t0, t1) / iters);
 
     // glass::nvidia chol
-    constexpr size_t nv_chol_smem = glass::nvidia::cholDecomp_InPlace_smem_size<float, N, THREADS>();
+    constexpr size_t nv_chol_smem = glass::nvidia::cholDecomp_InPlace_scratch_bytes<float, N, THREADS>();
     clock_gettime(CLOCK_MONOTONIC, &t0);
     k_nv_chol<N><<<1, THREADS, nv_chol_smem>>>(dA_master, dA, dSink, iters);
     cudaDeviceSynchronize();
@@ -228,7 +228,7 @@ static void bench_size_ct(int iters) {
            N, elapsed_us(t0, t1) / iters);
 
     // glass::nvidia chol+trsm
-    constexpr size_t nv_trsm_smem = glass::nvidia::trsm_smem_size<float, N, 1, THREADS>();
+    constexpr size_t nv_trsm_smem = glass::nvidia::trsm_scratch_bytes<float, N, 1, THREADS>();
     constexpr size_t nv_chol_trsm_smem = nv_chol_smem > nv_trsm_smem ? nv_chol_smem : nv_trsm_smem;
     clock_gettime(CLOCK_MONOTONIC, &t0);
     k_nv_chol_trsm<N><<<1, THREADS, nv_chol_trsm_smem>>>(dA_master, db_master, dA, db, dSink, iters);
@@ -238,7 +238,7 @@ static void bench_size_ct(int iters) {
            N, elapsed_us(t0, t1) / iters);
 
     // glass::nvidia posv (fused)
-    constexpr size_t nv_posv_smem = glass::nvidia::posv_smem_size<float, N, 1, THREADS>();
+    constexpr size_t nv_posv_smem = glass::nvidia::posv_scratch_bytes<float, N, 1, THREADS>();
     clock_gettime(CLOCK_MONOTONIC, &t0);
     k_nv_posv<N><<<1, THREADS, nv_posv_smem>>>(dA_master, db_master, dA, db, dSink, iters);
     cudaDeviceSynchronize();

--- a/bench/bench_mega_sweep.cu
+++ b/bench/bench_mega_sweep.cu
@@ -238,16 +238,16 @@ static double nv_op_time(Op op, T* A, T* B, T* C, T* x, T* y, int reps) {
 #if MEGA_NV_BLAS
     if constexpr (nv_blas_ok<T,N>()) {
         if (op == DOT) {
-            size_t smem = glass::nvidia::reduce_smem_size<T,NV_DOT_TB>();
+            size_t smem = glass::nvidia::reduce_scratch_bytes<T,NV_DOT_TB>();
             return nv_timed(kn_dot<T,N>, smem, [&]{ kn_dot<T,N><<<grid,NV_DOT_TB,smem>>>(x, y); }, reps);
         }
         if (op == GEMV) {
-            size_t smem = glass::nvidia::gemv_smem_size<T,N,N>();
+            size_t smem = glass::nvidia::gemv_scratch_bytes<T,N,N>();
             int tb = (int)glass::nvidia::gemv_threads<T,N,N>();
             return nv_timed(kn_gemv<T,N>, smem, [&]{ kn_gemv<T,N><<<grid,tb,smem>>>(A, x, y); }, reps);
         }
         if (op == GEMM) {
-            size_t smem = glass::nvidia::gemm_smem_size<T,N,N,N>();
+            size_t smem = glass::nvidia::gemm_scratch_bytes<T,N,N,N>();
             int tb = (int)glass::nvidia::gemm_threads<T,N,N,N>();
             return nv_timed(kn_gemm<T,N>, smem, [&]{ kn_gemm<T,N><<<grid,tb,smem>>>(A, B, C); }, reps);
         }
@@ -256,15 +256,15 @@ static double nv_op_time(Op op, T* A, T* B, T* C, T* x, T* y, int reps) {
 #if MEGA_NV_LAPACK
     if constexpr (nv_lapack_ok<T,N>()) {
         if (op == CHOL) {
-            size_t smem = glass::nvidia::cholDecomp_InPlace_smem_size<T,N,NV_LP_TB>();
+            size_t smem = glass::nvidia::cholDecomp_InPlace_scratch_bytes<T,N,NV_LP_TB>();
             return nv_timed(kn_chol<T,N>, smem, [&]{ kn_chol<T,N><<<grid,NV_LP_TB,smem>>>(A); }, reps);
         }
         if (op == TRSV) {
-            size_t smem = glass::nvidia::trsm_smem_size<T,N,1,NV_LP_TB>();
+            size_t smem = glass::nvidia::trsm_scratch_bytes<T,N,1,NV_LP_TB>();
             return nv_timed(kn_trsv<T,N>, smem, [&]{ kn_trsv<T,N><<<grid,NV_LP_TB,smem>>>(A, x); }, reps);
         }
         if (op == POSV) {
-            size_t smem = glass::nvidia::posv_smem_size<T,N,1,NV_LP_TB>();
+            size_t smem = glass::nvidia::posv_scratch_bytes<T,N,1,NV_LP_TB>();
             return nv_timed(kn_posv<T,N>, smem, [&]{ kn_posv<T,N><<<grid,NV_LP_TB,smem>>>(A, x); }, reps);
         }
     }

--- a/bench/bench_reduce.cu
+++ b/bench/bench_reduce.cu
@@ -1,4 +1,4 @@
-// bench_reduce.cu — L1 benchmarks: glass:: reduce/dot/l2norm vs. CUB BlockReduce
+// bench_reduce.cu — L1 benchmarks: glass:: reduce/dot/nrm2 vs. CUB BlockReduce
 // Compilation: nvcc -std=c++17 -arch=sm_XX -I.. -I../src -O3 bench_reduce.cu -o bench_reduce
 // Usage: ./bench_reduce <n> [iters]
 
@@ -8,7 +8,7 @@
 #include <cmath>
 #include <cub/cub.cuh>
 #include "../glass.cuh"
-#include "../glass-nvidia.cuh"  // pulls in glass::nvidia::reduce/dot/l2norm (CUB-backed)
+#include "../glass-nvidia.cuh"  // pulls in glass::nvidia::reduce/dot/nrm2 (CUB-backed)
 
 static const int THREADS = 256;
 
@@ -42,11 +42,11 @@ __global__ void k_nv_dot(float* x, float* y, volatile float* sink, int iters) {
 }
 
 template<int N>
-__global__ void k_nv_l2norm(float* x, volatile float* sink, int iters) {
+__global__ void k_nv_nrm2(float* x, volatile float* sink, int iters) {
     extern __shared__ float scratch[];
     for (int rep = 0; rep < iters; rep++) {
         float out;
-        glass::nvidia::l2norm<float, N, THREADS>(x, &out, scratch);
+        glass::nvidia::nrm2<float, N, THREADS>(x, &out, scratch);
         __syncthreads();
         if (threadIdx.x == 0) sink[rep & 0xFF] = out;
         __syncthreads();
@@ -81,12 +81,12 @@ __global__ void k_glass_dot(float* x, float* y, int n, int iters) {
     if (threadIdx.x == 0) x[0] = smem[0];
 }
 
-__global__ void k_glass_l2norm(float* x, int n, int iters) {
+__global__ void k_glass_nrm2(float* x, int n, int iters) {
     extern __shared__ float smem[];
     for (int rep = 0; rep < iters; rep++) {
         for (int i = threadIdx.x; i < n; i += blockDim.x) smem[i] = x[i];
         __syncthreads();
-        glass::high_speed::l2norm(n, smem, smem + n);
+        glass::high_speed::nrm2(n, smem, smem + n);
         __syncthreads();
     }
     if (threadIdx.x == 0) x[0] = smem[0];
@@ -129,12 +129,12 @@ __global__ void k_cub_reduce(float* x, float* out, int n, int iters) {
             }                                                                                 \
             if (threadIdx.x == 0) x[0] = smem[0];                                            \
         }                                                                                     \
-        __global__ void k_l2norm(float* x, int iters) {                                      \
+        __global__ void k_nrm2(float* x, int iters) {                                      \
             extern __shared__ float smem[];                                                   \
             for (int rep = 0; rep < iters; rep++) {                                           \
                 for (int i = threadIdx.x; i < N; i += blockDim.x) smem[i] = x[i];           \
                 __syncthreads();                                                              \
-                glass::high_speed::l2norm<float, N>(smem, smem + N);                         \
+                glass::high_speed::nrm2<float, N>(smem, smem + N);                         \
                 __syncthreads();                                                              \
             }                                                                                 \
             if (threadIdx.x == 0) x[0] = smem[0];                                            \
@@ -205,12 +205,12 @@ int main(int argc, char** argv) {
     clock_gettime(CLOCK_MONOTONIC, &t1);
     printf("glass::high_speed::dot       n=%3d  %.3f us/op\n", n, elapsed_us(t0, t1) / iters);
 
-    // ─── glass::high_speed::l2norm ────────────────────────────────────
+    // ─── glass::high_speed::nrm2 ────────────────────────────────────
     clock_gettime(CLOCK_MONOTONIC, &t0);
-    k_glass_l2norm<<<1, THREADS, smem_bytes>>>(dx, n, iters);
+    k_glass_nrm2<<<1, THREADS, smem_bytes>>>(dx, n, iters);
     cudaDeviceSynchronize();
     clock_gettime(CLOCK_MONOTONIC, &t1);
-    printf("glass::high_speed::l2norm    n=%3d  %.3f us/op\n", n, elapsed_us(t0, t1) / iters);
+    printf("glass::high_speed::nrm2    n=%3d  %.3f us/op\n", n, elapsed_us(t0, t1) / iters);
 
     // ─── cub::BlockReduce ────────────────────────────────────────────────────
     clock_gettime(CLOCK_MONOTONIC, &t0);
@@ -235,10 +235,10 @@ int main(int argc, char** argv) {
             printf("glass::hs::dot<CT>           n=%3d  %.3f us/op\n",                  \
                    N, elapsed_us(t0, t1) / iters);                                        \
             clock_gettime(CLOCK_MONOTONIC, &t0);                                         \
-            glass_reduce_ct_##N::k_l2norm<<<1, THREADS, smem_bytes>>>(dx, iters);       \
+            glass_reduce_ct_##N::k_nrm2<<<1, THREADS, smem_bytes>>>(dx, iters);       \
             cudaDeviceSynchronize();                                                      \
             clock_gettime(CLOCK_MONOTONIC, &t1);                                         \
-            printf("glass::hs::l2norm<CT>        n=%3d  %.3f us/op\n",                  \
+            printf("glass::hs::nrm2<CT>        n=%3d  %.3f us/op\n",                  \
                    N, elapsed_us(t0, t1) / iters);                                        \
         }
     MAYBE_GLASS_REDUCE_CT(4)
@@ -254,7 +254,7 @@ int main(int argc, char** argv) {
     // ─── glass::nvidia (CUB-backed) — only for pre-instantiated sizes ────────
     float *dSink;
     cudaMalloc(&dSink, 256 * sizeof(float));
-    constexpr size_t nv_smem = glass::nvidia::reduce_smem_size<float, THREADS>();
+    constexpr size_t nv_smem = glass::nvidia::reduce_scratch_bytes<float, THREADS>();
     #define MAYBE_NV_REDUCE_CT(N)                                                            \
         if (n == N) {                                                                         \
             constexpr size_t nv_smem_total = nv_smem + 2 * N * sizeof(float);                \
@@ -271,10 +271,10 @@ int main(int argc, char** argv) {
             printf("glass::nvidia::dot<CT>       n=%3d  %.3f us/op\n",                       \
                    N, elapsed_us(t0, t1) / iters);                                            \
             clock_gettime(CLOCK_MONOTONIC, &t0);                                              \
-            k_nv_l2norm<N><<<1, THREADS, nv_smem>>>(dx, dSink, iters);                       \
+            k_nv_nrm2<N><<<1, THREADS, nv_smem>>>(dx, dSink, iters);                       \
             cudaDeviceSynchronize();                                                          \
             clock_gettime(CLOCK_MONOTONIC, &t1);                                              \
-            printf("glass::nvidia::l2norm<CT>    n=%3d  %.3f us/op\n",                       \
+            printf("glass::nvidia::nrm2<CT>    n=%3d  %.3f us/op\n",                       \
                    N, elapsed_us(t0, t1) / iters);                                            \
         }
     MAYBE_NV_REDUCE_CT(4)

--- a/bench/run_bench.py
+++ b/bench/run_bench.py
@@ -262,7 +262,7 @@ def main():
     all_results = {}
 
     # bench_reduce (L1): powers-of-2 vector sizes up to block limit (256)
-    print("Running L1 reductions (reduce, dot, l2norm vs CUB)...")
+    print("Running L1 reductions (reduce, dot, nrm2 vs CUB)...")
     reduce_rows = []
     for n in [8, 16, 32, 64, 128, 256]:
         print(f"  n={n} ...", end=" ", flush=True)

--- a/docs/agent_debugging_guide.md
+++ b/docs/agent_debugging_guide.md
@@ -46,8 +46,11 @@ Source map you will reference constantly:
    thread assumption (§1).
 4. **Check both layouts where relevant.** Storage order is a compile-time flag, not a runtime
    crash — wrong layout = silently wrong numbers. For any L2/L3 change, validate **column-major
-   (default) AND row-major** (and `TRANSPOSE_B` for `gemm`). `test_l3.py` already has
-   `test_gemm`, `test_gemm_t`, `test_gemm_rowmajor`, `test_gemm_ex` — extend them, don't bypass.
+   (default) AND all transpose combos** (`TRANSPOSE_A`/`TRANSPOSE_B` for `gemm`; a row-major
+   operand is a transpose, so there is no per-operand row-major flag — only `ROW_MAJOR_C`).
+   `test_l3.py` already has `test_gemm_rt`, `test_gemm_ct`, `test_gemm_warp`,
+   `test_gemm_rowmajor_is_transpose` (the non-square + all-distinct-`M,N,K` net that catches the
+   silent-on-square dim mapping) — extend them, don't bypass.
 5. **Check the `beta = 0` path and uninitialized destinations** (§1c). If your op writes a
    destination via a beta-form GEMM, make sure the caller initializes C.
 6. **MathDx-optional paths must still build and skip gracefully without it** (§3). Run the suite
@@ -130,13 +133,13 @@ GLASS's beta-form GEMM computes `C[cidx] = alpha*res + beta*C[cidx]` — it **re
 "C is read; caller must initialize it"). If `C` is an **uninitialized scratch slot**, its leftover
 bit pattern can be `NaN`/`Inf`, and `0 * NaN == NaN` poisons the result even though beta is 0.
 
-- **Where this applies:** every beta-taking path — `glass::gemm` / `gemm_ex` / `gemm_impl`,
-  `gemm_tiled`, `row_strided_gemm`, and the `_1d` batched variants — when called with
+- **Where this applies:** every beta-taking path — `glass::gemm` / `gemm_impl`,
+  `gemm_tiled`, `gemm_strided`, and the `_1d` batched variants — when called with
   `beta = 0` into a destination the caller did not initialize.
 - **The fix:** the **caller must initialize `C`** before a `beta = 0` write into cold scratch
   (a tiny `for (i=rank; i<size; i+=size) C[i] = 0;` + `__syncthreads()`), OR use a GLASS
   overload that has no `beta*C` term. `gemm.cuh` provides implicit-`beta=0` overloads (the
-  `gemm`/`gemm_ex` forms documented "with implicit `beta = 0`") that write `C` directly and never
+  `gemm` forms documented "with implicit `beta = 0`") that write `C` directly and never
   read it — prefer those for write-into-fresh-scratch.
 - **The tell:** a discrepancy that is **thread-count-dependent and vanishes when isolated / run at
   1 thread** is the signature of reading cold scratch (the leftover bytes are nondeterministic
@@ -146,22 +149,25 @@ bit pattern can be `NaN`/`Inf`, and `0 * NaN == NaN` poisons the result even tho
 
 ### 1d. Storage-order / layout-flag mistakes
 
-`ROW_MAJOR_A` / `ROW_MAJOR_B` / `ROW_MAJOR_C` and `TRANSPOSE_B` are **compile-time template
+`TRANSPOSE_A` / `TRANSPOSE_B` and `ROW_MAJOR_C` are **compile-time template
 flags** (default column-major). Passing data in the wrong order does **not crash** — it silently
 indexes the wrong elements and produces wrong numbers.
 
-- Column-major (default): `A[row + col*m]`. Row-major: `A[row*cols + col]`. `gemm_impl` selects
-  per-matrix via `ROW_MAJOR_? ? A[row*n+ind] : A[ind*m+row]` etc. (see `gemm.cuh`). On the
+- Column-major (default): `A[row + col*m]`. Row-major: `A[row*cols + col]`. `gemm_impl` selects the
+  operand index via the `TRANSPOSE_A`/`TRANSPOSE_B` flags (a row-major operand == its
+  transposed column-major view), and the output index via `ROW_MAJOR_C` (see `gemm.cuh`). On the
   `glass::nvidia::` path the equivalent is the `layout` enum (`LA`, `LB`, `LC`) mapping to
   cuBLASDx `Arrangement`.
-- **Catch it by testing both layouts.** Mirror `test_l3.py`: `test_gemm` (col-major), and
-  `test_gemm_rowmajor` / `test_gemm_ex` feed `A.ravel()` (C-order) vs
+- **Catch it by testing both layouts.** Mirror `test_l3.py`: `test_gemm_rt`/`test_gemm_ct` (all transpose combos), and
+  `test_gemm_rowmajor_is_transpose` feeds a row-major operand (C-order) vs
   `np.asfortranarray(B).ravel(order='F')` (F-order) deliberately, and reshape the result with the
   matching order. If you add a layout, add the paired test; a layout bug is invisible to a
   same-layout round-trip.
-- **Known restriction:** pure-SIMT `glass::gemm` with `TRANSPOSE_B=true` requires `B` square
-  (n×n) — see `test_gemm_t`'s comment. The `glass::nvidia::` path (`LB=row_major`) has no such
-  restriction. Don't "fix" the SIMT path to accept non-square B without updating that test.
+- **No squareness restriction (since the BLAS-convention standardization):** `glass::gemm`
+  follows standard BLAS — `C` is `M×N`, contraction `K`, with independent `TRANSPOSE_A`
+  (`A` is `K×M`) and `TRANSPOSE_B` (`B` is `N×K`) flags. All four transpose combos work at any
+  rectangular `M,N,K` (the old "`TRANSPOSE_B` requires `B` square" limitation is gone). The
+  `test_gemm_rt`/`test_gemm_ct` matrices exercise all combos at non-square, all-distinct dims.
 
 ### 1e. Shared-memory sizing — dynamic scratch must match the host-side size helper
 
@@ -172,9 +178,9 @@ Functions that take `extern __shared__` scratch (or an explicit scratch pointer)
   split into `s_A = smem` and `s_B = smem + m*TILE`. The host size is computed by
   `glass_gemm_dispatch_smem<T>(m, k, block_threads, tile)` in `glass.cuh` (returns 0 when tiling
   is not warranted: `m >= 32` or `m*k > block_threads`). `test_l3.cu`'s `gemm_tiled` op hard-codes
-  the matching `(m*8 + 8*k)*sizeof(float)` with `TILE=8` — if you change the tile size on one side
+  the matching `(m*8 + 8*n)*sizeof(float)` with `TILE=8` — if you change the tile size on one side
   you MUST change it on both. A too-small allocation overruns `s_B`.
-- **`high_speed::reduce` / `dot` / `l2norm`:** need `ceil(blockDim/32)*sizeof(T)` bytes of
+- **`high_speed::reduce` / `dot` / `nrm2`:** need `ceil(blockDim/32)*sizeof(T)` bytes of
   `s_scratch` (one slot per warp). Under-sizing this overflows when `blockDim > 32*available`.
 - **`glass::nvidia::` (CUB) L1:** scratch is `sizeof(cub::BlockReduce<T,THREADS>::TempStorage)`;
   query it with `glass::nvidia::reduce_smem_size<T,THREADS>()`. For the cuBLASDx/cuSOLVERDx

--- a/docs/source/api_reference/banded.rst
+++ b/docs/source/api_reference/banded.rst
@@ -14,3 +14,12 @@ See :doc:`../user_guide/concepts/block_tridiagonal` for the layout in detail, an
 :doc:`pcg` for the conjugate-gradient solver built on top of this matvec.
 
 .. doxygenfile:: src/base/banded/bdmv.cuh
+
+Block accessors (``store_block`` / ``load_block``)
+--------------------------------------------------
+
+Strided read/write of a single ``BlockSize × BlockSize`` block into / out of a
+``[L | D | R]`` strip (with an optional scale), used to assemble and unpack the
+block-tridiagonal strips. Block- and warp-scoped forms.
+
+.. doxygenfile:: src/base/banded/block_access.cuh

--- a/docs/source/api_reference/l1.rst
+++ b/docs/source/api_reference/l1.rst
@@ -12,10 +12,14 @@ axpy / axpby
 
 .. doxygenfile:: src/base/L1/axpy.cuh
 
+.. doxygenfile:: src/base/L1/axpy_strided.cuh
+
 copy
 ----
 
 .. doxygenfile:: src/base/L1/copy.cuh
+
+.. doxygenfile:: src/base/L1/copy_strided.cuh
 
 scal
 ----
@@ -51,7 +55,9 @@ Norms
 
 .. doxygenfile:: src/base/L1/norm.cuh
 
-.. doxygenfile:: src/base/L1/l2norm.cuh
+.. doxygenfile:: src/base/L1/nrm2.cuh
+
+.. doxygenfile:: src/base/L1/nrm1_diff.cuh
 
 .. doxygenfile:: src/base/L1/infnorm.cuh
 

--- a/docs/source/api_reference/l3.rst
+++ b/docs/source/api_reference/l3.rst
@@ -6,9 +6,11 @@ indexed variants), matrix inversion (single, **partial-pivoting**
 ``invertMatrix_pivoted``, and **K-way fused** multi-matrix),
 Cholesky factorization (single and **K-way fused**), triangular solves, symmetric
 rank-k / rank-2k updates (``syrk`` / ``syr2k``), symmetric-indefinite ``LDLᵀ``
-(``ldlt``), and SPD solves (``posv`` / ``potrs``). The GEMM family takes compile-time storage-order flags
-(``ROW_MAJOR_A`` / ``ROW_MAJOR_B`` / ``ROW_MAJOR_C``) and a ``TRANSPOSE_B``
-flag; see :doc:`../user_guide/concepts/backend_dispatch` for how the dispatch
+(``ldlt``), and SPD solves (``posv`` / ``potrs``). The GEMM family follows the
+standard BLAS convention (``C`` is M×N, contraction K) with ``TRANSPOSE_A`` /
+``TRANSPOSE_B`` operand flags and a single ``ROW_MAJOR_C`` output flag — a
+row-major operand is just a transpose, so per-operand row-major flags were
+removed; see :doc:`../user_guide/concepts/backend_dispatch` for how the dispatch
 GEMM chooses a path. Single-warp (``glass::warp::``) variants of ``gemm``,
 ``cholDecomp_InPlace``, and ``trsm`` render inline beside their block-scoped
 sibling; see :doc:`warp`.

--- a/docs/source/api_reference/nvidia.rst
+++ b/docs/source/api_reference/nvidia.rst
@@ -8,7 +8,7 @@ see :doc:`../user_guide/concepts/backend_dispatch`. The L2/L3/LAPACK paths
 require NVIDIA MathDx (``MATHDX_ROOT``) — see
 :doc:`../user_guide/getting_started/installation`.
 
-Each call has a companion **host-side** query helper (``*_smem_size``,
+Each call has a companion **host-side** query helper (``*_scratch_bytes``,
 ``*_threads``, ``*_block_threads_valid``) used to size the launch.
 
 L1 (CUB-backed reductions)

--- a/docs/source/api_reference/pcg.rst
+++ b/docs/source/api_reference/pcg.rst
@@ -10,7 +10,7 @@ block solves one system (launch one block per independent solve); it uses only
 ``S`` and ``Pinv`` use the ``[L|D|R]`` block-tridiagonal layout of
 :doc:`banded`, and all vectors use the same padded
 ``(knot_points + 2)·state_size`` layout. Size the dynamic shared memory with
-``glass::pcg_smem_size<T, state_size, knot_points>(threads)``. The launch
+``glass::pcg_scratch_bytes<T, state_size, knot_points>(threads)``. The launch
 thread count must be a multiple of 32 (the inner dot uses a warp reduction).
 
 See :doc:`../user_guide/concepts/block_tridiagonal` for the layout and a worked

--- a/docs/source/api_reference/warp.rst
+++ b/docs/source/api_reference/warp.rst
@@ -29,7 +29,7 @@ rendered signatures appear on the :doc:`l1`, :doc:`l2`, and :doc:`l3` pages.
   homogeneous-transform multiplies).
 * ``glass::warp::cholDecomp_InPlace`` — small SPD Cholesky factor.
 * ``glass::warp::trsv`` — flagged triangular solve (``LOWER`` / ``UNIT`` /
-  ``TRANS``), subsuming the lower ``glass::warp::trsm`` /
+  ``TRANSPOSE``), subsuming the lower ``glass::warp::trsm`` /
   ``glass::warp::trsm_transpose``.
 * ``glass::warp::posv`` — the **composed warp-per-problem SPD solve**
   (Cholesky → forward/back ``trsv``), proving the L1/L2/L3 glue composes into a

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ templates_path = ["_templates"]
 exclude_patterns = []
 
 # The header-only sub-namespaces (low_memory / high_speed / simple) are reopened
-# across several headers (reduce/norm/l2norm/asum/dot), so listing those files
+# across several headers (reduce/norm/nrm2/asum/dot), so listing those files
 # separately in the API reference makes Breathe re-emit the same namespace
 # anchor per file. Sphinx flags that as a duplicate explicit target — cosmetic,
 # not a content error — so we silence the docutils target-name category here.

--- a/docs/source/user_guide/concepts/backend_dispatch.rst
+++ b/docs/source/user_guide/concepts/backend_dispatch.rst
@@ -60,9 +60,9 @@ that reflects its arithmetic intensity:
      - ``max(M,N) >= 32``
    * - ``cublasdx_wins_batched<M, N, K, BATCH, SM>``
      - ``BATCH >= 8 AND max(M,N,K) >= 8``
-   * - ``cublasdx_wins_row_strided_gemm<...>``
+   * - ``cublasdx_wins_gemm_strided<...>``
      - delegates to ``cublasdx_wins<>``
-   * - ``cublasdx_wins_row_strided_gemv<...>``
+   * - ``cublasdx_wins_gemv_strided<...>``
      - delegates to ``cublasdx_wins_gemv<>``
 
 Restricted to ``float``: the heuristic returns SIMT for non-float types.

--- a/docs/source/user_guide/concepts/batched_1d.rst
+++ b/docs/source/user_guide/concepts/batched_1d.rst
@@ -68,7 +68,7 @@ template parameters (defaults: ``N*K`` and ``M*K`` for tight packing).
 
 .. note::
 
-   A related primitive, ``glass::indexed_batched_gemm``
+   A related primitive, ``glass::gemm_batched_indexed``
    (``src/base/L3/gemm_batched_indexed.cuh``), gathers per-batch operands
    through an index array at irregular offsets. It lives in ``glass::`` (not
    ``glass::nvidia::``) and uses a *different* model — a block stride over the

--- a/docs/source/user_guide/concepts/batching.rst
+++ b/docs/source/user_guide/concepts/batching.rst
@@ -1,0 +1,64 @@
+Batching models
+===============
+
+GLASS is single-block by design: you launch **one block per independent
+problem**, and the block's threads cooperate over data already in shared/global
+memory. But many callers have *many* small problems to run at once, and GLASS
+offers several distinct ways to pack them. They differ in how problems map onto
+threads/warps/blocks and in what stride/offset metadata they take — pick by how
+your problems are laid out in memory and how many threads you can give each one.
+
+.. list-table:: The batching models
+   :header-rows: 1
+   :widths: 22 30 48
+
+   * - Model
+     - Functions
+     - When to use
+   * - **One block per problem** (the base model)
+     - every plain op (``gemm`` / ``gemv`` / ``syrk`` / ``posv`` / …)
+     - The default. One ``<<<num_problems, threads>>>`` launch; each block owns
+       one problem. Use when each problem is big enough to keep a block busy.
+   * - **Block-per-problem, strided sub-blocks**
+     - ``gemm_strided`` / ``gemv_strided`` (and ``axpy_strided`` /
+       ``copy_strided`` for L1)
+     - One block still owns one problem, but the operands are *sub-blocks* of a
+       larger column-major matrix addressed with explicit leading dimensions
+       (row strides). Use to operate on a tile in place without copying it out.
+   * - **Flattened-batch, block-stride indexed**
+     - ``gemm_batched_indexed``
+     - A flat batch of GEMMs whose operands live at arbitrary offsets given by an
+       index array; blocks stride over the batch. Use for gather-style batches
+       where problem *i*'s pointers are not a fixed stride apart.
+   * - **K-way fused, interleaved in one block**
+     - ``invertMatrix`` / ``cholDecomp_InPlace`` (K-way overloads; ``inv2`` /
+       ``inv3`` wrappers)
+     - A *single* block factors/inverts K independent matrices at once by
+       interleaving their sweeps over one shared row loop. Use when K is small
+       and each matrix is too small to fill a block alone — fills the block by
+       fusing across problems instead of across rows.
+   * - **TC-group SIMT-1D batched**
+     - the batched-1D GEMM APIs (see :doc:`batched_1d`)
+     - Designed for kernels with a single 1D thread block that must run a batch
+       of tiny GEMMs; threads are partitioned into per-problem groups. Use inside
+       an existing 1D-block kernel that can't relaunch.
+   * - **Warp-per-problem**
+     - ``glass::warp::`` ops (``dot`` / ``gemv`` / ``trsv`` / ``cholDecomp_InPlace``
+       / ``posv`` / …)
+     - One 32-lane warp owns one problem; pack many warps into a block to run
+       many problems concurrently (``threadIdx.y`` selects the warp). Use for the
+       smallest problems (N ≈ 7–32) where a whole block per problem would waste
+       lanes. See :doc:`contraction_parallel`.
+   * - **Segmented**
+     - ``gemv_segmented``
+     - One matvec whose output rows are partitioned into contiguous segments with
+       per-segment row counts. Use for ragged/block-structured matvecs.
+
+Naming convention
+-----------------
+
+All batching variants follow ``operation_qualifier`` — the operation first, the
+batching qualifier as a suffix (``gemm_strided``, ``gemv_segmented``,
+``gemm_batched_indexed``), and the file name matches the function name. The
+qualifier names *how the problems are packed*, never the scope (scope is the
+namespace — ``glass::`` vs ``glass::warp::``; see :doc:`namespaces`).

--- a/docs/source/user_guide/concepts/block_tridiagonal.rst
+++ b/docs/source/user_guide/concepts/block_tridiagonal.rst
@@ -74,7 +74,7 @@ is tested on the preconditioned residual ``rho = rᵀz``:
 Sizing and launch:
 
 * Dynamic shared memory =
-  ``glass::pcg_smem_size<T, state_size, knot_points>(threads)`` elements (five
+  ``glass::pcg_scratch_bytes<T, state_size, knot_points>(threads)`` elements (five
   padded work vectors + the warp-dot scratch); five scalars live in static
   ``__shared__``.
 * The block thread count **must be a multiple of 32** — the inner dot product
@@ -85,7 +85,7 @@ Sizing and launch:
 .. code-block:: cpp
 
    constexpr int SS = 6, KP = 32;
-   size_t smem = glass::pcg_smem_size<float, SS, KP>(threads) * sizeof(float);
+   size_t smem = glass::pcg_scratch_bytes<float, SS, KP>(threads) * sizeof(float);
    pcg_kernel<<<num_problems, threads, smem>>>(d_x, d_S, d_Pinv, d_b, ...);
    // inside the kernel:
    extern __shared__ float s_mem[];

--- a/docs/source/user_guide/concepts/index.rst
+++ b/docs/source/user_guide/concepts/index.rst
@@ -16,5 +16,6 @@ single 1D thread block, and the block-tridiagonal layout used by the
    namespaces
    trailing_sync
    tuning
+   batching
    batched_1d
    block_tridiagonal

--- a/docs/source/user_guide/concepts/namespaces.rst
+++ b/docs/source/user_guide/concepts/namespaces.rst
@@ -39,7 +39,7 @@ When you add an operation, decide what kind of variation it is:
 - **A different algorithm or decomposition → its own function name (a suffix).**
   The contraction-parallel gemm is :cpp:func:`glass::gemm_reduced`, not a
   ``glass::reduced::`` namespace — matching the existing ``gemm_tiled`` /
-  ``gemm_dispatch`` / ``gemm_ex`` precedent. Same scope, different name.
+  ``gemm_dispatch`` precedent. Same scope, different name.
 - **Optional, additive behavior → a compile-time** ``bool`` **flag that compiles
   out.** ``cholDecomp_InPlace<T, N, CHECK>``, ``ldlt<T, N, CHECK>``,
   ``posv<T, N, NRHS, REGULARIZE, CHECK>`` all default the flag to ``false`` and

--- a/docs/source/user_guide/concepts/trailing_sync.rst
+++ b/docs/source/user_guide/concepts/trailing_sync.rst
@@ -1,10 +1,13 @@
 Trailing Synchronization (``TRAILING_SYNC``)
 ============================================
 
-GLASS L3 functions (``gemm``, ``gemv``, ``row_strided_*``, ``gemm_batched_1d``,
-``gemm_strided_batched_1d``, ...) take a final boolean template parameter
-**``TRAILING_SYNC`` that defaults to ``true``**. It controls whether the
-function emits a ``__syncthreads()`` before returning.
+**Uniformity rule (project-wide design decision):** *every* public GLASS op takes
+a final boolean template parameter **``TRAILING_SYNC`` that defaults to ``true``**,
+on both the ``glass::`` and ``glass::cgrps::`` surfaces. It controls whether the
+function ends on a barrier (``__syncthreads()`` for the block surface,
+``cooperative_groups::sync`` for the cgrps surface) so the result is valid for ALL
+threads. One consistent mental model: a GLASS op acts like a standalone kernel
+unless you opt out.
 
 Default vs. opt-out
 -------------------
@@ -36,31 +39,26 @@ with a SIMT ``parallel_loop`` and want to collapse the two syncs into one.
 Where it applies
 ----------------
 
-The full surface as of 2026-05:
+As of the 2026-06-25 uniformity wave, ``TRAILING_SYNC`` is on **every** public op
+that has a *separable* trailing barrier — all of L1 (``reduce``/``dot``/elementwise/
+``axpy``/``copy``/``scal``/``swap``/``clip``/``set_const``/``ident``/``transpose``/
+``infnorm``/``asum``/``nrm2`` + the ``high_speed::``/``low_memory::`` reductions),
+L2 (``gemv``/``ger`` + ``gemv_strided``/``gemv_segmented``/``gemv_reduced``), and L3
+(``gemm`` + ``gemm_strided``/``gemm_batched_indexed``/``gemm_reduced``/``syrk``/
+``syr2k``/``syrk_reduced``/tensor/congruence) — plus the cuBLASDx-backed
+``glass::nvidia::`` paths.
 
-* **L1** (``l1.cuh``): ``reduce``, ``dot``, ``l2norm``. The *leading* sync that
-  protects CUB ``BlockReduce`` ``TempStorage`` from prior writes is **not**
-  gated — it is required for correctness. Only the *trailing* barrier (after the
-  thread-0 write of the reduction result) is.
-* **L2** (``l2.cuh``): ``gemv``, ``row_strided_gemv`` — primary templates and
-  every ``_GLASS_GEMV_NO_BD`` / ``_GLASS_GEMV_BD`` macro-emitted
-  specialization. The cuBLASDx-backed specializations emit **both**
-  ``TRAILING_SYNC=true`` and ``=false`` variants from a single
-  ``DEFINE_NVIDIA_GEMV*`` invocation.
-* **L3** (``l3.cuh``): ``gemm``, ``gemm_batched``, ``row_strided_gemm`` — same
-  dual-specialization pattern via ``_GLASS_GEMM_NO_BD`` / ``_GLASS_GEMM_BD`` /
-  ``_GLASS_GEMM_BATCHED_BD``.
-* **L3 SIMT** (``l3_simt.cuh``): ``gemm_batched_1d``,
-  ``gemm_strided_batched_1d``.
-* **LAPACK** (``lapack.cuh``): ``posv``, ``cholDecomp_InPlace``, ``gesv_no_pivot``,
-  ``gels``, ``trsm`` — primary templates and macro-emitted specializations.
+Interior barriers (between algorithm phases) are **required for correctness and are
+never gated** — only the final trailing barrier is.
 
-.. note::
+Documented exceptions (the flag is intentionally absent):
 
-   Interior ``__syncthreads()`` inside ``gemm`` / ``gemm_batched`` / LAPACK
-   factor-solve flows (between phases) is **required for correctness and is not
-   gated** on ``TRAILING_SYNC`` — only the final trailing barrier before return
-   is.
+* **Algorithm-terminated-by-a-barrier ops** — ``cholDecomp_InPlace`` /
+  ``invertMatrix`` / ``trsm`` / ``trsv`` / ``posv`` / ``ldlt``. Their final step is
+  *itself* a barrier inside the factorization loop, so there is no separable
+  trailing barrier to gate; they always end synced.
+* **``glass::warp::`` lockstep ops** — a single warp runs in lockstep, so a trailing
+  "sync" is a no-op (``__syncwarp`` at most); the flag would be vacuous.
 
 Testing
 -------

--- a/docs/source/user_guide/concepts/tuning.rst
+++ b/docs/source/user_guide/concepts/tuning.rst
@@ -13,7 +13,7 @@ compile time (see :doc:`backend_dispatch`). The decision lives in
 3. A static per-API heuristic for unmeasured shapes.
 
 Five per-API decision templates live in ``_glass_tuning`` (gemm, gemv,
-gemm_batched_1d, row_strided_gemm, row_strided_gemv); each can be specialized
+gemm_batched_1d, gemm_strided, gemv_strided); each can be specialized
 independently for a given (shape, SM).
 
 Picking a backend: measured defaults
@@ -115,8 +115,8 @@ Quick start
 
    cd GLASS
    python3 bench/autotune.py
-   # → measures all 5 auto-dispatching primaries (gemm, gemv, row_strided_gemv,
-   #   row_strided_gemm, gemm_batched_1d) across each one's default shape grid
+   # → measures all 5 auto-dispatching primaries (gemm, gemv, gemv_strided,
+   #   gemm_strided, gemm_batched_1d) across each one's default shape grid
    # → writes bench/tuning/<hostname>.cuh with the per-host specializations
 
 The script:
@@ -137,7 +137,7 @@ Restricting the run:
 .. code-block:: bash
 
    python3 bench/autotune.py --apis gemm,gemv
-   python3 bench/autotune.py --apis row_strided_gemv --shapes "6,6,8;14,14,16"
+   python3 bench/autotune.py --apis gemv_strided --shapes "6,6,8;14,14,16"
    python3 bench/autotune.py --apis gemv --shapes '6,6;14,14;32,32' --iters 20000 --dry-run
 
 ``--shapes`` takes a ``;``-separated tuple list; the arity must match the chosen

--- a/docs/source/user_guide/getting_started/installation.rst
+++ b/docs/source/user_guide/getting_started/installation.rst
@@ -71,7 +71,7 @@ manual download from the NVIDIA Developer portal.
      - Used by
      - Header-only?
    * - CUB
-     - ``glass::nvidia::reduce`` / ``dot`` / ``l2norm``
+     - ``glass::nvidia::reduce`` / ``dot`` / ``nrm2``
      - Yes (bundled with CUDA)
    * - cuBLASDx
      - ``gemv``, ``gemm``, batched GEMM

--- a/docs/source/user_guide/tutorials/benchmarks.rst
+++ b/docs/source/user_guide/tutorials/benchmarks.rst
@@ -15,7 +15,7 @@ What's in ``bench/``
    * - File
      - Comparison
    * - ``bench_reduce.cu``
-     - ``glass::*::reduce/dot/l2norm`` (plain, low_memory, high_speed,
+     - ``glass::*::reduce/dot/nrm2`` (plain, low_memory, high_speed,
        compile-time) vs CUB ``BlockReduce`` vs ``glass::nvidia::reduce``
    * - ``bench_gemv.cu``
      - ``glass::gemv`` (runtime + compile-time) vs raw cuBLASDx vs

--- a/docs/source/user_guide/tutorials/using_nvidia_backend.rst
+++ b/docs/source/user_guide/tutorials/using_nvidia_backend.rst
@@ -61,7 +61,7 @@ the **exact** thread count — a mismatch deadlocks.
 
    #include "glass-nvidia.cuh"
 
-   constexpr auto smem    = glass::nvidia::gemm_smem_size<float, 6, 6, 6>();
+   constexpr auto smem    = glass::nvidia::gemm_scratch_bytes<float, 6, 6, 6>();
    constexpr auto threads = glass::nvidia::gemm_threads<float, 6, 6, 6>();
 
    __global__ void k(float* A, float* B, float* C) {
@@ -90,7 +90,7 @@ idle inside the GEMM:
        glass::nvidia::gemm<float, 6, 6, 6, 352>(1.f, A, B, 0.f, C, smem_buf);
    }
 
-   constexpr auto smem = glass::nvidia::gemm_smem_size<float, 6, 6, 6, 352>();
+   constexpr auto smem = glass::nvidia::gemm_scratch_bytes<float, 6, 6, 6, 352>();
    k<<<1, 352, smem>>>(dA, dB, dC);
 
 Query the smallest valid ``TC`` for a ``(T, M, N, K, SM)`` tuple:
@@ -166,7 +166,7 @@ Linear solvers (cuSOLVERDx)
        glass::nvidia::posv<float, 7, 1, 256>(A, b, smem_buf);
    }
 
-   constexpr auto smem = glass::nvidia::posv_smem_size<float, 7, 1, 256>();
+   constexpr auto smem = glass::nvidia::posv_scratch_bytes<float, 7, 1, 256>();
    k<<<1, 256, smem>>>(dA, db);
 
 Available cuSOLVERDx wrappers: ``cholDecomp_InPlace``, ``trsm``, ``posv``, ``potrs``,

--- a/examples/02_gemm.cu
+++ b/examples/02_gemm.cu
@@ -3,8 +3,9 @@
 // Build (from this examples/ dir):
 //   nvcc -std=c++17 -arch=sm_75 -I.. 02_gemm.cu -o gemm && ./gemm
 //
-// Computes C = alpha*A*B + beta*C, column-major. A is m x n, B is n x k,
-// C is m x k. Uses both the runtime-size and compile-time-size overloads.
+// Computes C = alpha*op(A)*op(B) + beta*C, column-major (standard BLAS): C is
+// m x n, contraction k; A is m x k, B is k x n. Uses the runtime-size and
+// compile-time-size overloads (TRANSPOSE_A/TRANSPOSE_B/ROW_MAJOR_C flags default off).
 
 #include "glass.cuh"
 #include <cstdio>

--- a/examples/05_gemm_dispatch.cu
+++ b/examples/05_gemm_dispatch.cu
@@ -4,7 +4,7 @@
 //   nvcc -std=c++17 -arch=sm_75 -I.. 05_gemm_dispatch.cu -o dispatch && ./dispatch
 //
 // glass::gemm_dispatch auto-selects the shared-memory-tiled GEMM when scratch
-// pointers are supplied (and m*k <= blockDim), else the plain path. The host
+// pointers are supplied (and m*n <= blockDim), else the plain path. The host
 // helper glass_gemm_dispatch_smem() computes the bytes to launch with; it
 // returns 0 when tiling is not warranted (then pass nullptr scratch).
 
@@ -40,7 +40,7 @@ int main() {
     cudaMemcpy(dB, hB, sizeof(hB), cudaMemcpyHostToDevice);
 
     // Host: how many shared bytes does the dispatched path need?
-    size_t smem = glass_gemm_dispatch_smem<float>(m, k, threads);
+    size_t smem = glass_gemm_dispatch_smem<float>(m, n, threads);
     printf("dispatch smem = %zu bytes (%s)\n", smem,
            smem ? "tiled path" : "plain path");
 

--- a/examples/06_nvidia_gemm.cu
+++ b/examples/06_nvidia_gemm.cu
@@ -19,7 +19,7 @@
 //     it selects the cuBLASDx-tuned config and the pre-instantiated GEMM table.
 //   * 16x16x16 is a pre-instantiated cuBLASDx shape (see glass-nvidia.cuh); the
 //     default form launches with EXACTLY gemm_threads<>() threads and
-//     gemm_smem_size<>() bytes of shared memory — a mismatch deadlocks.
+//     gemm_scratch_bytes<>() bytes of shared memory — a mismatch deadlocks.
 
 #include "glass-nvidia.cuh"
 #include <cstdio>
@@ -28,7 +28,7 @@
 constexpr int M = 16, N = 16, K = 16;
 
 // Host-queryable, constexpr: the thread count + shared bytes cuBLASDx wants.
-constexpr auto SMEM    = glass::nvidia::gemm_smem_size<float, M, N, K>();
+constexpr auto SMEM    = glass::nvidia::gemm_scratch_bytes<float, M, N, K>();
 constexpr auto THREADS = glass::nvidia::gemm_threads<float, M, N, K>();
 
 __global__ void nvidia_gemm(float *A, float *B, float *C) {

--- a/examples/08_pcg_solve.cu
+++ b/examples/08_pcg_solve.cu
@@ -61,7 +61,7 @@ int main() {
     cudaMemcpy(dx, x, sizeof(x), cudaMemcpyHostToDevice);
 
     const int threads = 32;            // must be a multiple of 32 (warp-dot)
-    size_t smem = glass::pcg_smem_size<float, SS, KP>(threads) * sizeof(float);
+    size_t smem = glass::pcg_scratch_bytes<float, SS, KP>(threads);
     pcg_kernel<<<1, threads, smem>>>(dx, dS, dPinv, db, 100, 1e-6f, 1e-12f, diters);
     cudaDeviceSynchronize();
 

--- a/examples/10_gemm_basics.cu
+++ b/examples/10_gemm_basics.cu
@@ -1,0 +1,76 @@
+// 10_gemm_basics.cu — the standard-BLAS GEMM convention and its transpose flags.
+//
+// Build (from this examples/ dir):
+//   nvcc -std=c++17 -arch=sm_75 -I.. 10_gemm_basics.cu -o gemm_basics && ./gemm_basics
+//
+// GLASS gemm follows the standard BLAS / cuBLAS / NumPy / Eigen convention:
+//
+//   C = alpha * op(A) * op(B) + beta * C    (column-major)
+//   C is M×N,  contraction K.
+//   op(A) is M×K:  TRANSPOSE_A=false ⇒ A is M×K ;  true ⇒ A is K×M (op(A)=Aᵀ).
+//   op(B) is K×N:  TRANSPOSE_B=false ⇒ B is K×N ;  true ⇒ B is N×K (op(B)=Bᵀ).
+//
+//   NumPy:  C = alpha * opA(A) @ opB(B) + beta * C
+//   Eigen:  C.noalias() = alpha * (opA(A) * opB(B)) + beta * C;   // col-major
+//
+// We deliberately use a NON-SQUARE shape (M=2, N=3, K=4): the dimension order
+// matters, and a square example would hide a wrong mapping.
+
+#include "glass.cuh"
+#include <cstdio>
+#include <cmath>
+#include <cuda_runtime.h>
+
+static constexpr int M = 2, N = 3, K = 4;
+
+template <bool TA, bool TB>
+__global__ void run(const float* A, const float* B, float* C) {
+    // beta = 0 overload: C is overwritten (never read).
+    glass::gemm<float, M, N, K, TA, TB>(1.0f, const_cast<float*>(A), const_cast<float*>(B), C);
+}
+
+// Host reference: logical op(A) is M×K, op(B) is K×N, C is M×N (all col-major).
+static void ref(const float* opA, const float* opB, float* C) {
+    for (int m = 0; m < M; m++)
+        for (int n = 0; n < N; n++) {
+            float s = 0;
+            for (int k = 0; k < K; k++) s += opA[m + k*M] * opB[k + n*K];
+            C[m + n*M] = s;
+        }
+}
+
+int main() {
+    // opA (M×K) and opB (K×N) are the LOGICAL operands.
+    float opA[M*K], opB[K*N];
+    for (int i = 0; i < M*K; i++) opA[i] = 0.1f * (i + 1);
+    for (int i = 0; i < K*N; i++) opB[i] = 0.2f * (i + 1) - 0.5f;
+
+    // Physical storage for each transpose flag: a transposed operand is stored
+    // as op(_)ᵀ in column-major (i.e. A is K×M when TRANSPOSE_A).
+    float A_n[M*K], A_t[K*M], B_n[K*N], B_t[N*K];
+    for (int m = 0; m < M; m++) for (int k = 0; k < K; k++) { A_n[m + k*M] = opA[m + k*M]; A_t[k + m*K] = opA[m + k*M]; }
+    for (int k = 0; k < K; k++) for (int n = 0; n < N; n++) { B_n[k + n*K] = opB[k + n*K]; B_t[n + k*N] = opB[k + n*K]; }
+
+    float ref_C[M*N]; ref(opA, opB, ref_C);
+
+    float *dA, *dB, *dC; cudaMalloc(&dA, sizeof(float)*K*M); cudaMalloc(&dB, sizeof(float)*N*K); cudaMalloc(&dC, sizeof(float)*M*N);
+    const char* names[4] = {"C = A * B     ", "C = AT * B    ", "C = A * BT    ", "C = AT * BT   "};
+    int bad = 0;
+    for (int combo = 0; combo < 4; combo++) {
+        bool ta = combo & 2, tb = combo & 1;
+        cudaMemcpy(dA, ta ? A_t : A_n, sizeof(float)*(ta ? K*M : M*K), cudaMemcpyHostToDevice);
+        cudaMemcpy(dB, tb ? B_t : B_n, sizeof(float)*(tb ? N*K : K*N), cudaMemcpyHostToDevice);
+        if      (!ta && !tb) run<false,false><<<1,64>>>(dA, dB, dC);
+        else if ( ta && !tb) run<true ,false><<<1,64>>>(dA, dB, dC);
+        else if (!ta &&  tb) run<false,true ><<<1,64>>>(dA, dB, dC);
+        else                 run<true ,true ><<<1,64>>>(dA, dB, dC);
+        cudaDeviceSynchronize();
+        float C[M*N]; cudaMemcpy(C, dC, sizeof(C), cudaMemcpyDeviceToHost);
+        float md = 0; for (int i = 0; i < M*N; i++) md = fmaxf(md, fabsf(C[i] - ref_C[i]));
+        printf("  %s  max_err=%.2e  %s\n", names[combo], md, md < 1e-5 ? "ok" : "FAIL");
+        bad += (md >= 1e-5);
+    }
+    cudaFree(dA); cudaFree(dB); cudaFree(dC);
+    printf(bad ? "FAIL\n" : "PASS\n");
+    return bad;
+}

--- a/examples/11_rowmajor_is_transpose.cu
+++ b/examples/11_rowmajor_is_transpose.cu
@@ -1,0 +1,60 @@
+// 11_rowmajor_is_transpose.cu — "row-major is just a transpose".
+//
+// Build (from this examples/ dir):
+//   nvcc -std=c++17 -arch=sm_75 -I.. 11_rowmajor_is_transpose.cu -o rmt && ./rmt
+//
+// GLASS gemm is column-major and has NO per-operand row-major flag (it was
+// pruned). You don't need one: a row-major M×K matrix occupies the SAME bytes as
+// a column-major K×M matrix, so to multiply by a row-major A you just pass it
+// with TRANSPOSE_A=true. This example shows the two paths give BIT-IDENTICAL
+// output, which is exactly why the separate ROW_MAJOR_A path was removed.
+//
+//   row-major A (M×K)  ==  column-major Aᵀ (K×M)   →   read with TRANSPOSE_A=true
+//
+// (The same holds for B via TRANSPOSE_B, and for a row-major C via ROW_MAJOR_C.)
+
+#include "glass.cuh"
+#include <cstdio>
+#include <cstring>
+#include <cuda_runtime.h>
+
+static constexpr int M = 3, N = 2, K = 4;
+
+__global__ void nn(const float* A, const float* B, float* C) {     // A col-major M×K
+    glass::gemm<float, M, N, K, /*TA=*/false, /*TB=*/false>(1.f, const_cast<float*>(A), const_cast<float*>(B), C);
+}
+__global__ void ta(const float* A, const float* B, float* C) {     // A row-major M×K == col-major K×M
+    glass::gemm<float, M, N, K, /*TA=*/true,  /*TB=*/false>(1.f, const_cast<float*>(A), const_cast<float*>(B), C);
+}
+
+int main() {
+    // The SAME logical A (M×K), laid out two ways.
+    float A_logical[M][K];
+    for (int m = 0; m < M; m++) for (int k = 0; k < K; k++) A_logical[m][k] = 0.3f*m - 0.1f*k + 1.f;
+    float A_colmajor[M*K];   // A[m + k*M]
+    float A_rowmajor[M*K];   // A[m*K + k]  ==  bytes of the K×M col-major transpose
+    for (int m = 0; m < M; m++) for (int k = 0; k < K; k++) {
+        A_colmajor[m + k*M] = A_logical[m][k];
+        A_rowmajor[m*K + k] = A_logical[m][k];
+    }
+    float B[K*N]; for (int i = 0; i < K*N; i++) B[i] = 0.2f*i - 0.4f;   // B col-major K×N
+
+    float *dA, *dB, *dC; cudaMalloc(&dA, sizeof(A_colmajor)); cudaMalloc(&dB, sizeof(B)); cudaMalloc(&dC, sizeof(float)*M*N);
+    cudaMemcpy(dB, B, sizeof(B), cudaMemcpyHostToDevice);
+
+    float C_nn[M*N], C_ta[M*N];
+    cudaMemcpy(dA, A_colmajor, sizeof(A_colmajor), cudaMemcpyHostToDevice);
+    nn<<<1,64>>>(dA, dB, dC); cudaDeviceSynchronize();
+    cudaMemcpy(C_nn, dC, sizeof(C_nn), cudaMemcpyDeviceToHost);
+
+    cudaMemcpy(dA, A_rowmajor, sizeof(A_rowmajor), cudaMemcpyHostToDevice);
+    ta<<<1,64>>>(dA, dB, dC); cudaDeviceSynchronize();
+    cudaMemcpy(C_ta, dC, sizeof(C_ta), cudaMemcpyDeviceToHost);
+
+    bool identical = (memcmp(C_nn, C_ta, sizeof(C_nn)) == 0);
+    printf("  col-major NN  vs  row-major-via-TRANSPOSE_A : %s\n",
+           identical ? "BIT-IDENTICAL" : "DIFFER");
+    cudaFree(dA); cudaFree(dB); cudaFree(dC);
+    printf(identical ? "PASS\n" : "FAIL\n");
+    return identical ? 0 : 1;
+}

--- a/examples/12_nrm2.cu
+++ b/examples/12_nrm2.cu
@@ -1,0 +1,52 @@
+// 12_nrm2.cu — Euclidean norm (BLAS nrm2), the standardized name for the old
+// `l2norm`.
+//
+// Build (from this examples/ dir):
+//   nvcc -std=c++17 -arch=sm_75 -I.. 12_nrm2.cu -o nrm2 && ./nrm2
+//
+//   nrm2(x) = sqrt(Σ xᵢ²)
+//   NumPy:  np.linalg.norm(x)
+//   Eigen:  x.norm()
+//
+// Block forms live in glass::high_speed:: / glass::low_memory:: (they write the
+// result to an output slot); glass::warp::nrm2 returns the value in-register.
+
+#include "glass.cuh"
+#include <cstdio>
+#include <cmath>
+#include <cuda_runtime.h>
+
+static constexpr int Ncompile = 8;
+
+__global__ void k_block(float* x, float* scratch) {
+    // high_speed::nrm2<T, N> — compile-time length, warp-reduced, DESTRUCTIVE:
+    // the result lands in x[0] (the block forms overwrite their input).
+    glass::high_speed::nrm2<float, Ncompile>(x, scratch);
+}
+__global__ void k_warp(uint32_t n, const float* x, float* out) {
+    float r = glass::warp::nrm2<float>(n, x);   // value-returning, non-destructive
+    if ((threadIdx.x & 31) == 0) *out = r;
+}
+
+int main() {
+    float x[Ncompile]; for (int i = 0; i < Ncompile; i++) x[i] = 0.5f*i - 1.3f;
+    double s = 0; for (int i = 0; i < Ncompile; i++) s += (double)x[i]*x[i];
+    float expected = (float)sqrt(s);
+
+    float *dx, *dout, *dscr; cudaMalloc(&dx, sizeof(x)); cudaMalloc(&dout, sizeof(float)); cudaMalloc(&dscr, sizeof(float)*8);
+
+    float block_r, warp_r;
+    cudaMemcpy(dx, x, sizeof(x), cudaMemcpyHostToDevice);
+    k_block<<<1, 64>>>(dx, dscr); cudaDeviceSynchronize();
+    cudaMemcpy(&block_r, dx, sizeof(float), cudaMemcpyDeviceToHost);   // result in x[0]
+    cudaMemcpy(dx, x, sizeof(x), cudaMemcpyHostToDevice);              // restore (block was destructive)
+    k_warp<<<1, 32>>>(Ncompile, dx, dout); cudaDeviceSynchronize();
+    cudaMemcpy(&warp_r, dout, sizeof(float), cudaMemcpyDeviceToHost);
+
+    bool ok = fabsf(block_r - expected) < 1e-5 && fabsf(warp_r - expected) < 1e-5;
+    printf("  nrm2 block=%.6f  warp=%.6f  expected=%.6f (np.linalg.norm / Eigen x.norm())\n",
+           block_r, warp_r, expected);
+    cudaFree(dx); cudaFree(dout); cudaFree(dscr);
+    printf(ok ? "PASS\n" : "FAIL\n");
+    return ok ? 0 : 1;
+}

--- a/examples/13_gemm_strided.cu
+++ b/examples/13_gemm_strided.cu
@@ -1,0 +1,54 @@
+// 13_gemm_strided.cu — GEMM on column-major sub-blocks with explicit
+// leading dimensions (the "strided" GEMM).
+//
+// Build (from this examples/ dir):
+//   nvcc -std=c++17 -arch=sm_75 -I.. 13_gemm_strided.cu -o rsgemm && ./rsgemm
+//
+// Same standard convention as glass::gemm (C is M×N, contraction K), but A and B
+// live inside larger buffers with custom column strides (leading dimensions):
+//
+//   A is M×K, leading dim A_RS ≥ M :  A[m][k] = A_buf[m + k*A_RS]
+//   B is K×N, leading dim B_RS ≥ K :  B[k][n] = B_buf[k + n*B_RS]
+//   C is M×N, standard column-major (LDC = M).
+//
+//   alpha/beta are at the FRONT, matching every other GLASS op:
+//     glass::gemm_strided<T, M, N, K, A_RS, B_RS>(alpha, A, B, beta, C);
+//   NumPy:  C = alpha * A @ B + beta * C    (on the strided sub-views)
+
+#include "glass.cuh"
+#include <cstdio>
+#include <cmath>
+#include <cuda_runtime.h>
+
+static constexpr int M = 5, N = 7, K = 3, A_RS = 8, B_RS = 6;  // A_RS>M, B_RS>K
+
+__global__ void run(const float* A, const float* B, float beta, float* C) {
+    glass::gemm_strided<float, M, N, K, A_RS, B_RS>(1.5f, const_cast<float*>(A), const_cast<float*>(B), beta, C);
+}
+
+int main() {
+    float A[A_RS*K], B[B_RS*N], C[M*N];
+    for (int i = 0; i < A_RS*K; i++) A[i] = 0.1f*i - 0.3f;
+    for (int i = 0; i < B_RS*N; i++) B[i] = 0.2f*i - 0.5f;
+    for (int i = 0; i < M*N;   i++) C[i] = 1.0f;
+    const float alpha = 1.5f, beta = 0.25f;
+
+    float ref[M*N];
+    for (int m = 0; m < M; m++) for (int n = 0; n < N; n++) {
+        float s = 0; for (int k = 0; k < K; k++) s += A[m + k*A_RS] * B[k + n*B_RS];
+        ref[m + n*M] = alpha*s + beta*C[m + n*M];
+    }
+
+    float *dA, *dB, *dC; cudaMalloc(&dA, sizeof(A)); cudaMalloc(&dB, sizeof(B)); cudaMalloc(&dC, sizeof(C));
+    cudaMemcpy(dA, A, sizeof(A), cudaMemcpyHostToDevice);
+    cudaMemcpy(dB, B, sizeof(B), cudaMemcpyHostToDevice);
+    cudaMemcpy(dC, C, sizeof(C), cudaMemcpyHostToDevice);
+    run<<<1, 64>>>(dA, dB, beta, dC); cudaDeviceSynchronize();
+    float out[M*N]; cudaMemcpy(out, dC, sizeof(out), cudaMemcpyDeviceToHost);
+
+    float md = 0; for (int i = 0; i < M*N; i++) md = fmaxf(md, fabsf(out[i] - ref[i]));
+    printf("  gemm_strided %dx%dx%d  A_RS=%d B_RS=%d  max_err=%.2e\n", M, N, K, A_RS, B_RS, md);
+    cudaFree(dA); cudaFree(dB); cudaFree(dC);
+    printf(md < 1e-4 ? "PASS\n" : "FAIL\n");
+    return md < 1e-4 ? 0 : 1;
+}

--- a/examples/MIGRATION.md
+++ b/examples/MIGRATION.md
@@ -1,0 +1,79 @@
+# GLASS BLAS-convention migration cheatsheet
+
+GLASS now follows the standard BLAS / cuBLAS / NumPy / Eigen conventions. Most
+call sites change mechanically. The one subtle case is the `gemm` template-arg
+swap: it is **silent when your matrices are square**, so audit non-square calls.
+
+Column-major is the default everywhere (Fortran / Eigen default).
+
+## 1. `gemm` — contraction moved to the last dim (`<M,N,K>` → `<M,K,N>`)
+
+```cpp
+// C is now M×N with contraction K (was: middle dim was the contraction).
+//   op(A) is M×K (TRANSPOSE_A ⇒ A is K×M);  op(B) is K×N (TRANSPOSE_B ⇒ B is N×K).
+
+- glass::gemm<float, M, N, K>(alpha, A, B, beta, C);   // OLD: A M×N, B N×K, C M×K
++ glass::gemm<float, M, K, N>(alpha, A, B, beta, C);   // NEW: C M×K, contraction N → swap last two args
+
+// runtime form: same swap
+- glass::gemm<float>(m, n, k, alpha, A, B, beta, C);
++ glass::gemm<float>(m, k, n, alpha, A, B, beta, C);
+```
+
+New capability (genuinely rectangular, no squareness assumption):
+
+```cpp
+glass::gemm<float, M, N, K, /*TA=*/true,  /*TB=*/false>(alpha, A, B, beta, C); // C = Aᵀ·B
+glass::gemm<float, M, N, K, /*TA=*/false, /*TB=*/true >(alpha, A, B, beta, C); // C = A·Bᵀ
+glass::gemm<float, M, N, K, /*TA=*/true,  /*TB=*/true >(alpha, A, B, beta, C); // C = Aᵀ·Bᵀ
+```
+
+## 2. `gemm_ex` and per-operand `ROW_MAJOR_A` / `ROW_MAJOR_B` are GONE
+
+A row-major operand is a transposed column-major operand — express it with the
+transpose flags instead (see `11_rowmajor_is_transpose.cu`):
+
+```cpp
+- glass::gemm_ex<float, /*TB*/false, /*RM_A*/true, /*RM_B*/false, /*RM_C*/true>(m,n,k, alpha,A,B,beta,C);
++ glass::gemm<float, M, N, K, /*TA=*/true, /*TB=*/false, /*ROW_MAJOR_C=*/true>(alpha, A, B, beta, C);
+//        row-major A (M×K) == col-major K×M ⇒ TRANSPOSE_A;  ROW_MAJOR_C kept as the one output-layout flag.
+```
+
+## 3. `gemm_strided` / `gemv_strided` — alpha/beta to the FRONT
+
+```cpp
+- glass::gemm_strided<float, M, N, K, A_RS, B_RS>(A, B, C, alpha, beta);
++ glass::gemm_strided<float, M, K, N, A_RS, B_RS>(alpha, A, B, beta, C);  // + the gemm dim swap
+
+- glass::gemv_strided<float, M, N, RS>(A, x, y, alpha, beta);
++ glass::gemv_strided<float, M, N, RS>(alpha, A, x, beta, y);
+```
+
+## 4. `l2norm` → `nrm2` (BLAS name; Eigen `x.norm()`)
+
+```cpp
+- glass::high_speed::l2norm<float, N>(x, scratch);   glass::warp::l2norm<float>(n, x);
++ glass::high_speed::nrm2  <float, N>(x, scratch);   glass::warp::nrm2  <float>(n, x);
+```
+
+## 5. `gemv` — `gemv_ex` removed; `gemv` keeps `ROW_MAJOR`
+
+`glass::gemv<float, TRANSPOSE, ROW_MAJOR>(m, n, alpha, A, x, beta, y)` already
+matches BLAS (`y = alpha·op(A)·x + beta·y`); use `TRANSPOSE=true` for `Aᵀx`.
+
+The redundant `gemv_ex` (just `gemv` with the defaults stripped) is GONE — call
+`gemv` with explicit flags instead:
+```cpp
+- glass::gemv_ex<float, /*TRANSPOSE*/false, /*ROW_MAJOR_A*/true>(m, n, alpha, A, x, beta, y);
++ glass::gemv    <float, /*TRANSPOSE*/false, /*ROW_MAJOR  */true>(m, n, alpha, A, x, beta, y);
+```
+Unlike `gemm`, `gemv` **keeps** its per-matrix `ROW_MAJOR` flag: `TRANSPOSE`
+already selects the math op (`A·x` vs `Aᵀ·x`), so a row-major operand cannot also
+be expressed as a transpose.
+
+---
+
+Eigen equivalences (column-major): `gemm` = `C.noalias() = alpha*(opA*opB) +
+beta*C;`, `nrm2` = `x.norm()`, `asum` = `x.lpNorm<1>()`. The runnable worked
+examples for all of the above are `10_gemm_basics.cu`,
+`11_rowmajor_is_transpose.cu`, `12_nrm2.cu`, `13_gemm_strided.cu`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,10 @@ build. For the full API surface and the backend-choice guide, read that README.
 |------|-------|----------------|
 | [`01_axpy_simt.cu`](01_axpy_simt.cu) | L1 vector op `axpy` (`y = αx + y`), **runtime size** | pure SIMT — no extra deps |
 | [`02_gemm.cu`](02_gemm.cu) | single-block `gemm` (`C = αAB + βC`), runtime + **compile-time** size overloads, column-major | pure SIMT — no extra deps |
+| [`10_gemm_basics.cu`](10_gemm_basics.cu) | the **standard-BLAS GEMM convention** (`C` is M×N, contraction K) and all four `TRANSPOSE_A`/`TRANSPOSE_B` combos, verified at a non-square shape | pure SIMT — no extra deps |
+| [`11_rowmajor_is_transpose.cu`](11_rowmajor_is_transpose.cu) | **"row-major is just a transpose"** — a row-major operand read with `TRANSPOSE_*` gives bit-identical output (why per-operand `ROW_MAJOR` was pruned) | pure SIMT — no extra deps |
+| [`12_nrm2.cu`](12_nrm2.cu) | Euclidean norm `nrm2` (BLAS name; `np.linalg.norm` / Eigen `x.norm()`), block + warp forms | pure SIMT — no extra deps |
+| [`13_gemm_strided.cu`](13_gemm_strided.cu) | `gemm_strided` — GEMM on column-major sub-blocks with explicit leading dims, `alpha`/`beta` at the front | pure SIMT — no extra deps |
 | [`03_reduce.cu`](03_reduce.cu) | block reduction: `glass::reduce` and the warp-shuffle `glass::high_speed::reduce` (with scratch) | pure SIMT — no extra deps |
 | [`04_cgrps.cu`](04_cgrps.cu) | the **cooperative-groups** variant `glass::cgrps::gemm` (whole-block or warp-tile) | pure SIMT — no extra deps |
 | [`05_gemm_dispatch.cu`](05_gemm_dispatch.cu) | `glass::gemm_dispatch` + dynamic shared memory via the `glass_gemm_dispatch_smem` host helper (tiled path) | pure SIMT — no extra deps |
@@ -87,7 +91,13 @@ The MathDx-specific flags:
   single CUDA block; these examples all launch `<<<1, threads>>>`. To process
   many independent items, launch one block each (`<<<num_items, threads>>>`).
 - **Column-major by default.** Matrices are Fortran/column-major (`A[row +
-  col*m]`), matching cuBLAS. The pure-SIMT path takes a `ROW_MAJOR=true`
-  template parameter; the `glass::nvidia::` path uses the `layout` enum.
-- Reductions (`reduce`, `dot`, `l2norm`) write their result **in place** to
-  `x[0]` and may consume the input as scratch.
+  col*m]`), matching cuBLAS / Eigen. GEMM follows the standard BLAS convention
+  (`C` is M×N, contraction K) with `TRANSPOSE_A` / `TRANSPOSE_B` / `ROW_MAJOR_C`
+  flags; a row-major operand is just a transpose (`11_rowmajor_is_transpose.cu`).
+  The `glass::nvidia::` path uses the `layout` enum.
+- Reductions (`reduce`, `dot`, `nrm2`) write their result **in place** to
+  `x[0]` and may consume the input as scratch (the `glass::warp::` forms return
+  the value instead).
+- **Migrating from the old API?** See [`MIGRATION.md`](MIGRATION.md) for the
+  one-line OLD→NEW changes (the `gemm` dim swap, `gemm_ex` removal, `row_strided_*`
+  arg order, `l2norm`→`nrm2`).

--- a/glass-nvidia.cuh
+++ b/glass-nvidia.cuh
@@ -5,7 +5,7 @@
  *
  * Include this (instead of, or in addition to, glass.cuh) to access the
  * vendor-accelerated single-block linear-algebra paths. It pulls in:
- *   - L1 (l1.cuh)         CUB-backed block reductions: reduce / dot / l2norm.
+ *   - L1 (l1.cuh)         CUB-backed block reductions: reduce / dot / nrm2.
  *   - query_simt.cuh      SIMT-only dispatch + diagnostic helpers
  *                         (should_use_cublasdx<>, print_dispatch<>, ...).
  *   - L3 SIMT (l3_simt.cuh)  1D-launch batched GEMMs (no cuBLASDx dependency).
@@ -67,7 +67,7 @@
 namespace glass {
 namespace nvidia {
 
-    // L1: CUB-backed reduce / dot / l2norm
+    // L1: CUB-backed reduce / dot / nrm2
     #include "./src/nvidia/l1.cuh"
 
     // SIMT-only query helpers: should_use_cublasdx<>, print_dispatch<>,
@@ -118,7 +118,7 @@ namespace nvidia {
     // ---------------------------------------------------------------------
     // required_smem_for_dispatch_*<> — explicit-intent aliases (round-2).
     //
-    // The *_smem_size<> functions already encode the dispatch decision
+    // The *_scratch_bytes<> functions already encode the dispatch decision
     // (return 0 for SIMT-routed shapes, cuBLASDx scratch size otherwise),
     // but these aliases make consumer code self-documenting:
     //
@@ -134,7 +134,7 @@ namespace nvidia {
     /**
      * @brief Shared-memory bytes the dispatched `gemm<...>` needs (host-callable).
      *
-     * Self-documenting alias for `gemm_smem_size<...>()`: returns 0 for shapes
+     * Self-documenting alias for `gemm_scratch_bytes<...>()`: returns 0 for shapes
      * the auto-dispatch routes to SIMT, or the cuBLASDx scratch size otherwise.
      *
      * @tparam T             Scalar type.
@@ -154,13 +154,13 @@ namespace nvidia {
               layout LC = layout::col_major,
               uint32_t SM_VAL = SMS>
     constexpr std::size_t required_smem_for_dispatch_gemm() {
-        return gemm_smem_size<T, M, N, K, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
+        return gemm_scratch_bytes<T, M, N, K, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
     }
 
     /**
      * @brief Shared-memory bytes the dispatched `gemv<...>` needs (host-callable).
      *
-     * Self-documenting alias for `gemv_smem_size<...>()`: 0 when SIMT-routed,
+     * Self-documenting alias for `gemv_scratch_bytes<...>()`: 0 when SIMT-routed,
      * cuBLASDx scratch size otherwise.
      *
      * @tparam T             Scalar type.
@@ -179,13 +179,13 @@ namespace nvidia {
               layout LC = layout::col_major,
               uint32_t SM_VAL = SMS>
     constexpr std::size_t required_smem_for_dispatch_gemv() {
-        return gemv_smem_size<T, M, N, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
+        return gemv_scratch_bytes<T, M, N, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
     }
 
     /**
-     * @brief Shared-memory bytes the dispatched `row_strided_gemm<...>` needs (host-callable).
+     * @brief Shared-memory bytes the dispatched `gemm_strided<...>` needs (host-callable).
      *
-     * Self-documenting alias for `row_strided_gemm_smem_size<...>()`: 0 when
+     * Self-documenting alias for `gemm_strided_scratch_bytes<...>()`: 0 when
      * SIMT-routed (strides used directly), packing + cuBLASDx scratch otherwise.
      *
      * @tparam T             Scalar type.
@@ -201,21 +201,21 @@ namespace nvidia {
      * @tparam SM_VAL        Target SM architecture.
      */
     template <typename T, uint32_t M, uint32_t N, uint32_t K,
-              uint32_t A_RS = M, uint32_t B_RS = N,
+              uint32_t A_RS = M, uint32_t B_RS = K,
               uint32_t BLOCK_THREADS = 0,
               layout LA = layout::col_major,
               layout LB = layout::col_major,
               layout LC = layout::col_major,
               uint32_t SM_VAL = SMS>
-    constexpr std::size_t required_smem_for_dispatch_row_strided_gemm() {
-        return row_strided_gemm_smem_size<T, M, N, K, A_RS, B_RS,
+    constexpr std::size_t required_smem_for_dispatch_gemm_strided() {
+        return gemm_strided_scratch_bytes<T, M, N, K, A_RS, B_RS,
                                           BLOCK_THREADS, LA, LB, LC, SM_VAL>();
     }
 
     /**
-     * @brief Shared-memory bytes the dispatched `row_strided_gemv<...>` needs (host-callable).
+     * @brief Shared-memory bytes the dispatched `gemv_strided<...>` needs (host-callable).
      *
-     * Self-documenting alias for `row_strided_gemv_smem_size<...>()`: 0 when
+     * Self-documenting alias for `gemv_strided_scratch_bytes<...>()`: 0 when
      * SIMT-routed, A-packing + cuBLASDx scratch otherwise.
      *
      * @tparam T             Scalar type.
@@ -234,8 +234,8 @@ namespace nvidia {
               layout LB = layout::col_major,
               layout LC = layout::col_major,
               uint32_t SM_VAL = SMS>
-    constexpr std::size_t required_smem_for_dispatch_row_strided_gemv() {
-        return row_strided_gemv_smem_size<T, M, N, ROW_STRIDE,
+    constexpr std::size_t required_smem_for_dispatch_gemv_strided() {
+        return gemv_strided_scratch_bytes<T, M, N, ROW_STRIDE,
                                           BLOCK_THREADS, LA, LB, LC, SM_VAL>();
     }
 #endif // GLASS_HAVE_CUBLASDX

--- a/glass.cuh
+++ b/glass.cuh
@@ -16,9 +16,13 @@
 // Pre-include system headers at global scope so they are not pulled into the
 // namespace glass { } block when the base files include them via #pragma once.
 #include <cstdint>
+#include <cstddef>
 #include <math.h>
 
 namespace glass {
+    /*  barrier policy (shared *_impl bodies; BlockBarrier = threadIdx + __syncthreads)  */
+    #include "./src/base/barrier.cuh"
+
     /*      L1      */
     #include "./src/base/L1/reduce.cuh"
     #include "./src/base/L1/axpy.cuh"
@@ -33,12 +37,15 @@ namespace glass {
     #include "./src/base/L1/transpose.cuh"
     #include "./src/base/L1/prefix_sum.cuh"
     #include "./src/base/L1/norm.cuh"
-    #include "./src/base/L1/l2norm.cuh"
+    #include "./src/base/L1/nrm2.cuh"
     #include "./src/base/L1/infnorm.cuh"
     #include "./src/base/L1/iamax.cuh"
     #include "./src/base/L1/clip.cuh"
     #include "./src/base/L1/set_const.cuh"
     #include "./src/base/L1/asum.cuh"
+    #include "./src/base/L1/nrm1_diff.cuh"
+    #include "./src/base/L1/axpy_strided.cuh"
+    #include "./src/base/L1/copy_strided.cuh"
 
     /*      L2      */
     #include "./src/base/L2/gemv.cuh"
@@ -66,6 +73,7 @@ namespace glass {
 
     /*  block-tridiagonal: glass::bdmv (matvec) + glass::pcg (solver)  */
     #include "./src/base/banded/bdmv.cuh"
+    #include "./src/base/banded/block_access.cuh"
     #include "./src/base/pcg/solve.cuh"
 }
 
@@ -74,11 +82,12 @@ namespace glass {
  *
  * Compute on the host at launch time and pass as the kernel's dynamic-smem
  * argument. Returns 0 when tiling is not warranted (m >= 32 or
- * m*k > block_threads), in which case glass::gemm_dispatch runs the plain
- * (non-tiled) path. Host-callable.
+ * m*n > block_threads), in which case glass::gemm_dispatch runs the plain
+ * (non-tiled) path. Host-callable. Standard convention: C is m×n, contraction k;
+ * the tiled path stages an `m×TILE` A-tile and a `TILE×n` B-tile.
  *
  * Usage:
- *   size_t smem = glass_gemm_dispatch_smem<float>(m, k);
+ *   size_t smem = glass_gemm_dispatch_smem<float>(m, n);
  *   kernel<<<grid, 256, smem>>>(m, n, k, A, B, C);
  *   // inside the kernel:
  *   extern __shared__ T scratch[];
@@ -88,16 +97,16 @@ namespace glass {
  *
  * @tparam T            Scalar type (defaults to float).
  * @param  m            Rows of A / C.
- * @param  k            Inner dimension (cols of A, rows of B).
+ * @param  n            Columns of B / C.
  * @param  block_threads Launch thread count used for the tiling heuristic.
  * @param  tile         Tile width (must match the gemm_tiled<T, TILE> used).
  * @return Bytes of dynamic shared memory to allocate, or 0 for the plain path.
  */
 template <typename T = float>
-inline std::size_t glass_gemm_dispatch_smem(int m, int k,
+inline std::size_t glass_gemm_dispatch_smem(int m, int n,
                                             int block_threads = 256, int tile = 8)
 {
-    if (m < 32 && m * k <= block_threads)
-        return static_cast<std::size_t>(m * tile + tile * k) * sizeof(T);
+    if (m < 32 && m * n <= block_threads)
+        return static_cast<std::size_t>(m * tile + tile * n) * sizeof(T);
     return 0;
 }

--- a/src/L3/box_qp.cuh
+++ b/src/L3/box_qp.cuh
@@ -21,14 +21,14 @@
 // ============================================================================
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include "../base/L1/clip.cuh"
 #include "../base/L1/copy.cuh"
 #include "../base/L1/dot.cuh"
 #include "../base/L1/infnorm.cuh"
 #include "../base/L1/elementwise_logic.cuh"
 #include "../base/L3/gemm.cuh"
-#include <cstddef>
-#include <cstdint>
 
 namespace glass {
 namespace internal {
@@ -56,9 +56,9 @@ struct QPResult {
 // — low_memory::dot writes the full length-n buffer and reduces into [0], so the
 // accumulators must be length n, not single scalars.
 template <typename T>
-__host__ __device__ constexpr std::size_t box_qp_scratch_size(std::uint32_t n)
+__host__ __device__ constexpr std::size_t box_qp_scratch_bytes(std::uint32_t n)
 {
-    return static_cast<std::size_t>(5u) * n;
+    return static_cast<std::size_t>(5u) * n * sizeof(T);
 }
 
 // f(x) = 0.5 xᵀP x + qᵀx. Uses Px and tmp (each length n) as scratch. Returns
@@ -67,7 +67,7 @@ template <typename T>
 __device__ T qp_objective(std::uint32_t n, T *P, T *x, T *q, T *Px, T *tmp)
 {
     // Px = P @ x  (n×n · n×1). P symmetric ⇒ xᵀP x == xᵀ(P x).
-    gemm<T>(n, n, 1, (T)1, P, x, Px);
+    gemm<T>(n, 1, n, (T)1, P, x, Px);
     __syncthreads();
     low_memory::dot<T>(n, Px, x, tmp);     // tmp[0] = xᵀP x (uses tmp[0..n-1])
     T xPx = tmp[0];
@@ -77,7 +77,7 @@ __device__ T qp_objective(std::uint32_t n, T *P, T *x, T *q, T *Px, T *tmp)
 }
 
 // Solve the box QP. x: in = initial guess, out = solution (in-place, projected
-// onto [l,u]). scratch must hold >= box_qp_scratch_size<T>(n) elements.
+// onto [l,u]). scratch must hold >= box_qp_scratch_bytes<T>(n) elements.
 template <typename T>
 __device__ QPResult<T> box_qp(std::uint32_t n, T *P, T *q, T *l, T *u, T *x,
                               T *scratch, const QPParams<T> &params = QPParams<T>())
@@ -99,7 +99,7 @@ __device__ QPResult<T> box_qp(std::uint32_t n, T *P, T *q, T *l, T *u, T *x,
         out.iters = it + 1;
 
         // grad = P x + q
-        gemm<T>(n, n, 1, (T)1, P, x, grad);
+        gemm<T>(n, 1, n, (T)1, P, x, grad);
         __syncthreads();
         elementwise_add<T>(n, grad, q, grad);   // grad = grad + q
         __syncthreads();

--- a/src/base/L1/asum.cuh
+++ b/src/base/L1/asum.cuh
@@ -1,6 +1,20 @@
 #pragma once
 #include <cstdint>
 #include <math.h>
+#include "reduce.cuh"
+
+// Shared body: Σ|x[i]| via |x|→out + halving reduce; result in out[0] (x intact).
+// The shared engine for the cgrps:: plain asum (the block surface intentionally
+// exposes only the low_memory/high_speed/warp variants). Barrier policy supplies
+// rank/size + the internal/trailing sync.
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void asum_impl(Bar bar, uint32_t n, T *x, T *out)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) out[i] = abs(x[i]);
+    bar.sync();
+    reduce_impl<Bar, T, TRAILING_SYNC>(bar, n, out);
+}
 
 namespace low_memory {
     /**
@@ -14,7 +28,7 @@ namespace low_memory {
      * @param x    Input vector of length `n`.
      * @param out  Length-`n` scratch/output buffer; the result lands in `out[0]`.
      */
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void asum(uint32_t n, T *x, T *out)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -22,7 +36,7 @@ namespace low_memory {
         for (uint32_t i = rank; i < n; i += size) out[i] = abs(x[i]);
         __syncthreads();
         if (rank == 0) { for (uint32_t i = 1; i < n; i++) out[0] += out[i]; }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 }
 
@@ -41,7 +55,7 @@ namespace high_speed {
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
     // s_scratch: ceil(blockDim/32)*sizeof(T); result in x[0] (overwrites input!)
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void asum(uint32_t n, T *x, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -58,7 +72,7 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) x[0] = val;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -72,7 +86,7 @@ namespace high_speed {
      * @param x          In/out vector of length `N`; result lands in `x[0]`.
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
-    template <typename T, uint32_t N>
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
     __device__ void asum(T *x, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -89,6 +103,54 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) x[0] = val;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
+    }
+}
+
+namespace warp {
+    /**
+     * @brief Sum of absolute values within one warp: returns `Σ|x[i]|` on every lane.
+     *
+     * Single-warp ASUM, mirroring `warp::dot`: one 32-lane warp reduces the
+     * per-lane absolute-value partials with `__shfl_down_sync` and BROADCASTS the
+     * total to all 32 lanes via `__shfl_sync` (from a register — immune to the
+     * `__restrict__` stale-cache miscompile). Non-destructive (`x` untouched), no
+     * shared scratch, no `__syncthreads`. Full 32 lanes required; independent warps
+     * may run distinct problems concurrently. NumPy equivalent: `np.sum(np.abs(x))`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @param n  Number of elements.
+     * @param x  Input vector of length `n` (read-only).
+     * @return `Σ|x[i]|`, identical on every lane.
+     */
+    template <typename T>
+    __device__ T asum(uint32_t n, const T *x)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < n; i += 32) val += abs(x[i]);
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffffu, val, off);
+        return __shfl_sync(0xffffffffu, val, 0);
+    }
+
+    /**
+     * @brief Sum of absolute values within one warp, compile-time size (returns it on every lane).
+     *
+     * Compile-time-`N` overload of the single-warp ASUM. Non-destructive, no shared
+     * scratch, no `__syncthreads`. NumPy equivalent: `np.sum(np.abs(x))`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @tparam N  Number of elements (compile-time constant).
+     * @param x  Input vector of length `N` (read-only).
+     * @return `Σ|x[i]|`, identical on every lane.
+     */
+    template <typename T, uint32_t N>
+    __device__ T asum(const T *x)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < N; i += 32) val += abs(x[i]);
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffffu, val, off);
+        return __shfl_sync(0xffffffffu, val, 0);
     }
 }

--- a/src/base/L1/axpy.cuh
+++ b/src/base/L1/axpy.cuh
@@ -1,5 +1,15 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
+
+// shared body: AXPY in place `y = alpha*x + y`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void axpy_impl(Bar bar, uint32_t n, T alpha, T *x, T *y)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) y[i] = alpha*x[i] + y[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
 
 /**
  * @brief Scaled vector sum: `y = alpha * x + y` (AXPY).
@@ -13,12 +23,19 @@
  * @param x      Input vector of length `n`.
  * @param y      In/out vector of length `n` (overwritten with the result).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void axpy(uint32_t n, T alpha, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) y[i] = alpha*x[i] + y[i];
+    axpy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, alpha, x, y);
+}
+
+// shared body: out-of-place AXPY `z = alpha*x + y`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void axpy_impl(Bar bar, uint32_t n, T alpha, T *x, T *y, T *z)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) z[i] = alpha*x[i] + y[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
 }
 
 /**
@@ -34,12 +51,19 @@ __device__ void axpy(uint32_t n, T alpha, T *x, T *y)
  * @param y      Input vector of length `n`.
  * @param z      Output vector of length `n` (overwritten with the result).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void axpy(uint32_t n, T alpha, T *x, T *y, T *z)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) z[i] = alpha*x[i] + y[i];
+    axpy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, alpha, x, y, z);
+}
+
+// shared body: AXPBY `z = alpha*x + beta*y`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void axpby_impl(Bar bar, uint32_t n, T alpha, T *x, T beta, T *y, T *z)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) z[i] = alpha*x[i] + beta*y[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
 }
 
 /**
@@ -56,12 +80,10 @@ __device__ void axpy(uint32_t n, T alpha, T *x, T *y, T *z)
  * @param y      Input vector of length `n`.
  * @param z      Output vector of length `n` (overwritten with the result).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void axpby(uint32_t n, T alpha, T *x, T beta, T *y, T *z)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) z[i] = alpha*x[i] + beta*y[i];
+    axpby_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, alpha, x, beta, y, z);
 }
 
 // compile-time size overloads
@@ -76,12 +98,10 @@ __device__ void axpby(uint32_t n, T alpha, T *x, T beta, T *y, T *z)
  * @param x      Input vector of length `N`.
  * @param y      In/out vector of length `N` (overwritten with the result).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void axpy(T alpha, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) y[i] = alpha*x[i] + y[i];
+    axpy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, alpha, x, y);
 }
 
 /**
@@ -96,12 +116,10 @@ __device__ void axpy(T alpha, T *x, T *y)
  * @param y      Input vector of length `N`.
  * @param z      Output vector of length `N` (overwritten with the result).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void axpy(T alpha, T *x, T *y, T *z)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) z[i] = alpha*x[i] + y[i];
+    axpy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, alpha, x, y, z);
 }
 
 /**
@@ -117,12 +135,10 @@ __device__ void axpy(T alpha, T *x, T *y, T *z)
  * @param y      Input vector of length `N`.
  * @param z      Output vector of length `N` (overwritten with the result).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void axpby(T alpha, T *x, T beta, T *y, T *z)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) z[i] = alpha*x[i] + beta*y[i];
+    axpby_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, alpha, x, beta, y, z);
 }
 
 namespace warp {

--- a/src/base/L1/axpy_strided.cuh
+++ b/src/base/L1/axpy_strided.cuh
@@ -1,0 +1,73 @@
+#pragma once
+#include <cstdint>
+
+/**
+ * @file axpy_strided.cuh
+ * @brief Row-strided AXPY: `Y[r + c*Y_RS] += alpha * X[r + c*X_RS]` over an M×N block.
+ *
+ * The AXPY analogue of `gemv_strided` — adds an `M×N` (column-major) block of
+ * `X` into a same-shaped block of `Y` when the two live inside wider buffers with
+ * different leading dimensions (`X_RS`, `Y_RS`). PDDP packs a 14×14 update into a
+ * 21-lead buffer top-left (`Y_RS=21`, `X_RS=14`). Each `(r,c)` element is written
+ * by exactly one thread/lane, so there is no race and the op is trivially
+ * thread-count invariant. Block + `warp::`.
+ */
+
+/**
+ * @brief Row-strided AXPY `Y[r + c*Y_RS] += alpha * X[r + c*X_RS]` over an M×N block.
+ *
+ * Column-major; `X` is addressed at leading dimension `X_RS` (default `M`), `Y` at
+ * `Y_RS`. When `X_RS == M` and `Y_RS == M` this is a plain `glass::axpy` over the
+ * `M*N` contiguous elements. NumPy: `Y[:M,:N] += alpha * X[:M,:N]` (col-major lds).
+ *
+ * @tparam T             Scalar type (e.g. `float`, `double`).
+ * @tparam M             Rows of the block.
+ * @tparam N             Columns of the block.
+ * @tparam Y_RS          Column-major leading dimension of `Y`.
+ * @tparam X_RS          Column-major leading dimension of `X` (default `M`).
+ * @tparam TRAILING_SYNC Emit a trailing `__syncthreads()` (default true).
+ * @param alpha  Scalar multiplier on `X`.
+ * @param X      Input block, addressed at `X[r + c*X_RS]` (read-only).
+ * @param Y      In/out block, addressed at `Y[r + c*Y_RS]`.
+ */
+template <typename T, uint32_t M, uint32_t N, uint32_t Y_RS, uint32_t X_RS = M, bool TRAILING_SYNC = true>
+__device__ void axpy_strided(T alpha, const T* X, T* Y)
+{
+    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    for (uint32_t k = rank; k < M * N; k += size) {
+        uint32_t r = k % M, c = k / M;
+        Y[r + c * Y_RS] += alpha * X[r + c * X_RS];
+    }
+    if constexpr (TRAILING_SYNC) __syncthreads();
+}
+
+namespace warp {
+    /**
+     * @brief Row-strided AXPY within one warp: `Y[r + c*Y_RS] += alpha * X[r + c*X_RS]`.
+     *
+     * Single-warp form of `axpy_strided`: one 32-lane warp strides over the
+     * `M*N` block elements. Each element written once; no inter-lane comms, no
+     * shared scratch. `TRAILING_SYNC` gates a closing `__syncwarp()`. Full 32 lanes
+     * required; independent warps may run distinct problems concurrently.
+     *
+     * @tparam T             Scalar type.
+     * @tparam M,N           Block shape.
+     * @tparam Y_RS          Leading dimension of `Y`.
+     * @tparam X_RS          Leading dimension of `X` (default `M`).
+     * @tparam TRAILING_SYNC Emit a trailing `__syncwarp()` (default true).
+     * @param alpha  Scalar multiplier on `X`.
+     * @param X      Input block, addressed at `X[r + c*X_RS]` (read-only).
+     * @param Y      In/out block, addressed at `Y[r + c*Y_RS]`.
+     */
+    template <typename T, uint32_t M, uint32_t N, uint32_t Y_RS, uint32_t X_RS = M, bool TRAILING_SYNC = true>
+    __device__ void axpy_strided(T alpha, const T* X, T* Y)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (uint32_t k = lane; k < M * N; k += 32) {
+            uint32_t r = k % M, c = k / M;
+            Y[r + c * Y_RS] += alpha * X[r + c * X_RS];
+        }
+        if constexpr (TRAILING_SYNC) __syncwarp();
+    }
+}

--- a/src/base/L1/clip.cuh
+++ b/src/base/L1/clip.cuh
@@ -1,5 +1,16 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
+
+// shared body: element-wise clamp `x = clamp(x, l, u)`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void clip_impl(Bar bar, uint32_t n, T *x, T *l, T *u)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size)
+        x[i] = max(l[i], min(x[i], u[i]));
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
 
 /**
  * @brief Element-wise clamp in place: `x = clamp(x, l, u)`.
@@ -13,13 +24,10 @@
  * @param l  Per-element lower bounds, length `n`.
  * @param u  Per-element upper bounds, length `n`.
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void clip(uint32_t n, T *x, T *l, T *u)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size)
-        x[i] = max(l[i], min(x[i], u[i]));
+    clip_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, x, l, u);
 }
 
 /**
@@ -33,11 +41,8 @@ __device__ void clip(uint32_t n, T *x, T *l, T *u)
  * @param l  Per-element lower bounds, length `N`.
  * @param u  Per-element upper bounds, length `N`.
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void clip(T *x, T *l, T *u)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size)
-        x[i] = max(l[i], min(x[i], u[i]));
+    clip_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, x, l, u);
 }

--- a/src/base/L1/copy.cuh
+++ b/src/base/L1/copy.cuh
@@ -1,5 +1,15 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
+
+// shared body: plain copy `y = x`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void copy_impl(Bar bar, uint32_t n, T *x, T *y)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) y[i] = x[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
 
 /**
  * @brief Vector copy: `y = x` (COPY).
@@ -12,12 +22,19 @@
  * @param x  Input vector of length `n`.
  * @param y  Output vector of length `n` (overwritten with a copy of `x`).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void copy(uint32_t n, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) y[i] = x[i];
+    copy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, x, y);
+}
+
+// shared body: scaled copy `y = alpha*x`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void copy_impl(Bar bar, uint32_t n, T alpha, T *x, T *y)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) y[i] = alpha*x[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
 }
 
 /**
@@ -32,12 +49,10 @@ __device__ void copy(uint32_t n, T *x, T *y)
  * @param x      Input vector of length `n`.
  * @param y      Output vector of length `n` (overwritten with the result).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void copy(uint32_t n, T alpha, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) y[i] = alpha*x[i];
+    copy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, alpha, x, y);
 }
 
 /**
@@ -50,12 +65,10 @@ __device__ void copy(uint32_t n, T alpha, T *x, T *y)
  * @param x  Input vector of length `N`.
  * @param y  Output vector of length `N` (overwritten with a copy of `x`).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void copy(T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) y[i] = x[i];
+    copy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, x, y);
 }
 
 /**
@@ -69,12 +82,10 @@ __device__ void copy(T *x, T *y)
  * @param x      Input vector of length `N`.
  * @param y      Output vector of length `N` (overwritten with the result).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void copy(T alpha, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) y[i] = alpha*x[i];
+    copy_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, alpha, x, y);
 }
 
 namespace warp {

--- a/src/base/L1/copy_strided.cuh
+++ b/src/base/L1/copy_strided.cuh
@@ -1,0 +1,72 @@
+#pragma once
+#include <cstdint>
+
+/**
+ * @file copy_strided.cuh
+ * @brief Row-strided COPY: `Y[r + c*Y_RS] = alpha * X[r + c*X_RS]` over an M×N block.
+ *
+ * The COPY (overwrite) sibling of `axpy_strided` — moves a column-major `M×N`
+ * block of `X` into a same-shaped block of `Y` when the two live inside wider
+ * buffers with different leading dimensions (`X_RS`, `Y_RS`), optionally scaling by
+ * `alpha`. Each `(r,c)` element is written by exactly one thread/lane (no race,
+ * trivially thread-count invariant). Block + `warp::`.
+ */
+
+/**
+ * @brief Row-strided COPY `Y[r + c*Y_RS] = alpha * X[r + c*X_RS]` over an M×N block.
+ *
+ * Column-major; `X` at leading dimension `X_RS` (default `M`), `Y` at `Y_RS`. When
+ * `X_RS == M` and `Y_RS == M` this is a plain scaled `glass::copy` over `M*N`
+ * contiguous elements. NumPy: `Y[:M,:N] = alpha * X[:M,:N]` (col-major lds).
+ *
+ * @tparam T             Scalar type (e.g. `float`, `double`).
+ * @tparam M             Rows of the block.
+ * @tparam N             Columns of the block.
+ * @tparam Y_RS          Column-major leading dimension of `Y`.
+ * @tparam X_RS          Column-major leading dimension of `X` (default `M`).
+ * @tparam TRAILING_SYNC Emit a trailing `__syncthreads()` (default true).
+ * @param alpha  Scalar multiplier on `X`.
+ * @param X      Input block, addressed at `X[r + c*X_RS]` (read-only).
+ * @param Y      Output block, addressed at `Y[r + c*Y_RS]` (overwritten).
+ */
+template <typename T, uint32_t M, uint32_t N, uint32_t Y_RS, uint32_t X_RS = M, bool TRAILING_SYNC = true>
+__device__ void copy_strided(T alpha, const T* X, T* Y)
+{
+    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    for (uint32_t k = rank; k < M * N; k += size) {
+        uint32_t r = k % M, c = k / M;
+        Y[r + c * Y_RS] = alpha * X[r + c * X_RS];
+    }
+    if constexpr (TRAILING_SYNC) __syncthreads();
+}
+
+namespace warp {
+    /**
+     * @brief Row-strided COPY within one warp: `Y[r + c*Y_RS] = alpha * X[r + c*X_RS]`.
+     *
+     * Single-warp form of `copy_strided`: one 32-lane warp strides over the
+     * `M*N` block elements. Each element written once; no inter-lane comms, no
+     * shared scratch. `TRAILING_SYNC` gates a closing `__syncwarp()`. Full 32 lanes
+     * required; independent warps may run distinct problems concurrently.
+     *
+     * @tparam T             Scalar type.
+     * @tparam M,N           Block shape.
+     * @tparam Y_RS          Leading dimension of `Y`.
+     * @tparam X_RS          Leading dimension of `X` (default `M`).
+     * @tparam TRAILING_SYNC Emit a trailing `__syncwarp()` (default true).
+     * @param alpha  Scalar multiplier on `X`.
+     * @param X      Input block, addressed at `X[r + c*X_RS]` (read-only).
+     * @param Y      Output block, addressed at `Y[r + c*Y_RS]` (overwritten).
+     */
+    template <typename T, uint32_t M, uint32_t N, uint32_t Y_RS, uint32_t X_RS = M, bool TRAILING_SYNC = true>
+    __device__ void copy_strided(T alpha, const T* X, T* Y)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (uint32_t k = lane; k < M * N; k += 32) {
+            uint32_t r = k % M, c = k / M;
+            Y[r + c * Y_RS] = alpha * X[r + c * X_RS];
+        }
+        if constexpr (TRAILING_SYNC) __syncwarp();
+    }
+}

--- a/src/base/L1/dot.cuh
+++ b/src/base/L1/dot.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
 #include "reduce.cuh"
 
@@ -14,15 +15,22 @@
  * @param x  Input vector of length `n`.
  * @param y  In/out vector of length `n`; the dot product lands in `y[0]`.
  */
+// Shared body: y = x·y (result in y[0]); element-wise multiply then halving
+// reduce on y. The trailing barrier rides on reduce_impl's TRAILING_SYNC.
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void dot_impl(Bar bar, uint32_t n, T *x, T *y)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) y[i] *= x[i];
+    bar.sync();
+    reduce_impl<Bar, T, TRAILING_SYNC>(bar, n, y);
+}
+
 // in-place: y = x·y (result in y[0]); uses halving reduce on y
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void dot(uint32_t n, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) y[i] *= x[i];
-    __syncthreads();
-    reduce<T>(n, y);
+    dot_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, x, y);
 }
 
 /**
@@ -36,14 +44,10 @@ __device__ void dot(uint32_t n, T *x, T *y)
  * @param x  Input vector of length `N`.
  * @param y  In/out vector of length `N`; the dot product lands in `y[0]`.
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void dot(T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) y[i] *= x[i];
-    __syncthreads();
-    reduce<T, N>(y);
+    dot_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, x, y);
 }
 
 namespace low_memory {
@@ -61,7 +65,7 @@ namespace low_memory {
      * @param out  Length-`n` scratch/output buffer; the result lands in `out[0]`.
      */
     // out: length-n scratch; result in out[0]
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void dot(uint32_t n, T *x, T *y, T *out)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -69,7 +73,7 @@ namespace low_memory {
         for (uint32_t i = rank; i < n; i += size) out[i] = x[i]*y[i];
         __syncthreads();
         if (rank == 0) { for (uint32_t i = 1; i < n; i++) out[0] += out[i]; }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 }
 
@@ -134,6 +138,20 @@ namespace warp {
 
 namespace high_speed {
     /**
+     * @brief Shared-scratch size in bytes for the `high_speed::dot` ops.
+     *
+     * The warp-shuffle dot combines across warps through one scratch slot per warp:
+     * `ceil(block_threads / 32)` elements of `T`. Allocate
+     * `high_speed::dot_scratch_bytes<T>(block_threads)` for the `s_scratch` argument.
+     *
+     * @tparam T  Scalar type.
+     * @param block_threads  Number of threads in the launching block.
+     * @return Bytes to allocate for `s_scratch`.
+     */
+    template <typename T>
+    __host__ __device__ constexpr std::size_t dot_scratch_bytes(uint32_t block_threads) { return static_cast<std::size_t>((block_threads + 31) / 32) * sizeof(T); }
+
+    /**
      * @brief Inner product: `out[0] = x · y` (DOT), warp-shuffle variant.
      *
      * Accumulates the element-wise products with a warp-shuffle reduction plus
@@ -148,7 +166,7 @@ namespace high_speed {
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
     // s_scratch: ceil(blockDim/32)*sizeof(T); result in out[0]
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void dot(uint32_t n, T *x, T *y, T *out, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -165,7 +183,7 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) out[0] = val;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -181,7 +199,7 @@ namespace high_speed {
      * @param out        Output buffer; the result lands in `out[0]`.
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
-    template <typename T, uint32_t N>
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
     __device__ void dot(T *x, T *y, T *out, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -198,6 +216,6 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) out[0] = val;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 }

--- a/src/base/L1/dot_strided_coalesced.cuh
+++ b/src/base/L1/dot_strided_coalesced.cuh
@@ -54,7 +54,7 @@
  * @param out        Destination for the scalar result (broadcast to all threads).
  * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
  */
-template <typename T, uint32_t N, uint32_t SX = 1, uint32_t SY = 1>
+template <typename T, uint32_t N, uint32_t SX = 1, uint32_t SY = 1, bool TRAILING_SYNC = true>
 __device__ void dot_strided_coalesced(const T* x, const T* y, T* out, T* s_scratch)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -77,5 +77,5 @@ __device__ void dot_strided_coalesced(const T* x, const T* y, T* out, T* s_scrat
         for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
         if (rank == 0) *out = val;
     }
-    __syncthreads();
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }

--- a/src/base/L1/elementwise_logic.cuh
+++ b/src/base/L1/elementwise_logic.cuh
@@ -1,9 +1,6 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
-
-#define _GLASS_RS \
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y; \
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
 
 /**
  * @brief Element-wise maximum: `c = max(a, b)`.
@@ -16,8 +13,16 @@
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_max(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = max(a[i], b[i]); }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_max_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = max(a[i], b[i]);
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_max(uint32_t N, T *a, T *b, T *c)
+{ elementwise_max_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise minimum: `c = min(a, b)`.
@@ -30,8 +35,16 @@ template <typename T> __device__ void elementwise_max(uint32_t N, T *a, T *b, T 
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_min(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = min(a[i], b[i]); }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_min_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = min(a[i], b[i]);
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_min(uint32_t N, T *a, T *b, T *c)
+{ elementwise_min_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise less-than: `c = (a < b)`.
@@ -44,8 +57,16 @@ template <typename T> __device__ void elementwise_min(uint32_t N, T *a, T *b, T 
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N` (1 where `a[i] < b[i]`, else 0).
  */
-template <typename T> __device__ void elementwise_less_than(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] < b[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_less_than_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i] < b[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_less_than(uint32_t N, T *a, T *b, T *c)
+{ elementwise_less_than_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise greater-than: `c = (a > b)`.
@@ -58,8 +79,16 @@ template <typename T> __device__ void elementwise_less_than(uint32_t N, T *a, T 
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N` (1 where `a[i] > b[i]`, else 0).
  */
-template <typename T> __device__ void elementwise_more_than(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] > b[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_more_than_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i] > b[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_more_than(uint32_t N, T *a, T *b, T *c)
+{ elementwise_more_than_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise less-than-or-equal: `c = (a <= b)`.
@@ -72,8 +101,16 @@ template <typename T> __device__ void elementwise_more_than(uint32_t N, T *a, T 
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N` (1 where `a[i] <= b[i]`, else 0).
  */
-template <typename T> __device__ void elementwise_less_than_or_eq(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] <= b[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_less_than_or_eq_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i] <= b[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_less_than_or_eq(uint32_t N, T *a, T *b, T *c)
+{ elementwise_less_than_or_eq_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise less-than-scalar: `c = (a < b)`.
@@ -87,8 +124,16 @@ template <typename T> __device__ void elementwise_less_than_or_eq(uint32_t N, T 
  * @param b  Scalar threshold.
  * @param c  Output vector of length `N` (1 where `a[i] < b`, else 0).
  */
-template <typename T> __device__ void elementwise_less_than_scalar(uint32_t N, T *a, T b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] < b; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_less_than_scalar_impl(Bar bar, uint32_t N, T *a, T b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i] < b;
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_less_than_scalar(uint32_t N, T *a, T b, T *c)
+{ elementwise_less_than_scalar_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise logical AND: `c = (a && b)`.
@@ -101,8 +146,16 @@ template <typename T> __device__ void elementwise_less_than_scalar(uint32_t N, T
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N` (1 where both are nonzero, else 0).
  */
-template <typename T> __device__ void elementwise_and(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] && b[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_and_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i] && b[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_and(uint32_t N, T *a, T *b, T *c)
+{ elementwise_and_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise logical NOT: `c = !a`.
@@ -114,8 +167,16 @@ template <typename T> __device__ void elementwise_and(uint32_t N, T *a, T *b, T 
  * @param a  Input vector of length `N`.
  * @param c  Output vector of length `N` (1 where `a[i]` is zero, else 0).
  */
-template <typename T> __device__ void elementwise_not(uint32_t N, T *a, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = !a[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_not_impl(Bar bar, uint32_t N, T *a, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = !a[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_not(uint32_t N, T *a, T *c)
+{ elementwise_not_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, c); }
 
 /**
  * @brief Element-wise absolute value: `b = |a|`.
@@ -127,8 +188,16 @@ template <typename T> __device__ void elementwise_not(uint32_t N, T *a, T *c)
  * @param a  Input vector of length `N`.
  * @param b  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_abs(uint32_t N, T *a, T *b)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) b[i] = abs(a[i]); }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_abs_impl(Bar bar, uint32_t N, T *a, T *b)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) b[i] = abs(a[i]);
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_abs(uint32_t N, T *a, T *b)
+{ elementwise_abs_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b); }
 
 /**
  * @brief Element-wise (Hadamard) product: `c = a ⊙ b`.
@@ -141,8 +210,16 @@ template <typename T> __device__ void elementwise_abs(uint32_t N, T *a, T *b)
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_mult(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i]*b[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_mult_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i]*b[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_mult(uint32_t N, T *a, T *b, T *c)
+{ elementwise_mult_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise subtraction: `c = a - b`.
@@ -155,8 +232,16 @@ template <typename T> __device__ void elementwise_mult(uint32_t N, T *a, T *b, T
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_sub(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] - b[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_sub_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i] - b[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_sub(uint32_t N, T *a, T *b, T *c)
+{ elementwise_sub_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise addition: `c = a + b`.
@@ -169,8 +254,16 @@ template <typename T> __device__ void elementwise_sub(uint32_t N, T *a, T *b, T 
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_add(uint32_t N, T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] + b[i]; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_add_impl(Bar bar, uint32_t N, T *a, T *b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i] + b[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_add(uint32_t N, T *a, T *b, T *c)
+{ elementwise_add_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise scalar multiply: `c = a * b`.
@@ -183,8 +276,16 @@ template <typename T> __device__ void elementwise_add(uint32_t N, T *a, T *b, T 
  * @param b  Scalar multiplier.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_mult_scalar(uint32_t N, T *a, T b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i]*b; }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_mult_scalar_impl(Bar bar, uint32_t N, T *a, T b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = a[i]*b;
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_mult_scalar(uint32_t N, T *a, T b, T *c)
+{ elementwise_mult_scalar_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise maximum against a scalar: `c = max(a, b)`.
@@ -197,8 +298,16 @@ template <typename T> __device__ void elementwise_mult_scalar(uint32_t N, T *a, 
  * @param b  Scalar lower bound.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_max_scalar(uint32_t N, T *a, T b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = max(a[i], b); }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_max_scalar_impl(Bar bar, uint32_t N, T *a, T b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = max(a[i], b);
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_max_scalar(uint32_t N, T *a, T b, T *c)
+{ elementwise_max_scalar_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise minimum against a scalar: `c = min(a, b)`.
@@ -211,8 +320,16 @@ template <typename T> __device__ void elementwise_max_scalar(uint32_t N, T *a, T
  * @param b  Scalar upper bound.
  * @param c  Output vector of length `N`.
  */
-template <typename T> __device__ void elementwise_min_scalar(uint32_t N, T *a, T b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = min(a[i], b); }
+// shared body
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void elementwise_min_scalar_impl(Bar bar, uint32_t N, T *a, T b, T *c)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < N; i += size) c[i] = min(a[i], b);
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+template <typename T, bool TRAILING_SYNC = true> __device__ void elementwise_min_scalar(uint32_t N, T *a, T b, T *c)
+{ elementwise_min_scalar_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 // compile-time size overloads
 /**
@@ -226,8 +343,8 @@ template <typename T> __device__ void elementwise_min_scalar(uint32_t N, T *a, T
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T, uint32_t N> __device__ void elementwise_max(T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = max(a[i], b[i]); }
+template <typename T, uint32_t N, bool TRAILING_SYNC = true> __device__ void elementwise_max(T *a, T *b, T *c)
+{ elementwise_max_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise minimum: `c = min(a, b)`, compile-time size.
@@ -240,8 +357,8 @@ template <typename T, uint32_t N> __device__ void elementwise_max(T *a, T *b, T 
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T, uint32_t N> __device__ void elementwise_min(T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = min(a[i], b[i]); }
+template <typename T, uint32_t N, bool TRAILING_SYNC = true> __device__ void elementwise_min(T *a, T *b, T *c)
+{ elementwise_min_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise absolute value: `b = |a|`, compile-time size.
@@ -253,8 +370,8 @@ template <typename T, uint32_t N> __device__ void elementwise_min(T *a, T *b, T 
  * @param a  Input vector of length `N`.
  * @param b  Output vector of length `N`.
  */
-template <typename T, uint32_t N> __device__ void elementwise_abs(T *a, T *b)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) b[i] = abs(a[i]); }
+template <typename T, uint32_t N, bool TRAILING_SYNC = true> __device__ void elementwise_abs(T *a, T *b)
+{ elementwise_abs_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b); }
 
 /**
  * @brief Element-wise (Hadamard) product: `c = a ⊙ b`, compile-time size.
@@ -267,8 +384,8 @@ template <typename T, uint32_t N> __device__ void elementwise_abs(T *a, T *b)
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T, uint32_t N> __device__ void elementwise_mult(T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i]*b[i]; }
+template <typename T, uint32_t N, bool TRAILING_SYNC = true> __device__ void elementwise_mult(T *a, T *b, T *c)
+{ elementwise_mult_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise subtraction: `c = a - b`, compile-time size.
@@ -281,8 +398,8 @@ template <typename T, uint32_t N> __device__ void elementwise_mult(T *a, T *b, T
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T, uint32_t N> __device__ void elementwise_sub(T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] - b[i]; }
+template <typename T, uint32_t N, bool TRAILING_SYNC = true> __device__ void elementwise_sub(T *a, T *b, T *c)
+{ elementwise_sub_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }
 
 /**
  * @brief Element-wise addition: `c = a + b`, compile-time size.
@@ -295,7 +412,5 @@ template <typename T, uint32_t N> __device__ void elementwise_sub(T *a, T *b, T 
  * @param b  Input vector of length `N`.
  * @param c  Output vector of length `N`.
  */
-template <typename T, uint32_t N> __device__ void elementwise_add(T *a, T *b, T *c)
-{ _GLASS_RS for (uint32_t i = rank; i < N; i += size) c[i] = a[i] + b[i]; }
-
-#undef _GLASS_RS
+template <typename T, uint32_t N, bool TRAILING_SYNC = true> __device__ void elementwise_add(T *a, T *b, T *c)
+{ elementwise_add_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a, b, c); }

--- a/src/base/L1/iamax.cuh
+++ b/src/base/L1/iamax.cuh
@@ -45,7 +45,7 @@ __device__ __forceinline__ void combine(T &key, uint32_t &idx, T ckey, uint32_t 
  *
  * @par Scratch sizing
  * This variant uses no shared scratch (a serial pass on thread 0). For the
- * warp-shuffle `high_speed::` variant size scratch via `iamax_hs_temp_size`.
+ * warp-shuffle `high_speed::` variant size scratch via `iamax_hs_scratch_bytes`.
  *
  * The routine ends on a trailing `__syncthreads()`, so `out[0]` is block-visible
  * on return.
@@ -54,15 +54,15 @@ __device__ __forceinline__ void combine(T &key, uint32_t &idx, T ckey, uint32_t 
  * @param n    Number of elements.
  * @param x    Read-only input vector of length `n` (not modified).
  * @param out  Output: `out[0]` receives the argmax index.
- * @param s_temp  Shared scratch of `iamax_temp_size` elements (key + index lanes).
+ * @param s_scratch  Shared scratch of `iamax_scratch_bytes` elements (key + index lanes).
  */
-template <typename T>
-__device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *s_temp) {
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *s_scratch) {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    // s_temp layout: [0..size) abs-keys, then index lanes packed after.
-    T *s_key = s_temp;
-    uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_temp + size);
+    // s_scratch layout: [0..size) abs-keys, then index lanes packed after.
+    T *s_key = s_scratch;
+    uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_scratch + size);
 
     // Per-thread local argmax over the strided range (deterministic tie-break).
     T best_key = static_cast<T>(0);
@@ -85,7 +85,7 @@ __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *s_temp) {
         // All-zero (or fully inactive) vector → no element beat the (0,MAX) seed.
         out[0] = (idx == UINT32_MAX) ? 0u : idx;
     }
-    __syncthreads();
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -100,11 +100,11 @@ __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *s_temp) {
  * @tparam N  Number of elements (compile-time constant).
  * @param x    Read-only input vector of length `N` (not modified).
  * @param out  Output: `out[0]` receives the argmax index.
- * @param s_temp  Shared scratch of `iamax_temp_size` elements.
+ * @param s_scratch  Shared scratch of `iamax_scratch_bytes` elements.
  */
-template <typename T, uint32_t N>
-__device__ void iamax(const T *x, uint32_t *out, T *s_temp) {
-    iamax<T>(N, x, out, s_temp);
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
+__device__ void iamax(const T *x, uint32_t *out, T *s_scratch) {
+    iamax<T, TRAILING_SYNC>(N, x, out, s_scratch);
 }
 
 /**
@@ -119,14 +119,14 @@ __device__ void iamax(const T *x, uint32_t *out, T *s_temp) {
  * @param x        Read-only input vector of length `n` (not modified).
  * @param out      Output: `out[0]` receives the argmax index.
  * @param out_val  Output: `out_val[0]` receives `max|x|`.
- * @param s_temp   Shared scratch of `iamax_temp_size` elements.
+ * @param s_scratch   Shared scratch of `iamax_scratch_bytes` elements.
  */
-template <typename T>
-__device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *out_val, T *s_temp) {
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *out_val, T *s_scratch) {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    T *s_key = s_temp;
-    uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_temp + size);
+    T *s_key = s_scratch;
+    uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_scratch + size);
 
     T best_key = static_cast<T>(0);
     uint32_t best_idx = UINT32_MAX;
@@ -147,7 +147,7 @@ __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *out_val, T *s_te
         out[0] = (idx == UINT32_MAX) ? 0u : idx;
         out_val[0] = key;
     }
-    __syncthreads();
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -161,46 +161,45 @@ __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *out_val, T *s_te
  * @param x        Read-only input vector of length `N` (not modified).
  * @param out      Output: `out[0]` receives the argmax index.
  * @param out_val  Output: `out_val[0]` receives `max|x|`.
- * @param s_temp   Shared scratch of `iamax_temp_size` elements.
+ * @param s_scratch   Shared scratch of `iamax_scratch_bytes` elements.
  */
-template <typename T, uint32_t N>
-__device__ void iamax(const T *x, uint32_t *out, T *out_val, T *s_temp) {
-    iamax<T>(N, x, out, out_val, s_temp);
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
+__device__ void iamax(const T *x, uint32_t *out, T *out_val, T *s_scratch) {
+    iamax<T, TRAILING_SYNC>(N, x, out, out_val, s_scratch);
 }
 
 /**
- * @brief Shared-scratch element count for the default/`low_memory` `iamax`.
+ * @brief Shared-scratch size in bytes for the default/`low_memory` `iamax`.
  *
  * The default variant stores one abs-key (`T`) and one index (`uint32_t`) per
- * thread. Allocate `iamax_temp_size<T>(block_threads)` elements of `T` for
- * `s_temp` (the index lanes are packed into the same buffer after the keys).
+ * thread. Allocate `iamax_scratch_bytes<T>(block_threads)` bytes of `T` for
+ * `s_scratch` (the index lanes are packed into the same buffer after the keys).
  *
  * @tparam T  Scalar type.
  * @param block_threads  Number of threads in the launching block.
- * @return Element count (of `T`) to allocate for `s_temp`.
+ * @return Bytes to allocate for `s_scratch`.
  */
 template <typename T>
-constexpr uint32_t iamax_temp_size(uint32_t block_threads) {
-    // size keys (T) + size indices (uint32_t), expressed in units of T.
-    return block_threads + (block_threads * sizeof(uint32_t) + sizeof(T) - 1) / sizeof(T);
+__host__ __device__ constexpr std::size_t iamax_scratch_bytes(uint32_t block_threads) {
+    return (static_cast<std::size_t>(block_threads + (block_threads * sizeof(uint32_t) + sizeof(T) - 1) / sizeof(T))) * sizeof(T);
 }
 
 /**
- * @brief Shared-scratch element count for `high_speed::iamax`.
+ * @brief Shared-scratch size in bytes for `high_speed::iamax`.
  *
  * The warp-shuffle variant reduces within each warp in registers and combines
  * across warps through scratch, needing one (key,index) slot per warp:
- * `ceil(block_threads/32)` of each. Allocate `iamax_hs_temp_size<T>(block_threads)`
- * elements of `T` for its `s_temp`.
+ * `ceil(block_threads/32)` of each. Allocate `iamax_hs_scratch_bytes<T>(block_threads)`
+ * elements of `T` for its `s_scratch`.
  *
  * @tparam T  Scalar type.
  * @param block_threads  Number of threads in the launching block.
- * @return Element count (of `T`) to allocate for the `high_speed::iamax` scratch.
+ * @return Bytes to allocate for the `high_speed::iamax` scratch.
  */
 template <typename T>
-constexpr uint32_t iamax_hs_temp_size(uint32_t block_threads) {
-    return ((block_threads + 31) / 32)
-         + (((block_threads + 31) / 32) * sizeof(uint32_t) + sizeof(T) - 1) / sizeof(T);
+__host__ __device__ constexpr std::size_t iamax_hs_scratch_bytes(uint32_t block_threads) {
+    return (static_cast<std::size_t>(((block_threads + 31) / 32)
+         + (((block_threads + 31) / 32) * sizeof(uint32_t) + sizeof(T) - 1) / sizeof(T))) * sizeof(T);
 }
 
 namespace low_memory {
@@ -218,7 +217,7 @@ namespace low_memory {
      * @param x    Read-only input vector of length `n` (not modified).
      * @param out  Output: `out[0]` receives the argmax index.
      */
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void iamax(uint32_t n, const T *x, uint32_t *out) {
         if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
             T key = static_cast<T>(0);
@@ -228,7 +227,7 @@ namespace low_memory {
             }
             out[0] = (idx == UINT32_MAX) ? 0u : idx;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -242,9 +241,9 @@ namespace low_memory {
      * @param x    Read-only input vector of length `N` (not modified).
      * @param out  Output: `out[0]` receives the argmax index.
      */
-    template <typename T, uint32_t N>
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
     __device__ void iamax(const T *x, uint32_t *out) {
-        iamax<T>(N, x, out);
+        iamax<T, TRAILING_SYNC>(N, x, out);
     }
 
     /**
@@ -259,7 +258,7 @@ namespace low_memory {
      * @param out      Output: `out[0]` receives the argmax index.
      * @param out_val  Output: `out_val[0]` receives `max|x|`.
      */
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *out_val) {
         if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0) {
             T key = static_cast<T>(0);
@@ -270,7 +269,7 @@ namespace low_memory {
             out[0] = (idx == UINT32_MAX) ? 0u : idx;
             out_val[0] = key;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -284,9 +283,9 @@ namespace low_memory {
      * @param out      Output: `out[0]` receives the argmax index.
      * @param out_val  Output: `out_val[0]` receives `max|x|`.
      */
-    template <typename T, uint32_t N>
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
     __device__ void iamax(const T *x, uint32_t *out, T *out_val) {
-        iamax<T>(N, x, out, out_val);
+        iamax<T, TRAILING_SYNC>(N, x, out, out_val);
     }
 }
 
@@ -296,7 +295,7 @@ namespace high_speed {
      *
      * Each thread forms a strided per-thread argmax in registers, the warp folds
      * it with `__shfl_down_sync` (carrying the (key,index) pair), and the per-warp
-     * winners are combined through `s_temp`. Non-destructive. NumPy equivalent:
+     * winners are combined through `s_scratch`. Non-destructive. NumPy equivalent:
      * `int(np.argmax(np.abs(x)))`.
      *
      * @par Tie-break / NaN
@@ -305,22 +304,22 @@ namespace high_speed {
      * exclude NaN in tests). All-zero vector → index `0`.
      *
      * @par Scratch
-     * `s_temp` must hold `iamax_hs_temp_size<T>(blockDim)` elements (one (key,index)
+     * `s_scratch` must hold `iamax_hs_scratch_bytes<T>(blockDim)` elements (one (key,index)
      * slot per warp). Ends on a trailing `__syncthreads()`.
      *
      * @tparam T  Scalar type (e.g. `float`, `double`).
      * @param n       Number of elements.
      * @param x       Read-only input vector of length `n` (not modified).
      * @param out     Output: `out[0]` receives the argmax index.
-     * @param s_temp  Shared scratch sized by `iamax_hs_temp_size<T>(blockDim)`.
+     * @param s_scratch  Shared scratch sized by `iamax_hs_scratch_bytes<T>(blockDim)`.
      */
-    template <typename T>
-    __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *s_temp) {
+    template <typename T, bool TRAILING_SYNC = true>
+    __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *s_scratch) {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
         uint32_t size = blockDim.x * blockDim.y * blockDim.z;
         uint32_t nw = (size + 31) / 32;
-        T *s_key = s_temp;
-        uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_temp + nw);
+        T *s_key = s_scratch;
+        uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_scratch + nw);
 
         // Per-thread strided argmax.
         T key = static_cast<T>(0);
@@ -349,24 +348,24 @@ namespace high_speed {
             }
             if (rank == 0) out[0] = (idx == UINT32_MAX) ? 0u : idx;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
      * @brief i_amax, warp-shuffle variant, compile-time size.
      *
      * Compile-time-`N` overload of the warp-shuffle i_amax. NumPy equivalent:
-     * `int(np.argmax(np.abs(x)))`. Scratch via `iamax_hs_temp_size<T>(blockDim)`.
+     * `int(np.argmax(np.abs(x)))`. Scratch via `iamax_hs_scratch_bytes<T>(blockDim)`.
      *
      * @tparam T  Scalar type (e.g. `float`, `double`).
      * @tparam N  Number of elements (compile-time constant).
      * @param x       Read-only input vector of length `N` (not modified).
      * @param out     Output: `out[0]` receives the argmax index.
-     * @param s_temp  Shared scratch sized by `iamax_hs_temp_size<T>(blockDim)`.
+     * @param s_scratch  Shared scratch sized by `iamax_hs_scratch_bytes<T>(blockDim)`.
      */
-    template <typename T, uint32_t N>
-    __device__ void iamax(const T *x, uint32_t *out, T *s_temp) {
-        iamax<T>(N, x, out, s_temp);
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
+    __device__ void iamax(const T *x, uint32_t *out, T *s_scratch) {
+        iamax<T, TRAILING_SYNC>(N, x, out, s_scratch);
     }
 
     /**
@@ -380,15 +379,15 @@ namespace high_speed {
      * @param x        Read-only input vector of length `n` (not modified).
      * @param out      Output: `out[0]` receives the argmax index.
      * @param out_val  Output: `out_val[0]` receives `max|x|`.
-     * @param s_temp   Shared scratch sized by `iamax_hs_temp_size<T>(blockDim)`.
+     * @param s_scratch   Shared scratch sized by `iamax_hs_scratch_bytes<T>(blockDim)`.
      */
-    template <typename T>
-    __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *out_val, T *s_temp) {
+    template <typename T, bool TRAILING_SYNC = true>
+    __device__ void iamax(uint32_t n, const T *x, uint32_t *out, T *out_val, T *s_scratch) {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
         uint32_t size = blockDim.x * blockDim.y * blockDim.z;
         uint32_t nw = (size + 31) / 32;
-        T *s_key = s_temp;
-        uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_temp + nw);
+        T *s_key = s_scratch;
+        uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_scratch + nw);
 
         T key = static_cast<T>(0);
         uint32_t idx = UINT32_MAX;
@@ -414,7 +413,7 @@ namespace high_speed {
             }
             if (rank == 0) { out[0] = (idx == UINT32_MAX) ? 0u : idx; out_val[0] = key; }
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -428,11 +427,11 @@ namespace high_speed {
      * @param x        Read-only input vector of length `N` (not modified).
      * @param out      Output: `out[0]` receives the argmax index.
      * @param out_val  Output: `out_val[0]` receives `max|x|`.
-     * @param s_temp   Shared scratch sized by `iamax_hs_temp_size<T>(blockDim)`.
+     * @param s_scratch   Shared scratch sized by `iamax_hs_scratch_bytes<T>(blockDim)`.
      */
-    template <typename T, uint32_t N>
-    __device__ void iamax(const T *x, uint32_t *out, T *out_val, T *s_temp) {
-        iamax<T>(N, x, out, out_val, s_temp);
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
+    __device__ void iamax(const T *x, uint32_t *out, T *out_val, T *s_scratch) {
+        iamax<T, TRAILING_SYNC>(N, x, out, out_val, s_scratch);
     }
 }
 

--- a/src/base/L1/ident.cuh
+++ b/src/base/L1/ident.cuh
@@ -1,5 +1,18 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
+
+// shared body: write the n×n identity (column-major)
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void loadIdentity_impl(Bar bar, uint32_t n, T *A)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n*n; i += size) {
+        uint32_t r = i % n, c = i / n;
+        A[i] = static_cast<T>(r == c);
+    }
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
 
 /**
  * @brief Load the identity matrix: `A = I_n` (column-major).
@@ -11,15 +24,20 @@
  * @param n  Matrix dimension (number of rows/columns).
  * @param A  Output matrix of `n*n` elements (column-major).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void loadIdentity(uint32_t n, T *A)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n*n; i += size) {
-        uint32_t r = i % n, c = i / n;
-        A[i] = static_cast<T>(r == c);
-    }
+    loadIdentity_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, A);
+}
+
+// shared body: add a scaled identity to the diagonal `A += alpha*I`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void addI_impl(Bar bar, uint32_t n, T *A, T alpha)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n*n; i += size)
+        if (i % n == i / n) A[i] += alpha;
+    if constexpr (TRAILING_SYNC) bar.sync();
 }
 
 /**
@@ -33,13 +51,10 @@ __device__ void loadIdentity(uint32_t n, T *A)
  * @param A      In/out matrix of `n*n` elements (column-major).
  * @param alpha  Scalar added to each diagonal entry.
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void addI(uint32_t n, T *A, T alpha)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n*n; i += size)
-        if (i % n == i / n) A[i] += alpha;
+    addI_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, A, alpha);
 }
 
 /**
@@ -51,15 +66,10 @@ __device__ void addI(uint32_t n, T *A, T alpha)
  * @tparam N  Matrix dimension (compile-time constant).
  * @param A  Output matrix of `N*N` elements (column-major).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void loadIdentity(T *A)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N*N; i += size) {
-        uint32_t r = i % N, c = i / N;
-        A[i] = static_cast<T>(r == c);
-    }
+    loadIdentity_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, A);
 }
 
 /**
@@ -72,13 +82,22 @@ __device__ void loadIdentity(T *A)
  * @param A      In/out matrix of `N*N` elements (column-major).
  * @param alpha  Scalar added to each diagonal entry.
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void addI(T *A, T alpha)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N*N; i += size)
-        if (i % N == i / N) A[i] += alpha;
+    addI_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, A, alpha);
+}
+
+// shared body: add a scaled identity to the leading diagonal block
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void addI_partial_impl(Bar bar, uint32_t n, T *A, T alpha, uint32_t diag_count)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n*n; i += size) {
+        uint32_t r = i % n, c = i / n;
+        if (r == c && r < diag_count) A[i] += alpha;
+    }
+    if constexpr (TRAILING_SYNC) bar.sync();
 }
 
 /**
@@ -96,15 +115,10 @@ __device__ void addI(T *A, T alpha)
  * @param alpha       Scalar added to each of the leading diagonal entries.
  * @param diag_count  Number of leading diagonal entries to bump (`<= n`).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void addI_partial(uint32_t n, T *A, T alpha, uint32_t diag_count)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n*n; i += size) {
-        uint32_t r = i % n, c = i / n;
-        if (r == c && r < diag_count) A[i] += alpha;
-    }
+    addI_partial_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, A, alpha, diag_count);
 }
 
 /**
@@ -119,13 +133,8 @@ __device__ void addI_partial(uint32_t n, T *A, T alpha, uint32_t diag_count)
  * @param A      In/out matrix of `N*N` elements (column-major).
  * @param alpha  Scalar added to each of the leading diagonal entries.
  */
-template <typename T, uint32_t N, uint32_t DIAG_COUNT>
+template <typename T, uint32_t N, uint32_t DIAG_COUNT, bool TRAILING_SYNC = true>
 __device__ void addI_partial(T *A, T alpha)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N*N; i += size) {
-        uint32_t r = i % N, c = i / N;
-        if (r == c && r < DIAG_COUNT) A[i] += alpha;
-    }
+    addI_partial_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, A, alpha, DIAG_COUNT);
 }

--- a/src/base/L1/infnorm.cuh
+++ b/src/base/L1/infnorm.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
 
 /**
@@ -12,11 +13,13 @@
  * @param n  Number of elements.
  * @param x  In/out vector of length `n`; the result lands in `x[0]`.
  */
-template <typename T>
-__device__ void infnorm(uint32_t n, T *x)
+// Shared body: max|x[i]| via halving reduce; result in x[0]. Barrier policy
+// supplies rank/size + internal/trailing sync, shared by glass:: and cgrps::.
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void infnorm_impl(Bar bar, uint32_t n, T *x)
 {
-    uint32_t ind = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t stride = blockDim.x * blockDim.y * blockDim.z;
+    uint32_t ind = bar.rank();
+    uint32_t stride = bar.size();
     uint32_t left = n;
     bool odd;
     while (left > 3) {
@@ -25,9 +28,16 @@ __device__ void infnorm(uint32_t n, T *x)
         for (uint32_t i = ind; i < left; i += stride)
             x[i] = max(abs(x[i]), abs(x[i + left]));
         if (ind == 0 && odd) x[0] = max(abs(x[0]), abs(x[2*left]));
-        __syncthreads();
+        bar.sync();
     }
     if (ind == 0) { for (uint32_t i = 1; i < left; i++) x[0] = max(abs(x[0]), abs(x[i])); }
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void infnorm(uint32_t n, T *x)
+{
+    infnorm_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, x);
 }
 
 /**
@@ -40,20 +50,8 @@ __device__ void infnorm(uint32_t n, T *x)
  * @tparam N  Number of elements (compile-time constant).
  * @param x  In/out vector of length `N`; the result lands in `x[0]`.
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void infnorm(T *x)
 {
-    uint32_t ind = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t stride = blockDim.x * blockDim.y * blockDim.z;
-    uint32_t left = N;
-    bool odd;
-    while (left > 3) {
-        odd = left % 2;
-        left = (left - odd) / 2;
-        for (uint32_t i = ind; i < left; i += stride)
-            x[i] = max(abs(x[i]), abs(x[i + left]));
-        if (ind == 0 && odd) x[0] = max(abs(x[0]), abs(x[2*left]));
-        __syncthreads();
-    }
-    if (ind == 0) { for (uint32_t i = 1; i < left; i++) x[0] = max(abs(x[0]), abs(x[i])); }
+    infnorm_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, x);
 }

--- a/src/base/L1/norm.cuh
+++ b/src/base/L1/norm.cuh
@@ -16,7 +16,7 @@ namespace low_memory {
      * @param a    Input vector of length `N`.
      * @param out  Length-`N` scratch/output buffer; the result lands in `out[0]`.
      */
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void vector_norm(uint32_t N, T *a, T *out)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -27,7 +27,7 @@ namespace low_memory {
             for (uint32_t i = 1; i < N; i++) out[0] += out[i];
             out[0] = sqrtf(out[0]);
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 }
 
@@ -45,7 +45,7 @@ namespace high_speed {
      * @param out        Output buffer; the result lands in `out[0]`.
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void vector_norm(uint32_t N, T *a, T *out, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -62,7 +62,7 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) out[0] = sqrtf(val);
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -77,7 +77,7 @@ namespace high_speed {
      * @param out        Output buffer; the result lands in `out[0]`.
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
-    template <typename T, uint32_t N>
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
     __device__ void vector_norm(T *a, T *out, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -94,6 +94,6 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) out[0] = sqrtf(val);
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 }

--- a/src/base/L1/nrm1_diff.cuh
+++ b/src/base/L1/nrm1_diff.cuh
@@ -1,0 +1,159 @@
+#pragma once
+#include <cstdint>
+#include <math.h>
+
+/**
+ * @file nrm1_diff.cuh
+ * @brief 1-norm of a difference: `‖x − y‖₁ = Σ|x[i] − y[i]|`.
+ *
+ * The `asum` sibling for a difference — the residual/convergence check GATO's
+ * Schur loop wants without materializing `x − y` first. Inputs are read-only
+ * (non-destructive). Block forms mirror `asum.cuh` (`low_memory` serial-tail and
+ * `high_speed` warp-shuffle); `warp::nrm1_diff` mirrors `warp::dot` (returns the
+ * scalar broadcast to every lane). Thread-count invariant.
+ */
+
+namespace low_memory {
+    /**
+     * @brief `out[0] = Σ|x[i] − y[i]|` (‖x−y‖₁), low-memory variant.
+     *
+     * Writes the per-element absolute differences into `out`, then thread 0
+     * serially accumulates them into `out[0]`. `x`/`y` are untouched. NumPy
+     * equivalent: `np.sum(np.abs(x - y))`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @param n    Number of elements.
+     * @param x    Input vector of length `n` (read-only).
+     * @param y    Input vector of length `n` (read-only).
+     * @param out  Length-`n` scratch/output buffer; the result lands in `out[0]`.
+     */
+    template <typename T, bool TRAILING_SYNC = true>
+    __device__ void nrm1_diff(uint32_t n, const T *x, const T *y, T *out)
+    {
+        uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+        uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+        for (uint32_t i = rank; i < n; i += size) out[i] = abs(x[i] - y[i]);
+        __syncthreads();
+        if (rank == 0) { for (uint32_t i = 1; i < n; i++) out[0] += out[i]; }
+        if constexpr (TRAILING_SYNC) __syncthreads();
+    }
+}
+
+namespace high_speed {
+    /**
+     * @brief `out[0] = Σ|x[i] − y[i]|` (‖x−y‖₁), warp-shuffle variant.
+     *
+     * Reduces the absolute differences with a warp-shuffle reduction plus an
+     * inter-warp reduction through shared scratch; the result lands in `out[0]`.
+     * `x`/`y` are untouched. NumPy equivalent: `np.sum(np.abs(x - y))`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @param n          Number of elements.
+     * @param x          Input vector of length `n` (read-only).
+     * @param y          Input vector of length `n` (read-only).
+     * @param out        Output; the result lands in `out[0]`.
+     * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
+     */
+    template <typename T, bool TRAILING_SYNC = true>
+    __device__ void nrm1_diff(uint32_t n, const T *x, const T *y, T *out, T *s_scratch)
+    {
+        uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+        uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+        T val = static_cast<T>(0);
+        for (uint32_t i = rank; i < n; i += size) val += abs(x[i] - y[i]);
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
+        uint32_t lane = rank & 31, warp = rank >> 5;
+        if (lane == 0) s_scratch[warp] = val;
+        __syncthreads();
+        uint32_t nw = (size + 31) / 32;
+        if (rank < 32) {
+            val = (rank < nw) ? s_scratch[rank] : static_cast<T>(0);
+            for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
+            if (rank == 0) out[0] = val;
+        }
+        if constexpr (TRAILING_SYNC) __syncthreads();
+    }
+
+    /**
+     * @brief `out[0] = Σ|x[i] − y[i]|` (‖x−y‖₁), warp-shuffle, compile-time size.
+     *
+     * Compile-time-`N` overload of the warp-shuffle `nrm1_diff`. `x`/`y` untouched.
+     * NumPy equivalent: `np.sum(np.abs(x - y))`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @tparam N  Number of elements (compile-time constant).
+     * @param x          Input vector of length `N` (read-only).
+     * @param y          Input vector of length `N` (read-only).
+     * @param out        Output; the result lands in `out[0]`.
+     * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
+     */
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
+    __device__ void nrm1_diff(const T *x, const T *y, T *out, T *s_scratch)
+    {
+        uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+        uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+        T val = static_cast<T>(0);
+        for (uint32_t i = rank; i < N; i += size) val += abs(x[i] - y[i]);
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
+        uint32_t lane = rank & 31, warp = rank >> 5;
+        if (lane == 0) s_scratch[warp] = val;
+        __syncthreads();
+        uint32_t nw = (size + 31) / 32;
+        if (rank < 32) {
+            val = (rank < nw) ? s_scratch[rank] : static_cast<T>(0);
+            for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
+            if (rank == 0) out[0] = val;
+        }
+        if constexpr (TRAILING_SYNC) __syncthreads();
+    }
+}
+
+namespace warp {
+    /**
+     * @brief `‖x − y‖₁` within one warp: returns `Σ|x[i] − y[i]|` on every lane.
+     *
+     * One 32-lane warp forms the absolute differences and reduces with
+     * `__shfl_down_sync`, then BROADCASTS the scalar total back to all 32 lanes via
+     * `__shfl_sync` (from a register, never a shared re-read — immune to the
+     * `__restrict__` stale-cache miscompile). `x`/`y` untouched; no shared scratch,
+     * no `__syncthreads`. Full 32 lanes required; independent warps may run distinct
+     * problems concurrently. NumPy equivalent: `np.sum(np.abs(x - y))`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @param n  Number of elements.
+     * @param x  Input vector of length `n` (read-only).
+     * @param y  Input vector of length `n` (read-only).
+     * @return `‖x − y‖₁`, identical on every lane.
+     */
+    template <typename T>
+    __device__ T nrm1_diff(uint32_t n, const T *x, const T *y)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < n; i += 32) val += abs(x[i] - y[i]);
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffffu, val, off);
+        return __shfl_sync(0xffffffffu, val, 0);
+    }
+
+    /**
+     * @brief `‖x − y‖₁` within one warp, compile-time size (returns it on every lane).
+     *
+     * Compile-time-`N` overload of the single-warp `nrm1_diff`. No shared scratch,
+     * no `__syncthreads`. NumPy equivalent: `np.sum(np.abs(x - y))`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @tparam N  Number of elements (compile-time constant).
+     * @param x  Input vector of length `N` (read-only).
+     * @param y  Input vector of length `N` (read-only).
+     * @return `‖x − y‖₁`, identical on every lane.
+     */
+    template <typename T, uint32_t N>
+    __device__ T nrm1_diff(const T *x, const T *y)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < N; i += 32) val += abs(x[i] - y[i]);
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffffu, val, off);
+        return __shfl_sync(0xffffffffu, val, 0);
+    }
+}

--- a/src/base/L1/nrm2.cuh
+++ b/src/base/L1/nrm2.cuh
@@ -3,6 +3,23 @@
 #include <math.h>
 #include "reduce.cuh"
 
+// Shared body: ‖x‖₂ via square-in-place + halving reduce + sqrt; result in x[0].
+// The shared engine for the cgrps:: plain nrm2 (the block surface intentionally
+// exposes only the low_memory/high_speed/warp variants). Barrier policy supplies
+// rank/size + the internal/trailing sync. The inner reduce skips its trailing
+// barrier (rank 0 already holds the sum for the sqrt); the one trailing barrier
+// rides on TRAILING_SYNC.
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void nrm2_impl(Bar bar, uint32_t n, T *x)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) x[i] *= x[i];
+    bar.sync();
+    reduce_impl<Bar, T, false>(bar, n, x);
+    if (rank == 0) x[0] = sqrtf(x[0]);
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+
 namespace low_memory {
     /**
      * @brief Euclidean (L2) norm: `x[0] = ‖x‖₂` (in-place, destructive), low-memory variant.
@@ -15,8 +32,8 @@ namespace low_memory {
      * @param n  Number of elements.
      * @param x  In/out vector of length `n`; the result lands in `x[0]`.
      */
-    template <typename T>
-    __device__ void l2norm(uint32_t n, T *x)
+    template <typename T, bool TRAILING_SYNC = true>
+    __device__ void nrm2(uint32_t n, T *x)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
         uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -26,7 +43,7 @@ namespace low_memory {
             for (uint32_t i = 1; i < n; i++) x[0] += x[i];
             x[0] = sqrtf(x[0]);
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 }
 
@@ -43,8 +60,8 @@ namespace high_speed {
      * @param x          In/out vector of length `n`; the result lands in `x[0]`.
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
-    template <typename T>
-    __device__ void l2norm(uint32_t n, T *x, T *s_scratch)
+    template <typename T, bool TRAILING_SYNC = true>
+    __device__ void nrm2(uint32_t n, T *x, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
         uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -60,7 +77,7 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) x[0] = sqrtf(val);
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -74,8 +91,8 @@ namespace high_speed {
      * @param x          In/out vector of length `N`; the result lands in `x[0]`.
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
-    template <typename T, uint32_t N>
-    __device__ void l2norm(T *x, T *s_scratch)
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
+    __device__ void nrm2(T *x, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
         uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -91,6 +108,56 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) x[0] = sqrtf(val);
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
+    }
+}
+
+namespace warp {
+    /**
+     * @brief Euclidean (L2) norm within one warp: returns `‖x‖₂` on every lane.
+     *
+     * Single-warp L2 norm, mirroring `warp::dot`: one 32-lane warp reduces the
+     * per-lane sum-of-squares with `__shfl_down_sync`, BROADCASTS the total to all
+     * 32 lanes via `__shfl_sync` (from a register — immune to the `__restrict__`
+     * stale-cache miscompile), and each lane takes the square root. Non-destructive
+     * (`x` untouched), no shared scratch, no `__syncthreads`; uses type-generic
+     * `sqrt` (correct for `double`, unlike the block `sqrtf` forms). Full 32 lanes
+     * required. NumPy equivalent: `np.linalg.norm(x)`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @param n  Number of elements.
+     * @param x  Input vector of length `n` (read-only).
+     * @return `‖x‖₂`, identical on every lane.
+     */
+    template <typename T>
+    __device__ T nrm2(uint32_t n, const T *x)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < n; i += 32) val += x[i]*x[i];
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffffu, val, off);
+        return sqrt(__shfl_sync(0xffffffffu, val, 0));
+    }
+
+    /**
+     * @brief Euclidean (L2) norm within one warp, compile-time size (returns it on every lane).
+     *
+     * Compile-time-`N` overload of the single-warp L2 norm. Non-destructive, no
+     * shared scratch, no `__syncthreads`; type-generic `sqrt`. NumPy equivalent:
+     * `np.linalg.norm(x)`.
+     *
+     * @tparam T  Scalar type (e.g. `float`, `double`).
+     * @tparam N  Number of elements (compile-time constant).
+     * @param x  Input vector of length `N` (read-only).
+     * @return `‖x‖₂`, identical on every lane.
+     */
+    template <typename T, uint32_t N>
+    __device__ T nrm2(const T *x)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        T val = static_cast<T>(0);
+        for (uint32_t i = lane; i < N; i += 32) val += x[i]*x[i];
+        for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffffu, val, off);
+        return sqrt(__shfl_sync(0xffffffffu, val, 0));
     }
 }

--- a/src/base/L1/prefix_sum.cuh
+++ b/src/base/L1/prefix_sum.cuh
@@ -13,7 +13,7 @@
  * @param s_output  Output scan buffer of length `n` (in shared memory).
  * @param n         Number of elements (must not exceed `blockDim.x`).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void prefix_sum_exclusive(T *s_input, T *s_output, int n)
 {
     int tid = threadIdx.x;
@@ -26,6 +26,7 @@ __device__ void prefix_sum_exclusive(T *s_input, T *s_output, int n)
         __syncthreads();
         if (tid < n && tid >= d) s_output[tid] = tmp;
     }
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -39,7 +40,7 @@ __device__ void prefix_sum_exclusive(T *s_input, T *s_output, int n)
  * @param s_output  Output scan buffer of length `n` (in shared memory).
  * @param n         Number of elements (must not exceed `blockDim.x`).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void prefix_sum_inclusive(T *s_input, T *s_output, int n)
 {
     int tid = threadIdx.x;
@@ -52,4 +53,5 @@ __device__ void prefix_sum_inclusive(T *s_input, T *s_output, int n)
         __syncthreads();
         if (tid < n && tid >= d) s_output[tid] = tmp;
     }
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }

--- a/src/base/L1/reduce.cuh
+++ b/src/base/L1/reduce.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
 
 /**
@@ -12,21 +13,31 @@
  * @param n  Number of elements.
  * @param x  In/out vector of length `n`; the sum lands in `x[0]`.
  */
-// default threadIdx-based halving reduce; result in x[0]
-template <typename T>
-__device__ void reduce(uint32_t n, T *x)
+// Shared body: default halving (tree) reduce; result in x[0]. The barrier policy
+// supplies rank/size + the internal AND trailing sync, so the plain glass:: and
+// the cgrps:: surfaces share this one body. TRAILING_SYNC (default true) makes
+// x[0] valid for ALL threads; pass false when the caller owns the next barrier.
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void reduce_impl(Bar bar, uint32_t n, T *x)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    uint32_t rank = bar.rank(), size = bar.size();
     uint32_t left = n;
     while (left > 3) {
         bool odd = left % 2;
         left = (left - odd) / 2;
         for (uint32_t i = rank; i < left; i += size) x[i] += x[i + left];
         if (rank == 0 && odd) x[0] += x[2*left];
-        __syncthreads();
+        bar.sync();
     }
     if (rank == 0) { for (uint32_t i = 1; i < left; i++) x[0] += x[i]; }
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+
+// default threadIdx-based halving reduce; result in x[0]
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void reduce(uint32_t n, T *x)
+{
+    reduce_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, x);
 }
 
 /**
@@ -38,20 +49,10 @@ __device__ void reduce(uint32_t n, T *x)
  * @tparam N  Number of elements (compile-time constant).
  * @param x  In/out vector of length `N`; the sum lands in `x[0]`.
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void reduce(T *x)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    uint32_t left = N;
-    while (left > 3) {
-        bool odd = left % 2;
-        left = (left - odd) / 2;
-        for (uint32_t i = rank; i < left; i += size) x[i] += x[i + left];
-        if (rank == 0 && odd) x[0] += x[2*left];
-        __syncthreads();
-    }
-    if (rank == 0) { for (uint32_t i = 1; i < left; i++) x[0] += x[i]; }
+    reduce_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, x);
 }
 
 namespace low_memory {
@@ -65,12 +66,12 @@ namespace low_memory {
      * @param n  Number of elements.
      * @param x  In/out vector of length `n`; the sum lands in `x[0]`.
      */
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void reduce(uint32_t n, T *x)
     {
         if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0)
             for (uint32_t i = 1; i < n; i++) x[0] += x[i];
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -83,16 +84,30 @@ namespace low_memory {
      * @tparam N  Number of elements (compile-time constant).
      * @param x  In/out vector of length `N`; the sum lands in `x[0]`.
      */
-    template <typename T, uint32_t N>
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
     __device__ void reduce(T *x)
     {
         if (threadIdx.x == 0 && threadIdx.y == 0 && threadIdx.z == 0)
             for (uint32_t i = 1; i < N; i++) x[0] += x[i];
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 }
 
 namespace high_speed {
+    /**
+     * @brief Shared-scratch size in bytes for the `high_speed::reduce` ops.
+     *
+     * The warp-shuffle reduce combines across warps through one scratch slot per
+     * warp: `ceil(block_threads / 32)` elements of `T`. Allocate
+     * `high_speed::reduce_scratch_bytes<T>(block_threads)` for the `s_scratch` argument.
+     *
+     * @tparam T  Scalar type.
+     * @param block_threads  Number of threads in the launching block.
+     * @return Bytes to allocate for `s_scratch`.
+     */
+    template <typename T>
+    __host__ __device__ constexpr std::size_t reduce_scratch_bytes(uint32_t block_threads) { return static_cast<std::size_t>((block_threads + 31) / 32) * sizeof(T); }
+
     /**
      * @brief Sum reduction: `x[0] = Σ x[i]` (in-place), warp-shuffle variant.
      *
@@ -106,7 +121,7 @@ namespace high_speed {
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
     // warp-shuffle + inter-warp reduce; s_scratch: ceil(blockDim/32)*sizeof(T); result in x[0]
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ void reduce(uint32_t n, T *x, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -123,7 +138,7 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) x[0] = val;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     /**
@@ -137,7 +152,7 @@ namespace high_speed {
      * @param x          In/out vector of length `N`; the sum lands in `x[0]`.
      * @param s_scratch  Shared scratch of `ceil(blockDim/32)` elements (one per warp).
      */
-    template <typename T, uint32_t N>
+    template <typename T, uint32_t N, bool TRAILING_SYNC = true>
     __device__ void reduce(T *x, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -154,7 +169,7 @@ namespace high_speed {
             for (int off = 16; off > 0; off >>= 1) val += __shfl_down_sync(0xffffffff, val, off);
             if (rank == 0) x[0] = val;
         }
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
     }
 
     // ── register-partial → block-sum overload ────────────────────────────────
@@ -186,7 +201,7 @@ namespace high_speed {
      *                   on return `s_scratch[0]` holds the total.
      * @return The block-wide total `Σ partial`, identical on every thread.
      */
-    template <typename T>
+    template <typename T, bool TRAILING_SYNC = true>
     __device__ T reduce(T partial, T *s_scratch)
     {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -204,7 +219,7 @@ namespace high_speed {
         }
         __syncthreads();
         T total = s_scratch[0];
-        __syncthreads();
+        if constexpr (TRAILING_SYNC) __syncthreads();
         return total;
     }
 }

--- a/src/base/L1/scal.cuh
+++ b/src/base/L1/scal.cuh
@@ -1,5 +1,15 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
+
+// shared body: in-place scale `x = alpha*x`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void scal_impl(Bar bar, uint32_t n, T alpha, T *x)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) x[i] = alpha*x[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
 
 /**
  * @brief Scale a vector in place: `x = alpha * x` (SCAL).
@@ -11,12 +21,19 @@
  * @param alpha  Scalar multiplier.
  * @param x      In/out vector of length `n` (overwritten with the result).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void scal(uint32_t n, T alpha, T *x)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) x[i] = alpha*x[i];
+    scal_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, alpha, x);
+}
+
+// shared body: out-of-place scale `y = alpha*x`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void scal_impl(Bar bar, uint32_t n, T alpha, T *x, T *y)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) y[i] = alpha*x[i];
+    if constexpr (TRAILING_SYNC) bar.sync();
 }
 
 /**
@@ -30,12 +47,10 @@ __device__ void scal(uint32_t n, T alpha, T *x)
  * @param x      Input vector of length `n`.
  * @param y      Output vector of length `n` (overwritten with the result).
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void scal(uint32_t n, T alpha, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) y[i] = alpha*x[i];
+    scal_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, alpha, x, y);
 }
 
 /**
@@ -48,12 +63,10 @@ __device__ void scal(uint32_t n, T alpha, T *x, T *y)
  * @param alpha  Scalar multiplier.
  * @param x      In/out vector of length `N` (overwritten with the result).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void scal(T alpha, T *x)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) x[i] = alpha*x[i];
+    scal_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, alpha, x);
 }
 
 /**
@@ -67,12 +80,10 @@ __device__ void scal(T alpha, T *x)
  * @param x      Input vector of length `N`.
  * @param y      Output vector of length `N` (overwritten with the result).
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void scal(T alpha, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) y[i] = alpha*x[i];
+    scal_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, alpha, x, y);
 }
 
 namespace warp {

--- a/src/base/L1/set_const.cuh
+++ b/src/base/L1/set_const.cuh
@@ -1,5 +1,15 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
+
+// shared body: broadcast a constant `x[i] = alpha`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void set_const_impl(Bar bar, uint32_t n, T alpha, T *x)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) x[i] = alpha;
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
 
 /**
  * @brief Fill a vector with a constant: `x[i] = alpha`.
@@ -11,12 +21,10 @@
  * @param alpha  Value to broadcast into every element.
  * @param x      Output vector of length `n`.
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void set_const(uint32_t n, T alpha, T *x)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) x[i] = alpha;
+    set_const_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, alpha, x);
 }
 
 /**
@@ -29,10 +37,8 @@ __device__ void set_const(uint32_t n, T alpha, T *x)
  * @param alpha  Value to broadcast into every element.
  * @param x      Output vector of length `N`.
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void set_const(T alpha, T *x)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) x[i] = alpha;
+    set_const_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, alpha, x);
 }

--- a/src/base/L1/swap.cuh
+++ b/src/base/L1/swap.cuh
@@ -1,5 +1,17 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
+
+// shared body: element-wise swap `x ↔ y`
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void swap_impl(Bar bar, uint32_t n, T *x, T *y)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t i = rank; i < n; i += size) {
+        T tmp = x[i]; x[i] = y[i]; y[i] = tmp;
+    }
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
 
 /**
  * @brief Swap two vectors element-wise: `x ↔ y` (SWAP).
@@ -11,14 +23,10 @@
  * @param x  In/out vector of length `n`.
  * @param y  In/out vector of length `n`.
  */
-template <typename T>
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void swap(uint32_t n, T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < n; i += size) {
-        T tmp = x[i]; x[i] = y[i]; y[i] = tmp;
-    }
+    swap_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, n, x, y);
 }
 
 /**
@@ -31,12 +39,8 @@ __device__ void swap(uint32_t n, T *x, T *y)
  * @param x  In/out vector of length `N`.
  * @param y  In/out vector of length `N`.
  */
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void swap(T *x, T *y)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N; i += size) {
-        T tmp = x[i]; x[i] = y[i]; y[i] = tmp;
-    }
+    swap_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, x, y);
 }

--- a/src/base/L1/transpose.cuh
+++ b/src/base/L1/transpose.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
 
 /**
@@ -13,17 +14,23 @@
  * @param a  Input matrix of `N*M` elements (column-major).
  * @param b  Output matrix of `M*N` elements (column-major).
  */
-// out-of-place: NxM column-major a → b
-template <typename T>
-__device__ void transpose(uint32_t N, uint32_t M, T *a, T *b)
+// shared body: out-of-place transpose NxM column-major a → b
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void transpose_impl(Bar bar, uint32_t N, uint32_t M, T *a, T *b)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    uint32_t rank = bar.rank(), size = bar.size();
     for (uint32_t i = rank; i < N*M; i += size) {
         uint32_t col = i / N, row = i % N;
         b[col + M*row] = a[row + N*col];
     }
-    __syncthreads();
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+
+// out-of-place: NxM column-major a → b
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void transpose(uint32_t N, uint32_t M, T *a, T *b)
+{
+    transpose_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, M, a, b);
 }
 
 /**
@@ -36,12 +43,11 @@ __device__ void transpose(uint32_t N, uint32_t M, T *a, T *b)
  * @param N  Matrix dimension (number of rows/columns).
  * @param a  In/out matrix of `N*N` elements (column-major).
  */
-// in-place: NxN column-major
-template <typename T>
-__device__ void transpose(uint32_t N, T *a)
+// shared body: in-place transpose NxN column-major
+template <typename Bar, typename T, bool TRAILING_SYNC = true>
+__device__ void transpose_impl(Bar bar, uint32_t N, T *a)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    uint32_t rank = bar.rank(), size = bar.size();
     for (uint32_t idx = rank; idx < N*N; idx += size) {
         uint32_t i = idx % N, j = idx / N;
         if (i < j) {
@@ -49,7 +55,14 @@ __device__ void transpose(uint32_t N, T *a)
             T tmp = a[idx]; a[idx] = a[swap]; a[swap] = tmp;
         }
     }
-    __syncthreads();
+    if constexpr (TRAILING_SYNC) bar.sync();
+}
+
+// in-place: NxN column-major
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void transpose(uint32_t N, T *a)
+{
+    transpose_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a);
 }
 
 /**
@@ -65,16 +78,10 @@ __device__ void transpose(uint32_t N, T *a)
  * @param b  Output matrix of `M*N` elements (column-major).
  */
 // compile-time out-of-place
-template <typename T, uint32_t N, uint32_t M>
+template <typename T, uint32_t N, uint32_t M, bool TRAILING_SYNC = true>
 __device__ void transpose(T *a, T *b)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t i = rank; i < N*M; i += size) {
-        uint32_t col = i / N, row = i % N;
-        b[col + M*row] = a[row + N*col];
-    }
-    __syncthreads();
+    transpose_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, M, a, b);
 }
 
 /**
@@ -88,17 +95,8 @@ __device__ void transpose(T *a, T *b)
  * @param a  In/out matrix of `N*N` elements (column-major).
  */
 // compile-time in-place NxN
-template <typename T, uint32_t N>
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void transpose(T *a)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t idx = rank; idx < N*N; idx += size) {
-        uint32_t i = idx % N, j = idx / N;
-        if (i < j) {
-            uint32_t sw = i*N + j;
-            T tmp = a[idx]; a[idx] = a[sw]; a[sw] = tmp;
-        }
-    }
-    __syncthreads();
+    transpose_impl<BlockBarrier, T, TRAILING_SYNC>(BlockBarrier{}, N, a);
 }

--- a/src/base/L2/gemv.cuh
+++ b/src/base/L2/gemv.cuh
@@ -5,7 +5,7 @@
 template <typename T, bool TRANSPOSE, bool ROW_MAJOR_A>
 __device__ void gemv_impl(uint32_t rank, uint32_t size,
                            uint32_t m, uint32_t n,
-                           T alpha, T *A, T *x, T beta, T *y)
+                           T alpha, const T *A, const T *x, T beta, T *y)
 {
     if (TRANSPOSE) {
         for (uint32_t row = rank; row < n; row += size) {
@@ -31,7 +31,7 @@ __device__ void gemv_impl(uint32_t rank, uint32_t size,
 template <typename T, bool TRANSPOSE, bool ROW_MAJOR_A>
 __device__ void gemv_impl(uint32_t rank, uint32_t size,
                            uint32_t m, uint32_t n,
-                           T alpha, T *A, T *x, T *y)
+                           T alpha, const T *A, const T *x, T *y)
 {
     if (TRANSPOSE) {
         for (uint32_t row = rank; row < n; row += size) {
@@ -64,6 +64,13 @@ __device__ void gemv_impl(uint32_t rank, uint32_t size,
  * (`A` is column-major by default). NumPy equivalent: `y = alpha*A@x + beta*y`
  * (or `alpha*A.T@x + beta*y` when transposed).
  *
+ * Unlike `gemm` — where a row-major operand is just a transpose, so the only
+ * layout flag is `ROW_MAJOR_C` — GEMV keeps a per-matrix `ROW_MAJOR` flag:
+ * `TRANSPOSE` already selects the mathematical operation (`A·x` vs `Aᵀ·x`), so it
+ * cannot also stand in for the storage order. `TRANSPOSE` and `ROW_MAJOR` are
+ * therefore independent. (This flag fully subsumes the former `gemv_ex`, which
+ * was just `gemv` with the defaults removed and has been deleted.)
+ *
  * @tparam T          Scalar type (e.g. `float`, `double`).
  * @tparam TRANSPOSE  When true, multiply by `Aᵀ` instead of `A` (default false).
  * @tparam ROW_MAJOR  When true, `A` is stored row-major (default false = column-major).
@@ -75,12 +82,13 @@ __device__ void gemv_impl(uint32_t rank, uint32_t size,
  * @param beta   Scalar multiplier on the prior `y`.
  * @param y      In/out vector (length `m`, or `n` when transposed).
  */
-template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(uint32_t m, uint32_t n, T alpha, T *A, T *x, T beta, T *y)
+template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(uint32_t m, uint32_t n, T alpha, const T *A, const T *x, T beta, T *y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
     gemv_impl<T, TRANSPOSE, ROW_MAJOR>(rank, size, m, n, alpha, A, x, beta, y);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -100,68 +108,19 @@ __device__ void gemv(uint32_t m, uint32_t n, T alpha, T *A, T *x, T beta, T *y)
  * @param x      Input vector (length `n`, or `m` when transposed).
  * @param y      Output vector (length `m`, or `n` when transposed).
  */
-template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(uint32_t m, uint32_t n, T alpha, T *A, T *x, T *y)
+template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(uint32_t m, uint32_t n, T alpha, const T *A, const T *x, T *y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
     gemv_impl<T, TRANSPOSE, ROW_MAJOR>(rank, size, m, n, alpha, A, x, y);
-}
-
-/**
- * @brief Matrix-vector product with explicit layout control: `y = alpha * A * x + beta * y` (GEMV).
- *
- * Like `gemv` but exposes the per-matrix layout flag explicitly (no defaults),
- * for callers that want full control over `TRANSPOSE` and the storage order of
- * `A`. NumPy equivalent: `y = alpha*A@x + beta*y` (or `alpha*A.T@x + beta*y`).
- *
- * @tparam T           Scalar type (e.g. `float`, `double`).
- * @tparam TRANSPOSE   When true, multiply by `Aᵀ` instead of `A`.
- * @tparam ROW_MAJOR_A When true, `A` is stored row-major.
- * @param m      Number of rows of `A`.
- * @param n      Number of columns of `A`.
- * @param alpha  Scalar multiplier on the product.
- * @param A      Input matrix of `m*n` elements.
- * @param x      Input vector (length `n`, or `m` when transposed).
- * @param beta   Scalar multiplier on the prior `y`.
- * @param y      In/out vector (length `m`, or `n` when transposed).
- */
-template <typename T, bool TRANSPOSE, bool ROW_MAJOR_A>
-__device__ void gemv_ex(uint32_t m, uint32_t n, T alpha, T *A, T *x, T beta, T *y)
-{
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemv_impl<T, TRANSPOSE, ROW_MAJOR_A>(rank, size, m, n, alpha, A, x, beta, y);
-}
-
-/**
- * @brief Matrix-vector product with explicit layout control: `y = alpha * A * x` (GEMV), no-beta overload.
- *
- * Like the full `gemv_ex` but overwrites `y` (no `beta * y` term). NumPy
- * equivalent: `y = alpha*A@x` (or `alpha*A.T@x` when transposed).
- *
- * @tparam T           Scalar type (e.g. `float`, `double`).
- * @tparam TRANSPOSE   When true, multiply by `Aᵀ` instead of `A`.
- * @tparam ROW_MAJOR_A When true, `A` is stored row-major.
- * @param m      Number of rows of `A`.
- * @param n      Number of columns of `A`.
- * @param alpha  Scalar multiplier on the product.
- * @param A      Input matrix of `m*n` elements.
- * @param x      Input vector (length `n`, or `m` when transposed).
- * @param y      Output vector (length `m`, or `n` when transposed).
- */
-template <typename T, bool TRANSPOSE, bool ROW_MAJOR_A>
-__device__ void gemv_ex(uint32_t m, uint32_t n, T alpha, T *A, T *x, T *y)
-{
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemv_impl<T, TRANSPOSE, ROW_MAJOR_A>(rank, size, m, n, alpha, A, x, y);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 // compile-time impl: M, N as template params so inner col-loop is fully unrolled
 template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE, bool ROW_MAJOR_A>
 __device__ void gemv_impl_ct(uint32_t rank, uint32_t size,
-                              T alpha, T *A, T *x, T beta, T *y)
+                              T alpha, const T *A, const T *x, T beta, T *y)
 {
     if (TRANSPOSE) {
         for (uint32_t row = rank; row < N; row += size) {
@@ -186,7 +145,7 @@ __device__ void gemv_impl_ct(uint32_t rank, uint32_t size,
 
 template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE, bool ROW_MAJOR_A>
 __device__ void gemv_impl_ct(uint32_t rank, uint32_t size,
-                              T alpha, T *A, T *x, T *y)
+                              T alpha, const T *A, const T *x, T *y)
 {
     if (TRANSPOSE) {
         for (uint32_t row = rank; row < N; row += size) {
@@ -229,12 +188,13 @@ __device__ void gemv_impl_ct(uint32_t rank, uint32_t size,
  * @param beta   Scalar multiplier on the prior `y`.
  * @param y      In/out vector (length `M`, or `N` when transposed).
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(T alpha, T *A, T *x, T beta, T *y)
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(T alpha, const T *A, const T *x, T beta, T *y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
     gemv_impl_ct<T, M, N, TRANSPOSE, ROW_MAJOR>(rank, size, alpha, A, x, beta, y);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -253,12 +213,13 @@ __device__ void gemv(T alpha, T *A, T *x, T beta, T *y)
  * @param x      Input vector (length `N`, or `M` when transposed).
  * @param y      Output vector (length `M`, or `N` when transposed).
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(T alpha, T *A, T *x, T *y)
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(T alpha, const T *A, const T *x, T *y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
     gemv_impl_ct<T, M, N, TRANSPOSE, ROW_MAJOR>(rank, size, alpha, A, x, y);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 namespace warp {
@@ -293,7 +254,7 @@ namespace warp {
      * @param y      In/out vector (length `M`, or `N` when transposed).
      */
     template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-    __device__ void gemv(T alpha, T *A, T *x, T beta, T *y)
+    __device__ void gemv(T alpha, const T *A, const T *x, T beta, T *y)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
         gemv_impl_ct<T, M, N, TRANSPOSE, ROW_MAJOR>(lane, 32u, alpha, A, x, beta, y);
@@ -319,7 +280,7 @@ namespace warp {
      * @param y      Output vector (length `M`, or `N` when transposed; overwritten).
      */
     template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-    __device__ void gemv(T alpha, T *A, T *x, T *y)
+    __device__ void gemv(T alpha, const T *A, const T *x, T *y)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
         gemv_impl_ct<T, M, N, TRANSPOSE, ROW_MAJOR>(lane, 32u, alpha, A, x, y);

--- a/src/base/L2/gemv_reduced.cuh
+++ b/src/base/L2/gemv_reduced.cuh
@@ -14,14 +14,14 @@
 
 namespace detail {
     // y[out] = alpha * sum_c A(.)·x[c] + (HAS_BETA ? beta*y[out] : 0), compile-time
-    // M×N A. TRANS=false: out=row i in [0,M), contract c over N, A[i + c*M].
-    //        TRANS=true : out=col j in [0,N), contract c over M, A[c + j*M].
-    template <typename T, uint32_t M, uint32_t N, bool TRANS, bool HAS_BETA>
+    // M×N A. TRANSPOSE=false: out=row i in [0,M), contract c over N, A[i + c*M].
+    //        TRANSPOSE=true : out=col j in [0,N), contract c over M, A[c + j*M].
+    template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE, bool HAS_BETA>
     __device__ void gemv_reduced_impl(uint32_t rank, uint32_t size,
                                       T alpha, const T* A, const T* x, T beta, T* y)
     {
-        constexpr uint32_t n_out = TRANS ? N : M;
-        constexpr uint32_t CDIM  = TRANS ? M : N;
+        constexpr uint32_t n_out = TRANSPOSE ? N : M;
+        constexpr uint32_t CDIM  = TRANSPOSE ? M : N;
         if (size < 32u) {
             for (uint32_t o = rank; o < n_out; o += size) {
                 T p[32];
@@ -29,7 +29,7 @@ namespace detail {
                 for (uint32_t vlane = 0; vlane < 32u; ++vlane) {
                     T acc = static_cast<T>(0);
                     for (uint32_t c = vlane; c < CDIM; c += 32u)
-                        acc += (TRANS ? A[c + o*M] : A[o + c*M]) * x[c];
+                        acc += (TRANSPOSE ? A[c + o*M] : A[o + c*M]) * x[c];
                     p[vlane] = acc;
                 }
                 const T res = reduced_tree32<T>(p);
@@ -43,7 +43,7 @@ namespace detail {
             for (uint32_t o = warp; o < n_out; o += n_warps) {
                 T partial = static_cast<T>(0);
                 for (uint32_t c = lane; c < CDIM; c += 32u)
-                    partial += (TRANS ? A[c + o*M] : A[o + c*M]) * x[c];
+                    partial += (TRANSPOSE ? A[c + o*M] : A[o + c*M]) * x[c];
                 const T res = warp::reduce<T>(partial);
                 if (lane == 0) y[o] = HAS_BETA ? (alpha*res + beta*y[o]) : (alpha*res);
             }
@@ -61,20 +61,20 @@ namespace detail {
  *
  * @tparam T  Scalar type.
  * @tparam M,N  A is M x N (column-major).
- * @tparam TRANS  If true, computes `Aᵀ x` (output length N, contract over M); else `A x` (length M, contract over N).
+ * @tparam TRANSPOSE  If true, computes `Aᵀ x` (output length N, contract over M); else `A x` (length M, contract over N).
  * @tparam TRAILING_SYNC  Emit a trailing `__syncthreads()` (default true).
  * @param alpha  Scalar on the product.
  * @param A      Input matrix (M x N, column-major).
- * @param x      Input vector (length N if !TRANS else M).
+ * @param x      Input vector (length N if !TRANSPOSE else M).
  * @param beta   Scalar on the existing y (read; caller must initialize it).
- * @param y      In/out result (length M if !TRANS else N).
+ * @param y      In/out result (length M if !TRANSPOSE else N).
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void gemv_reduced(T alpha, const T* A, const T* x, T beta, T* y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    detail::gemv_reduced_impl<T, M, N, TRANS, true>(rank, size, alpha, A, x, beta, y);
+    detail::gemv_reduced_impl<T, M, N, TRANSPOSE, true>(rank, size, alpha, A, x, beta, y);
     if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
@@ -83,16 +83,16 @@ __device__ void gemv_reduced(T alpha, const T* A, const T* x, T beta, T* y)
  *
  * Overwrites y (not read). Otherwise identical to the beta overload.
  *
- * @tparam T,M,N,TRANS,TRAILING_SYNC  See the beta overload.
+ * @tparam T,M,N,TRANSPOSE,TRAILING_SYNC  See the beta overload.
  * @param alpha,A,x  See the beta overload.
  * @param y  Output (overwritten).
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void gemv_reduced(T alpha, const T* A, const T* x, T* y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    detail::gemv_reduced_impl<T, M, N, TRANS, false>(rank, size, alpha, A, x, static_cast<T>(0), y);
+    detail::gemv_reduced_impl<T, M, N, TRANSPOSE, false>(rank, size, alpha, A, x, static_cast<T>(0), y);
     if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
@@ -102,29 +102,29 @@ namespace warp {
      *
      * Warp-per-problem analogue of `glass::gemv_reduced`; one full 32-lane warp.
      *
-     * @tparam T,M,N,TRANS  See glass::gemv_reduced.
+     * @tparam T,M,N,TRANSPOSE  See glass::gemv_reduced.
      * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true).
      * @param alpha,A,x,beta,y  See glass::gemv_reduced.
      */
-    template <typename T, uint32_t M, uint32_t N, bool TRANS = false, bool TRAILING_SYNC = true>
+    template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
     __device__ void gemv_reduced(T alpha, const T* A, const T* x, T beta, T* y)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        detail::gemv_reduced_impl<T, M, N, TRANS, true>(lane, 32u, alpha, A, x, beta, y);
+        detail::gemv_reduced_impl<T, M, N, TRANSPOSE, true>(lane, 32u, alpha, A, x, beta, y);
         if constexpr (TRAILING_SYNC) __syncwarp();
     }
 
     /**
      * @brief Single-warp contraction-parallel GEMV, implicit `beta = 0`: `y = alpha * op(A) * x`.
      *
-     * @tparam T,M,N,TRANS,TRAILING_SYNC  See the beta overload.
+     * @tparam T,M,N,TRANSPOSE,TRAILING_SYNC  See the beta overload.
      * @param alpha,A,x,y  See the beta overload.
      */
-    template <typename T, uint32_t M, uint32_t N, bool TRANS = false, bool TRAILING_SYNC = true>
+    template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
     __device__ void gemv_reduced(T alpha, const T* A, const T* x, T* y)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        detail::gemv_reduced_impl<T, M, N, TRANS, false>(lane, 32u, alpha, A, x, static_cast<T>(0), y);
+        detail::gemv_reduced_impl<T, M, N, TRANSPOSE, false>(lane, 32u, alpha, A, x, static_cast<T>(0), y);
         if constexpr (TRAILING_SYNC) __syncwarp();
     }
 }

--- a/src/base/L2/gemv_segmented.cuh
+++ b/src/base/L2/gemv_segmented.cuh
@@ -8,7 +8,7 @@
 // A_seg is M rows x N cols, column-major with leading dimension ROW_STRIDE
 // (A_seg[i][j] = A[seg_a_off[seg] + i + j*ROW_STRIDE]).  M, N, ROW_STRIDE are
 // compile-time so the inner column loop is fully unrolled.  This is the
-// segmented analogue of row_strided_gemv<T,M,N,ROW_STRIDE>: instead of one
+// segmented analogue of gemv_strided<T,M,N,ROW_STRIDE>: instead of one
 // matrix it walks `segments` of them, with per-segment base offsets supplied by
 // the descriptor arrays seg_a_off / seg_x_off / seg_y_off.
 //
@@ -99,7 +99,7 @@
 template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE = M,
           bool FUSE_SCALED_ADD = false, bool TRANSPOSE = false,
           bool ATOMIC_Y = false, typename IDX_T = int>
-__device__ void segmented_row_strided_gemv(
+__device__ void gemv_segmented(
     uint32_t segments,
     const IDX_T* seg_a_off, const IDX_T* seg_x_off, const IDX_T* seg_y_off,
     const T* A, const T* x, T* y, T alpha, T beta,
@@ -141,7 +141,7 @@ __device__ void segmented_row_strided_gemv(
 /**
  * @brief Segmented (batched) column-major GEMV, no-beta overload: `y_seg = alpha*A_seg*x_seg` per segment.
  *
- * No-`beta` variant of `segmented_row_strided_gemv`: each segment overwrites its
+ * No-`beta` variant of `gemv_segmented`: each segment overwrites its
  * `y_seg` (optionally plus the fused scaled-add) or computes the transpose. This
  * also serves as the `ATOMIC_Y` entry point, since atomic accumulate takes no
  * `beta` (see the full overload's note on beta-under-atomic).
@@ -172,7 +172,7 @@ __device__ void segmented_row_strided_gemv(
 template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE = M,
           bool FUSE_SCALED_ADD = false, bool TRANSPOSE = false,
           bool ATOMIC_Y = false, typename IDX_T = int>
-__device__ void segmented_row_strided_gemv(
+__device__ void gemv_segmented(
     uint32_t segments,
     const IDX_T* seg_a_off, const IDX_T* seg_x_off, const IDX_T* seg_y_off,
     const T* A, const T* x, T* y, T alpha,

--- a/src/base/L2/gemv_strided.cuh
+++ b/src/base/L2/gemv_strided.cuh
@@ -22,14 +22,14 @@
  * @tparam M           Number of rows of `A` (compile-time constant).
  * @tparam N           Number of columns of `A` (compile-time constant).
  * @tparam ROW_STRIDE  Column-major leading dimension of `A` (default `M`).
+ * @param alpha  Scalar multiplier on the product.
  * @param A      Input matrix, addressed at `A[row + col*ROW_STRIDE]`.
  * @param x      Input vector of length `N`.
- * @param y      In/out vector of length `M`.
- * @param alpha  Scalar multiplier on the product.
  * @param beta   Scalar multiplier on the prior `y`.
+ * @param y      In/out vector of length `M`.
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE = M>
-__device__ void row_strided_gemv(const T* A, const T* x, T* y, T alpha, T beta)
+__device__ void gemv_strided(T alpha, const T* A, const T* x, T beta, T* y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -51,13 +51,13 @@ __device__ void row_strided_gemv(const T* A, const T* x, T* y, T alpha, T beta)
  * @tparam M           Number of rows of `A` (compile-time constant).
  * @tparam N           Number of columns of `A` (compile-time constant).
  * @tparam ROW_STRIDE  Column-major leading dimension of `A` (default `M`).
+ * @param alpha  Scalar multiplier on the product.
  * @param A      Input matrix, addressed at `A[row + col*ROW_STRIDE]`.
  * @param x      Input vector of length `N`.
  * @param y      Output vector of length `M`.
- * @param alpha  Scalar multiplier on the product.
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE = M>
-__device__ void row_strided_gemv(const T* A, const T* x, T* y, T alpha)
+__device__ void gemv_strided(T alpha, const T* A, const T* x, T* y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;

--- a/src/base/L2/ger.cuh
+++ b/src/base/L2/ger.cuh
@@ -16,8 +16,8 @@
  * @param A      In/out matrix of `m*n` elements (column-major).
  */
 // A += alpha * x * y^T  (A is m×n column-major)
-template <typename T>
-__device__ void ger(uint32_t m, uint32_t n, T alpha, T *x, T *y, T *A)
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void ger(uint32_t m, uint32_t n, T alpha, const T *x, const T *y, T *A)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -26,6 +26,7 @@ __device__ void ger(uint32_t m, uint32_t n, T alpha, T *x, T *y, T *A)
         for (uint32_t row = rank; row < m; row += size)
             A[row + col*m] += ay * x[row];
     }
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -42,8 +43,8 @@ __device__ void ger(uint32_t m, uint32_t n, T alpha, T *x, T *y, T *A)
  * @param y      Input vector of length `N`.
  * @param A      In/out matrix of `M*N` elements (column-major).
  */
-template <typename T, uint32_t M, uint32_t N>
-__device__ void ger(T alpha, T *x, T *y, T *A)
+template <typename T, uint32_t M, uint32_t N, bool TRAILING_SYNC = true>
+__device__ void ger(T alpha, const T *x, const T *y, T *A)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -52,4 +53,5 @@ __device__ void ger(T alpha, T *x, T *y, T *A)
         for (uint32_t row = rank; row < M; row += size)
             A[row + col*M] += ay * x[row];
     }
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }

--- a/src/base/L2/trsv.cuh
+++ b/src/base/L2/trsv.cuh
@@ -14,20 +14,20 @@
 //            strictly-upper entries are ignored; false = upper).
 //   UNIT   — when true the diagonal is implicitly 1 (A's diagonal is not read
 //            and the divide is skipped).
-//   TRANS  — when true the routine works with op(A) = Aᵀ against that SAME
+//   TRANSPOSE  — when true the routine works with op(A) = Aᵀ against that SAME
 //            stored triangle: trsv solves Aᵀx = b, trmv computes Aᵀx.
 //
 // op(A) is lower-triangular (forward sweep) when
-//   (LOWER && !TRANS) || (!LOWER && TRANS)
+//   (LOWER && !TRANSPOSE) || (!LOWER && TRANSPOSE)
 // and upper-triangular (backward sweep) otherwise.
 // ─────────────────────────────────────────────────────────────────────────────
 
 // core impl: explicit rank/size + flags. Solves op(A) x = b in place.
-template <typename T, bool LOWER, bool UNIT, bool TRANS>
+template <typename T, bool LOWER, bool UNIT, bool TRANSPOSE>
 __device__ void trsv_impl(uint32_t rank, uint32_t size, uint32_t n, const T* A, T* x)
 {
     // op(A) lower-triangular ⇒ forward elimination over pivots k = 0..n-1.
-    constexpr bool FORWARD = (LOWER && !TRANS) || (!LOWER && TRANS);
+    constexpr bool FORWARD = (LOWER && !TRANSPOSE) || (!LOWER && TRANSPOSE);
     for (uint32_t step = 0; step < n; step++) {
         uint32_t k = FORWARD ? step : (n - 1 - step);
         // resolve pivot x[k] = x[k] / op(A)[k][k]   (diag is A[k+k*n])
@@ -37,13 +37,13 @@ __device__ void trsv_impl(uint32_t rank, uint32_t size, uint32_t n, const T* A, 
         }
         T xk = x[k];
         // subtract x[k] * op(A)[i][k] from the trailing/leading unknowns:
-        //   op(A)[i][k] = TRANS ? A[k + i*n] : A[i + k*n]
+        //   op(A)[i][k] = TRANSPOSE ? A[k + i*n] : A[i + k*n]
         if (FORWARD) {
             for (uint32_t i = rank + k + 1; i < n; i += size)
-                x[i] -= (TRANS ? A[k + i * n] : A[i + k * n]) * xk;
+                x[i] -= (TRANSPOSE ? A[k + i * n] : A[i + k * n]) * xk;
         } else {
             for (uint32_t i = rank; i < k; i += size)
-                x[i] -= (TRANS ? A[k + i * n] : A[i + k * n]) * xk;
+                x[i] -= (TRANSPOSE ? A[k + i * n] : A[i + k * n]) * xk;
         }
         __syncthreads();               // pivot column consumed before next step
     }
@@ -57,28 +57,28 @@ __device__ void trsv_impl(uint32_t rank, uint32_t size, uint32_t n, const T* A, 
  * Solves the triangular system for `x`, overwriting the right-hand side `x`
  * (`x` holds `b` on entry, the solution on return). `A` is an `n×n` triangular
  * matrix stored column-major; only the triangle selected by `LOWER` is read.
- * Set `TRANS=true` to solve `Aᵀx = b` against that same stored triangle, and
+ * Set `TRANSPOSE=true` to solve `Aᵀx = b` against that same stored triangle, and
  * `UNIT=true` for an implicit unit diagonal (the diagonal of `A` is not read).
  * Column-oriented elimination (forward when `op(A)` is lower-triangular, i.e.
- * `(LOWER && !TRANS) || (!LOWER && TRANS)`, backward otherwise); ends with a
+ * `(LOWER && !TRANSPOSE) || (!LOWER && TRANSPOSE)`, backward otherwise); ends with a
  * trailing `__syncthreads()` so it composes without a defensive barrier.
  * SciPy equivalent:
- * `x = scipy.linalg.solve_triangular(A, b, lower=LOWER, unit_diagonal=UNIT, trans=(1 if TRANS else 0))`.
+ * `x = scipy.linalg.solve_triangular(A, b, lower=LOWER, unit_diagonal=UNIT, trans=(1 if TRANSPOSE else 0))`.
  *
  * @tparam T      Scalar type (e.g. `float`, `double`).
  * @tparam LOWER  When true `A`'s lower triangle holds the data (default true).
  * @tparam UNIT   When true the diagonal is implicitly 1 (default false).
- * @tparam TRANS  When true solve `Aᵀx = b` (default false).
+ * @tparam TRANSPOSE  When true solve `Aᵀx = b` (default false).
  * @param n  Dimension (`A` is `n×n`, `x` has length `n`).
  * @param A  Triangular matrix (column-major, `n*n` elements; read-only).
  * @param x  In/out right-hand side; on return holds the solution.
  */
-template <typename T, bool LOWER = true, bool UNIT = false, bool TRANS = false>
+template <typename T, bool LOWER = true, bool UNIT = false, bool TRANSPOSE = false>
 __device__ void trsv(uint32_t n, const T* A, T* x)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    trsv_impl<T, LOWER, UNIT, TRANS>(rank, size, n, A, x);
+    trsv_impl<T, LOWER, UNIT, TRANSPOSE>(rank, size, n, A, x);
 }
 
 // ─── trsv: compile-time size ──────────────────────────────────────────────────
@@ -88,22 +88,22 @@ __device__ void trsv(uint32_t n, const T* A, T* x)
  *
  * Same as the runtime `trsv` but with the dimension as a template parameter.
  * SciPy equivalent:
- * `x = scipy.linalg.solve_triangular(A, b, lower=LOWER, unit_diagonal=UNIT, trans=(1 if TRANS else 0))`.
+ * `x = scipy.linalg.solve_triangular(A, b, lower=LOWER, unit_diagonal=UNIT, trans=(1 if TRANSPOSE else 0))`.
  *
  * @tparam T      Scalar type (e.g. `float`, `double`).
  * @tparam N      Dimension (`A` is `N×N`, `x` has length `N`).
  * @tparam LOWER  When true `A`'s lower triangle holds the data (default true).
  * @tparam UNIT   When true the diagonal is implicitly 1 (default false).
- * @tparam TRANS  When true solve `Aᵀx = b` (default false).
+ * @tparam TRANSPOSE  When true solve `Aᵀx = b` (default false).
  * @param A  Triangular matrix (column-major, `N*N` elements; read-only).
  * @param x  In/out right-hand side; on return holds the solution.
  */
-template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANS = false>
+template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANSPOSE = false>
 __device__ void trsv(const T* A, T* x)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    trsv_impl<T, LOWER, UNIT, TRANS>(rank, size, N, A, x);
+    trsv_impl<T, LOWER, UNIT, TRANSPOSE>(rank, size, N, A, x);
 }
 
 // ─── trmv: out-of-place core ──────────────────────────────────────────────────
@@ -111,24 +111,24 @@ __device__ void trsv(const T* A, T* x)
 // core impl: explicit rank/size + flags. Computes y = op(A) x out of place.
 // Each thread owns disjoint outputs y[i] and only reads the intact x — no
 // interior barrier required.
-template <typename T, bool LOWER, bool UNIT, bool TRANS>
+template <typename T, bool LOWER, bool UNIT, bool TRANSPOSE>
 __device__ void trmv_impl(uint32_t rank, uint32_t size, uint32_t n,
                           const T* A, const T* x, T* y)
 {
     for (uint32_t i = rank; i < n; i += size) {
         // y[i] = sum_k op(A)[i][k] * x[k], summed over the triangle.
-        // op(A)[i][k] = TRANS ? A[k + i*n] : A[i + k*n]; lower-triangular op
+        // op(A)[i][k] = TRANSPOSE ? A[k + i*n] : A[i + k*n]; lower-triangular op
         // (forward) ⇒ k <= i, upper-triangular op ⇒ k >= i.
-        constexpr bool LOWER_OP = (LOWER && !TRANS) || (!LOWER && TRANS);
+        constexpr bool LOWER_OP = (LOWER && !TRANSPOSE) || (!LOWER && TRANSPOSE);
         T acc = UNIT ? x[i] : static_cast<T>(0);
         if (LOWER_OP) {
             uint32_t k_end = UNIT ? i : (i + 1);      // exclude diag when UNIT
             for (uint32_t k = 0; k < k_end; k++)
-                acc += (TRANS ? A[k + i * n] : A[i + k * n]) * x[k];
+                acc += (TRANSPOSE ? A[k + i * n] : A[i + k * n]) * x[k];
         } else {
             uint32_t k_start = UNIT ? (i + 1) : i;    // exclude diag when UNIT
             for (uint32_t k = k_start; k < n; k++)
-                acc += (TRANS ? A[k + i * n] : A[i + k * n]) * x[k];
+                acc += (TRANSPOSE ? A[k + i * n] : A[i + k * n]) * x[k];
         }
         y[i] = acc;
     }
@@ -139,7 +139,7 @@ __device__ void trmv_impl(uint32_t rank, uint32_t size, uint32_t n,
  *
  * Computes the triangular matvec into a separate output `y` (distinct from the
  * input `x`). `A` is an `n×n` triangular matrix stored column-major; only the
- * triangle selected by `LOWER` is read. Set `TRANS=true` to compute `Aᵀx`
+ * triangle selected by `LOWER` is read. Set `TRANSPOSE=true` to compute `Aᵀx`
  * against that same stored triangle, and `UNIT=true` for an implicit unit
  * diagonal. No interior barrier: each thread owns disjoint outputs and reads
  * the intact `x`. NumPy equivalent (lower, non-unit): `y = np.tril(A) @ x`
@@ -149,18 +149,18 @@ __device__ void trmv_impl(uint32_t rank, uint32_t size, uint32_t n,
  * @tparam T      Scalar type (e.g. `float`, `double`).
  * @tparam LOWER  When true `A`'s lower triangle holds the data (default true).
  * @tparam UNIT   When true the diagonal is implicitly 1 (default false).
- * @tparam TRANS  When true compute `Aᵀx` (default false).
+ * @tparam TRANSPOSE  When true compute `Aᵀx` (default false).
  * @param n  Dimension (`A` is `n×n`, `x` and `y` have length `n`).
  * @param A  Triangular matrix (column-major, `n*n` elements; read-only).
  * @param x  Input vector (length `n`; read-only).
  * @param y  Output vector (length `n`); must not alias `x`.
  */
-template <typename T, bool LOWER = true, bool UNIT = false, bool TRANS = false>
+template <typename T, bool LOWER = true, bool UNIT = false, bool TRANSPOSE = false>
 __device__ void trmv(uint32_t n, const T* A, const T* x, T* y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    trmv_impl<T, LOWER, UNIT, TRANS>(rank, size, n, A, x, y);
+    trmv_impl<T, LOWER, UNIT, TRANSPOSE>(rank, size, n, A, x, y);
 }
 
 /**
@@ -173,17 +173,17 @@ __device__ void trmv(uint32_t n, const T* A, const T* x, T* y)
  * @tparam N      Dimension (`A` is `N×N`, `x` and `y` have length `N`).
  * @tparam LOWER  When true `A`'s lower triangle holds the data (default true).
  * @tparam UNIT   When true the diagonal is implicitly 1 (default false).
- * @tparam TRANS  When true compute `Aᵀx` (default false).
+ * @tparam TRANSPOSE  When true compute `Aᵀx` (default false).
  * @param A  Triangular matrix (column-major, `N*N` elements; read-only).
  * @param x  Input vector (length `N`; read-only).
  * @param y  Output vector (length `N`); must not alias `x`.
  */
-template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANS = false>
+template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANSPOSE = false>
 __device__ void trmv(const T* A, const T* x, T* y)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    trmv_impl<T, LOWER, UNIT, TRANS>(rank, size, N, A, x, y);
+    trmv_impl<T, LOWER, UNIT, TRANSPOSE>(rank, size, N, A, x, y);
 }
 
 // ─── trmv: in-place wrapper (needs scratch) ──────────────────────────────────
@@ -195,34 +195,35 @@ __device__ void trmv(const T* A, const T* x, T* y)
  * back over `x`; that temporary is `n` elements long.
  *
  * @param n  Dimension passed to the in-place `trmv`.
- * @return   Number of `T` elements the `scratch` buffer must hold.
+ * @return   Bytes the `scratch` buffer must hold.
  */
-__host__ __device__ inline constexpr uint32_t trmv_scratch_size(uint32_t n) { return n; }
+template <typename T>
+__host__ __device__ inline constexpr std::size_t trmv_scratch_bytes(uint32_t n) { return static_cast<std::size_t>(n) * sizeof(T); }
 
 /**
  * @brief Triangular matrix-vector product `x = op(A) x`, in place (TRMV).
  *
  * In-place form: overwrites `x` with `op(A) x`. Because `trmv` reads the whole
  * `x` while writing each output, the wrapper computes into a caller-provided
- * `scratch` (length `n`, see `trmv_scratch_size`) and copies the result back
+ * `scratch` (length `n`, see `trmv_scratch_bytes`) and copies the result back
  * with a single barrier in between. Ends with a trailing `__syncthreads()`.
  * NumPy equivalent (lower, non-unit): `x = np.tril(A) @ x`.
  *
  * @tparam T      Scalar type (e.g. `float`, `double`).
  * @tparam LOWER  When true `A`'s lower triangle holds the data (default true).
  * @tparam UNIT   When true the diagonal is implicitly 1 (default false).
- * @tparam TRANS  When true compute `Aᵀx` (default false).
+ * @tparam TRANSPOSE  When true compute `Aᵀx` (default false).
  * @param n        Dimension (`A` is `n×n`, `x` and `scratch` have length `n`).
  * @param A        Triangular matrix (column-major, `n*n` elements; read-only).
  * @param x        In/out vector (length `n`); on return holds `op(A) x`.
- * @param scratch  Workspace of length `n` (see `trmv_scratch_size`).
+ * @param scratch  Workspace of length `n` (see `trmv_scratch_bytes`).
  */
-template <typename T, bool LOWER = true, bool UNIT = false, bool TRANS = false>
+template <typename T, bool LOWER = true, bool UNIT = false, bool TRANSPOSE = false>
 __device__ void trmv(uint32_t n, const T* A, T* x, T* scratch)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    trmv_impl<T, LOWER, UNIT, TRANS>(rank, size, n, A, x, scratch);
+    trmv_impl<T, LOWER, UNIT, TRANSPOSE>(rank, size, n, A, x, scratch);
     __syncthreads();                              // scratch fully written before read-back
     for (uint32_t i = rank; i < n; i += size) x[i] = scratch[i];
     __syncthreads();
@@ -238,17 +239,17 @@ __device__ void trmv(uint32_t n, const T* A, T* x, T* scratch)
  * @tparam N      Dimension (`A` is `N×N`, `x` and `scratch` have length `N`).
  * @tparam LOWER  When true `A`'s lower triangle holds the data (default true).
  * @tparam UNIT   When true the diagonal is implicitly 1 (default false).
- * @tparam TRANS  When true compute `Aᵀx` (default false).
+ * @tparam TRANSPOSE  When true compute `Aᵀx` (default false).
  * @param A        Triangular matrix (column-major, `N*N` elements; read-only).
  * @param x        In/out vector (length `N`); on return holds `op(A) x`.
- * @param scratch  Workspace of length `N` (see `trmv_scratch_size`).
+ * @param scratch  Workspace of length `N` (see `trmv_scratch_bytes`).
  */
-template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANS = false>
+template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANSPOSE = false>
 __device__ void trmv(const T* A, T* x, T* scratch)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    trmv_impl<T, LOWER, UNIT, TRANS>(rank, size, N, A, x, scratch);
+    trmv_impl<T, LOWER, UNIT, TRANSPOSE>(rank, size, N, A, x, scratch);
     __syncthreads();
     for (uint32_t i = rank; i < N; i += size) x[i] = scratch[i];
     __syncthreads();

--- a/src/base/L3/chol_InPlace.cuh
+++ b/src/base/L3/chol_InPlace.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
 #include <math.h>
 
@@ -23,11 +24,13 @@
  * @param s_A     In/out n x n matrix (column-major); on return its lower triangle holds L.
  * @param s_fail  Optional flag (CHECK only): set to 1 on a non-PD / NaN pivot, else 0. Ignored when null.
  */
-template <typename T, bool CHECK = false>
-__device__ void cholDecomp_InPlace(uint32_t n, T *s_A, int *s_fail = nullptr)
+// Shared body: in-place lower Cholesky; barrier policy supplies rank/size + the
+// two per-row syncs, so the glass:: and cgrps:: surfaces share this one body.
+// (No separable TRAILING_SYNC: the algorithm's final step is itself a barrier.)
+template <typename Bar, typename T, bool CHECK = false>
+__device__ void cholDecomp_InPlace_impl(Bar bar, uint32_t n, T *s_A, int *s_fail)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    uint32_t rank = bar.rank(), size = bar.size();
     if constexpr (CHECK) { if (rank == 0 && s_fail) *s_fail = 0; }   // only rank 0 writes s_fail
     for (uint32_t row = 0; row < n; row++) {
         if (rank == 0) {
@@ -38,14 +41,20 @@ __device__ void cholDecomp_InPlace(uint32_t n, T *s_A, int *s_fail = nullptr)
             if constexpr (CHECK) { if (s_fail && (d <= static_cast<T>(0) || isnan(d))) *s_fail = 1; }
             s_A[row*n + row] = sqrt(d);  // type-generic: float->float, double->double
         }
-        __syncthreads();
+        bar.sync();
         for (uint32_t col = rank + row + 1; col < n; col += size) {
             T sum = static_cast<T>(0);
             for (uint32_t kk = 0; kk < row; kk++) sum += s_A[kk*n + col]*s_A[kk*n + row];
             s_A[row*n + col] = (static_cast<T>(1)/s_A[row*n + row])*(s_A[row*n + col] - sum);
         }
-        __syncthreads();
+        bar.sync();
     }
+}
+
+template <typename T, bool CHECK = false>
+__device__ void cholDecomp_InPlace(uint32_t n, T *s_A, int *s_fail = nullptr)
+{
+    cholDecomp_InPlace_impl<BlockBarrier, T, CHECK>(BlockBarrier{}, n, s_A, s_fail);
 }
 
 /**

--- a/src/base/L3/congruence.cuh
+++ b/src/base/L3/congruence.cuh
@@ -88,17 +88,17 @@ namespace detail {
  * @tparam T  Scalar type.
  * @tparam N  Rows of X / dimension of M.
  * @tparam Kdim  Columns of X (= columns of the scratch).
- * @return Bytes for the `s_temp` buffer (these are small single-block sizes).
+ * @return Bytes for the `s_scratch` buffer (these are small single-block sizes).
  */
 template <typename T, uint32_t N, uint32_t Kdim>
-__host__ __device__ constexpr uint32_t congruence_smem_size() {
-    return static_cast<uint32_t>(N) * Kdim * sizeof(T);
+__host__ __device__ constexpr std::size_t congruence_scratch_bytes() {
+    return static_cast<std::size_t>(N) * Kdim * sizeof(T);
 }
 
 /**
  * @brief Symmetric congruence: `Q = alpha * Xᵀ·M·X + beta * Q` (Q symmetric).
  *
- * Forms `MX = M·X` into `s_temp`, then contracts `Q = Xᵀ·MX` over the shared
+ * Forms `MX = M·X` into `s_scratch`, then contracts `Q = Xᵀ·MX` over the shared
  * `N` dimension, computing only the lower triangle and mirroring it (the result
  * is symmetric when `M` is). Replaces two gemms + a temp + a transpose with one
  * fused call. Column-major; single block; thread-count invariant.
@@ -113,18 +113,18 @@ __host__ __device__ constexpr uint32_t congruence_smem_size() {
  * @param M       Input N x N matrix (column-major; symmetric for a symmetric Q).
  * @param beta    Scalar on the existing Q (read only when ACCUMULATE).
  * @param Q       In/out Kdim x Kdim result (column-major).
- * @param s_temp  Shared scratch of `congruence_smem_size<T,N,Kdim>()` bytes (holds M·X).
+ * @param s_scratch  Shared scratch of `congruence_scratch_bytes<T,N,Kdim>()` bytes (holds M·X).
  */
 template <typename T, uint32_t N, uint32_t Kdim,
           bool ACCUMULATE = false, bool TRAILING_SYNC = true>
-__device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T* s_temp)
+__device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T* s_scratch)
 {
     // step 1: MX = M * X  (N x N times N x Kdim -> N x Kdim), overwrite scratch.
-    gemm<T, N, N, Kdim>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(X), s_temp);
+    gemm<T, N, Kdim, N>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(X), s_scratch);
     __syncthreads();                         // MX visible before the Xᵀ·MX contraction
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    detail::xtY_impl<T, N, Kdim, Kdim, true, ACCUMULATE>(rank, size, alpha, X, s_temp, beta, Q);
+    detail::xtY_impl<T, N, Kdim, Kdim, true, ACCUMULATE>(rank, size, alpha, X, s_scratch, beta, Q);
     if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
@@ -133,7 +133,7 @@ __device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T*
  *
  * Like `congruence_sym` but with a distinct right operand `Y`, so the result is
  * not symmetric and the full `P x Qd` matrix is computed. Forms `MY = M·Y` into
- * `s_temp`, then contracts `R = Xᵀ·MY`. Column-major; single block; invariant.
+ * `s_scratch`, then contracts `R = Xᵀ·MY`. Column-major; single block; invariant.
  *
  * @tparam T  Scalar type.
  * @tparam N  Dimension of M (N x N) and rows of X and Y.
@@ -147,18 +147,69 @@ __device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T*
  * @param Y       Input N x Qd matrix (column-major).
  * @param beta    Scalar on the existing R (read only when ACCUMULATE).
  * @param R       In/out P x Qd result (column-major).
- * @param s_temp  Shared scratch of `congruence_smem_size<T,N,Qd>()` bytes (holds M·Y).
+ * @param s_scratch  Shared scratch of `congruence_scratch_bytes<T,N,Qd>()` bytes (holds M·Y).
  */
 template <typename T, uint32_t N, uint32_t P, uint32_t Qd,
           bool ACCUMULATE = false, bool TRAILING_SYNC = true>
-__device__ void bilinear(T alpha, const T* X, const T* M, const T* Y, T beta, T* R, T* s_temp)
+__device__ void bilinear(T alpha, const T* X, const T* M, const T* Y, T beta, T* R, T* s_scratch)
 {
-    gemm<T, N, N, Qd>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(Y), s_temp);
+    gemm<T, N, Qd, N>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(Y), s_scratch);
     __syncthreads();
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    detail::xtY_impl<T, N, P, Qd, false, ACCUMULATE>(rank, size, alpha, X, s_temp, beta, R);
+    detail::xtY_impl<T, N, P, Qd, false, ACCUMULATE>(rank, size, alpha, X, s_scratch, beta, R);
     if constexpr (TRAILING_SYNC) __syncthreads();
+}
+
+/**
+ * @brief Shared-memory element count for `congruence_accum` `s_scratch`.
+ *
+ * Holds the `Q×P` transpose `Gᵀ` plus the `congruence_sym` scratch (`M·Gᵀ`, also
+ * `Q×P`). Total `2*P*Q` elements of `T`.
+ */
+template <typename T, uint32_t P, uint32_t Q>
+__host__ __device__ constexpr uint32_t congruence_accum_smem_count() {
+    return 2u * P * Q;
+}
+
+/**
+ * @brief Accumulating congruence with a rectangular left factor: `C = alpha*G*M*Gᵀ + beta*C`.
+ *
+ * The "other orientation" of `congruence_sym`: here the rectangular factor `G` is
+ * `P×Q` (the natural storage in e.g. GATO's Schur assembly, where `G = B` and
+ * `M = R⁻¹`, giving `B·R⁻¹·Bᵀ`), `M` is `Q×Q` symmetric, and the symmetric result
+ * `C` is `P×P`. Mathematically `G·M·Gᵀ = XᵀMX` with `X = Gᵀ`, so this transposes
+ * `G` into scratch and defers to `congruence_sym<Q,P>` — inheriting its exact
+ * triangle+mirror symmetry and its honest FMA-order note. `ACCUMULATE` adds into
+ * `C` (the `+=` GATO wants); default overwrites. Single block, column-major,
+ * thread-count invariant. NumPy: `C = alpha*(G @ M @ G.T) + beta*C`.
+ *
+ * @tparam T  Scalar type.
+ * @tparam P  Rows of `G` — `C` is `P×P`.
+ * @tparam Q  Columns of `G` and dimension of `M` (`Q×Q`).
+ * @tparam ACCUMULATE  Add into `C` (true) vs overwrite (false, default).
+ * @tparam TRAILING_SYNC  Emit a trailing `__syncthreads()` (default true).
+ * @param alpha   Scalar on the product.
+ * @param G       Input `P×Q` matrix (column-major).
+ * @param M       Input `Q×Q` matrix (column-major, symmetric).
+ * @param beta    Scalar on the existing `C` (read only when ACCUMULATE).
+ * @param C       In/out `P×P` symmetric result (column-major).
+ * @param s_scratch  Shared scratch of `congruence_accum_smem_count<T,P,Q>()` elements.
+ */
+template <typename T, uint32_t P, uint32_t Q,
+          bool ACCUMULATE = false, bool TRAILING_SYNC = true>
+__device__ void congruence_accum(T alpha, const T* G, const T* M, T beta, T* C, T* s_scratch)
+{
+    T* Gt  = s_scratch;            // Q×P transpose of G (column-major)
+    T* scr = s_scratch + Q * P;    // congruence_sym scratch (M·Gᵀ), Q×P
+    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    for (uint32_t k = rank; k < P * Q; k += size) {
+        uint32_t p = k % P, q = k / P;       // G col-major P×Q: G[q*P + p] = G(p,q)
+        Gt[p * Q + q] = G[q * P + p];        // Gt col-major Q×P: Gt(q,p) = G(p,q)
+    }
+    __syncthreads();                          // Gᵀ visible before the congruence
+    congruence_sym<T, Q, P, ACCUMULATE, TRAILING_SYNC>(alpha, Gt, M, beta, C, scr);
 }
 
 // ─── single-warp congruence / bilinear ───────────────────────────────────────
@@ -171,16 +222,16 @@ namespace warp {
      *
      * @tparam T,N,Kdim,ACCUMULATE  See glass::congruence_sym.
      * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true).
-     * @param alpha,X,M,beta,Q,s_temp  See glass::congruence_sym.
+     * @param alpha,X,M,beta,Q,s_scratch  See glass::congruence_sym.
      */
     template <typename T, uint32_t N, uint32_t Kdim,
               bool ACCUMULATE = false, bool TRAILING_SYNC = true>
-    __device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T* s_temp)
+    __device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T* s_scratch)
     {
-        warp::gemm<T, N, N, Kdim>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(X), s_temp);
+        warp::gemm<T, N, Kdim, N>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(X), s_scratch);
         __syncwarp();
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        detail::xtY_impl<T, N, Kdim, Kdim, true, ACCUMULATE>(lane, 32u, alpha, X, s_temp, beta, Q);
+        detail::xtY_impl<T, N, Kdim, Kdim, true, ACCUMULATE>(lane, 32u, alpha, X, s_scratch, beta, Q);
         if constexpr (TRAILING_SYNC) __syncwarp();
     }
 
@@ -191,16 +242,42 @@ namespace warp {
      *
      * @tparam T,N,P,Qd,ACCUMULATE  See glass::bilinear.
      * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true).
-     * @param alpha,X,M,Y,beta,R,s_temp  See glass::bilinear.
+     * @param alpha,X,M,Y,beta,R,s_scratch  See glass::bilinear.
      */
     template <typename T, uint32_t N, uint32_t P, uint32_t Qd,
               bool ACCUMULATE = false, bool TRAILING_SYNC = true>
-    __device__ void bilinear(T alpha, const T* X, const T* M, const T* Y, T beta, T* R, T* s_temp)
+    __device__ void bilinear(T alpha, const T* X, const T* M, const T* Y, T beta, T* R, T* s_scratch)
     {
-        warp::gemm<T, N, N, Qd>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(Y), s_temp);
+        warp::gemm<T, N, Qd, N>(static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(Y), s_scratch);
         __syncwarp();
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        detail::xtY_impl<T, N, P, Qd, false, ACCUMULATE>(lane, 32u, alpha, X, s_temp, beta, R);
+        detail::xtY_impl<T, N, P, Qd, false, ACCUMULATE>(lane, 32u, alpha, X, s_scratch, beta, R);
         if constexpr (TRAILING_SYNC) __syncwarp();
+    }
+
+    /**
+     * @brief Single-warp accumulating congruence `C = alpha*G*M*Gᵀ + beta*C` (G is P×Q).
+     *
+     * Warp-per-problem analogue of `glass::congruence_accum`: one 32-lane warp
+     * transposes `G` into scratch and defers to `warp::congruence_sym<Q,P>`.
+     * See the block version for semantics.
+     *
+     * @tparam T,P,Q,ACCUMULATE  See glass::congruence_accum.
+     * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true).
+     * @param alpha,G,M,beta,C,s_scratch  See glass::congruence_accum.
+     */
+    template <typename T, uint32_t P, uint32_t Q,
+              bool ACCUMULATE = false, bool TRAILING_SYNC = true>
+    __device__ void congruence_accum(T alpha, const T* G, const T* M, T beta, T* C, T* s_scratch)
+    {
+        T* Gt  = s_scratch;
+        T* scr = s_scratch + Q * P;
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
+        for (uint32_t k = lane; k < P * Q; k += 32u) {
+            uint32_t p = k % P, q = k / P;
+            Gt[p * Q + q] = G[q * P + p];
+        }
+        __syncwarp();
+        warp::congruence_sym<T, Q, P, ACCUMULATE, TRAILING_SYNC>(alpha, Gt, M, beta, C, scr);
     }
 }

--- a/src/base/L3/gemm.cuh
+++ b/src/base/L3/gemm.cuh
@@ -1,119 +1,109 @@
 #pragma once
 #include <cstdint>
 
-// core impl: explicit rank/size + layout flags
-template <typename T, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C>
+// ─── GEMM: standard-BLAS convention ──────────────────────────────────────────
+//
+//   C = alpha * op(A) * op(B) + beta * C
+//
+//   C is M×N, the contraction dimension is K (this matches BLAS / cuBLASDx /
+//   NumPy / Eigen — `C[m,n] = alpha·Σ_k op(A)[m,k]·op(B)[k,n] + beta·C[m,n]`).
+//
+//   op(A) is M×K:  TRANSPOSE_A=false ⇒ A is M×K (A[m + k*M]);
+//                  TRANSPOSE_A=true  ⇒ A is K×M (A[k + m*K], op(A)=Aᵀ).
+//   op(B) is K×N:  TRANSPOSE_B=false ⇒ B is K×N (B[k + n*K]);
+//                  TRANSPOSE_B=true  ⇒ B is N×K (B[n + k*N], op(B)=Bᵀ).
+//   C:             ROW_MAJOR_C=false ⇒ column-major (C[m + n*M], LDC=M);
+//                  ROW_MAJOR_C=true  ⇒ row-major   (C[m*N + n]).
+//
+// All four transpose combinations work at any M,N,K (no squareness assumption).
+// Each C[m,n] is written by exactly one thread/lane (serial-K inner loop, no
+// reduction) ⇒ trivially thread-count invariant. Column-major operands by default.
+//
+// Row-major operands need no separate path: a row-major M×K matrix is exactly a
+// column-major K×M matrix, so pass it with the matching TRANSPOSE flag (see
+// examples/11_rowmajor_is_transpose.cu). That is why there is a single ROW_MAJOR_C
+// output flag and no per-operand row-major flags.
+//
+// NumPy: C = alpha*opA(A) @ opB(B) + beta*C ;
+// Eigen: C.noalias() = alpha*(opA(A)*opB(B)) + beta*C;  (column-major default)
+
+// ─── core impls: explicit rank/size + (TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C) ──
+
+template <typename T, bool TRANSPOSE_A, bool TRANSPOSE_B, bool ROW_MAJOR_C>
 __device__ void gemm_impl(uint32_t rank, uint32_t size,
-                           uint32_t m, uint32_t n, uint32_t k,
-                           T alpha, T *A, T *B, T beta, T *C)
+                          uint32_t m_, uint32_t n_, uint32_t k_,
+                          T alpha, const T *A, const T *B, T beta, T *C)
 {
-    const uint32_t C_cols = TRANSPOSE_B ? n : k;
-    const uint32_t maxel  = m * C_cols;
+    const uint32_t maxel = m_ * n_;
     for (uint32_t el = rank; el < maxel; el += size) {
-        uint32_t row = el % m, col = el / m;
+        uint32_t m = el % m_, n = el / m_;
         T res = static_cast<T>(0);
-        if (TRANSPOSE_B) {
-            for (uint32_t ind = 0; ind < n; ind++) {
-                T a = ROW_MAJOR_A ? A[row*n + ind] : A[ind*m + row];
-                T b = ROW_MAJOR_B ? B[col*n + ind] : B[ind*n + col];
-                res += a * b;
-            }
-        } else {
-            for (uint32_t ind = 0; ind < n; ind++) {
-                T a = ROW_MAJOR_A ? A[row*n + ind] : A[ind*m + row];
-                T b = ROW_MAJOR_B ? B[ind*k + col] : B[col*n + ind];
-                res += a * b;
-            }
+        for (uint32_t k = 0; k < k_; k++) {
+            T a = TRANSPOSE_A ? A[k + m*k_] : A[m + k*m_];
+            T b = TRANSPOSE_B ? B[n + k*n_] : B[k + n*k_];
+            res += a * b;
         }
-        uint32_t cidx = ROW_MAJOR_C ? (row*C_cols + col) : (col*m + row);
+        uint32_t cidx = ROW_MAJOR_C ? (m*n_ + n) : (m + n*m_);
         C[cidx] = alpha*res + beta*C[cidx];
     }
 }
 
-template <typename T, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C>
+template <typename T, bool TRANSPOSE_A, bool TRANSPOSE_B, bool ROW_MAJOR_C>
 __device__ void gemm_impl(uint32_t rank, uint32_t size,
-                           uint32_t m, uint32_t n, uint32_t k,
-                           T alpha, T *A, T *B, T *C)
+                          uint32_t m_, uint32_t n_, uint32_t k_,
+                          T alpha, const T *A, const T *B, T *C)
 {
-    const uint32_t C_cols = TRANSPOSE_B ? n : k;
-    const uint32_t maxel  = m * C_cols;
+    const uint32_t maxel = m_ * n_;
     for (uint32_t el = rank; el < maxel; el += size) {
-        uint32_t row = el % m, col = el / m;
+        uint32_t m = el % m_, n = el / m_;
         T res = static_cast<T>(0);
-        if (TRANSPOSE_B) {
-            for (uint32_t ind = 0; ind < n; ind++) {
-                T a = ROW_MAJOR_A ? A[row*n + ind] : A[ind*m + row];
-                T b = ROW_MAJOR_B ? B[col*n + ind] : B[ind*n + col];
-                res += a * b;
-            }
-        } else {
-            for (uint32_t ind = 0; ind < n; ind++) {
-                T a = ROW_MAJOR_A ? A[row*n + ind] : A[ind*m + row];
-                T b = ROW_MAJOR_B ? B[ind*k + col] : B[col*n + ind];
-                res += a * b;
-            }
+        for (uint32_t k = 0; k < k_; k++) {
+            T a = TRANSPOSE_A ? A[k + m*k_] : A[m + k*m_];
+            T b = TRANSPOSE_B ? B[n + k*n_] : B[k + n*k_];
+            res += a * b;
         }
-        uint32_t cidx = ROW_MAJOR_C ? (row*C_cols + col) : (col*m + row);
+        uint32_t cidx = ROW_MAJOR_C ? (m*n_ + n) : (m + n*m_);
         C[cidx] = alpha*res;
     }
 }
 
-// compile-time impl: M, N, K as template params so el%M and el/M use
-// cheap compiler-generated magic-number multiply instead of MUFU.RCP
-template <typename T, uint32_t M, uint32_t N, uint32_t K, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C>
+// compile-time impl: M, N, K as template params so el%M and el/M use cheap
+// compiler-generated magic-number multiply instead of MUFU.RCP, and the inner
+// K-loop is fully unrolled.
+template <typename T, uint32_t M, uint32_t N, uint32_t K,
+          bool TRANSPOSE_A, bool TRANSPOSE_B, bool ROW_MAJOR_C>
 __device__ void gemm_impl_ct(uint32_t rank, uint32_t size,
-                              T alpha, T *A, T *B, T beta, T *C)
+                             T alpha, const T *A, const T *B, T beta, T *C)
 {
-    constexpr uint32_t C_cols = TRANSPOSE_B ? N : K;
-    constexpr uint32_t maxel  = M * C_cols;
+    constexpr uint32_t maxel = M * N;
     for (uint32_t el = rank; el < maxel; el += size) {
-        uint32_t row = el % M, col = el / M;
+        uint32_t m = el % M, n = el / M;
         T res = static_cast<T>(0);
-        if (TRANSPOSE_B) {
-            for (uint32_t ind = 0; ind < N; ind++) {
-                T a = ROW_MAJOR_A ? A[row*N + ind] : A[ind*M + row];
-                T b = ROW_MAJOR_B ? B[col*N + ind] : B[ind*N + col];
-                res += a * b;
-            }
-        } else {
-            for (uint32_t ind = 0; ind < N; ind++) {
-                T a = ROW_MAJOR_A ? A[row*N + ind] : A[ind*M + row];
-                T b = ROW_MAJOR_B ? B[ind*K + col] : B[col*N + ind];
-                res += a * b;
-            }
+        for (uint32_t k = 0; k < K; k++) {
+            T a = TRANSPOSE_A ? A[k + m*K] : A[m + k*M];
+            T b = TRANSPOSE_B ? B[n + k*N] : B[k + n*K];
+            res += a * b;
         }
-        uint32_t cidx = ROW_MAJOR_C ? (row*C_cols + col) : (col*M + row);
+        uint32_t cidx = ROW_MAJOR_C ? (m*N + n) : (m + n*M);
         C[cidx] = alpha*res + beta*C[cidx];
     }
 }
 
-template <typename T, uint32_t M, uint32_t N, uint32_t K, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C>
+template <typename T, uint32_t M, uint32_t N, uint32_t K,
+          bool TRANSPOSE_A, bool TRANSPOSE_B, bool ROW_MAJOR_C>
 __device__ void gemm_impl_ct(uint32_t rank, uint32_t size,
-                              T alpha, T *A, T *B, T *C)
+                             T alpha, const T *A, const T *B, T *C)
 {
-    constexpr uint32_t C_cols = TRANSPOSE_B ? N : K;
-    constexpr uint32_t maxel  = M * C_cols;
+    constexpr uint32_t maxel = M * N;
     for (uint32_t el = rank; el < maxel; el += size) {
-        uint32_t row = el % M, col = el / M;
+        uint32_t m = el % M, n = el / M;
         T res = static_cast<T>(0);
-        if (TRANSPOSE_B) {
-            for (uint32_t ind = 0; ind < N; ind++) {
-                T a = ROW_MAJOR_A ? A[row*N + ind] : A[ind*M + row];
-                T b = ROW_MAJOR_B ? B[col*N + ind] : B[ind*N + col];
-                res += a * b;
-            }
-        } else {
-            for (uint32_t ind = 0; ind < N; ind++) {
-                T a = ROW_MAJOR_A ? A[row*N + ind] : A[ind*M + row];
-                T b = ROW_MAJOR_B ? B[ind*K + col] : B[col*N + ind];
-                res += a * b;
-            }
+        for (uint32_t k = 0; k < K; k++) {
+            T a = TRANSPOSE_A ? A[k + m*K] : A[m + k*M];
+            T b = TRANSPOSE_B ? B[n + k*N] : B[k + n*K];
+            res += a * b;
         }
-        uint32_t cidx = ROW_MAJOR_C ? (row*C_cols + col) : (col*M + row);
+        uint32_t cidx = ROW_MAJOR_C ? (m*N + n) : (m + n*M);
         C[cidx] = alpha*res;
     }
 }
@@ -121,251 +111,212 @@ __device__ void gemm_impl_ct(uint32_t rank, uint32_t size,
 // ─── runtime variants ─────────────────────────────────────────────────────────
 
 /**
- * @brief General matrix-matrix multiply: `C = alpha * A * op(B) + beta * C` (GEMM).
+ * @brief General matrix-matrix multiply: `C = alpha * op(A) * op(B) + beta * C` (GEMM).
  *
- * Runtime-size, single-block, flat-element parallelism: each thread owns output
- * elements strided over the block. Storage order is uniform across A, B, C
- * (`ROW_MAJOR` flag; false = column-major). NumPy equivalent:
- * `C = alpha * A @ B + beta * C`.
+ * Standard BLAS convention: `C` is `m×n`, contraction `k`. Runtime-size,
+ * single-block, flat-element parallelism: each thread owns output elements
+ * strided over the block. NumPy: `C = alpha * opA(A) @ opB(B) + beta * C`;
+ * Eigen: `C.noalias() = alpha*(opA(A)*opB(B)) + beta*C;`.
  *
  * @tparam T  Scalar type.
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (pure-SIMT path requires B square).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
- * @param m,n,k  Dimensions: A is m x n, B is n x k (or k x n when TRANSPOSE_B), C is m x (TRANSPOSE_B ? n : k).
+ * @tparam TRANSPOSE_A  If true, `A` is `k×m` and `op(A)=Aᵀ` (else `A` is `m×k`).
+ * @tparam TRANSPOSE_B  If true, `B` is `n×k` and `op(B)=Bᵀ` (else `B` is `k×n`).
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major / Fortran, LDC=m).
+ * @param m,n,k  Dimensions: `C` is `m×n`, contraction `k`.
  * @param alpha  Scalar multiplier on the product.
- * @param A,B    Input matrices.
+ * @param A,B    Input matrices (column-major; shapes per the transpose flags).
  * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C      In/out result matrix.
  */
-template <typename T, bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
+template <typename T, bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm(uint32_t m, uint32_t n, uint32_t k,
-                     T alpha, T *A, T *B, T beta, T *C)
+                     T alpha, const T *A, const T *B, T beta, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(rank, size, m, n, k, alpha, A, B, beta, C);
+    gemm_impl<T, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(rank, size, m, n, k, alpha, A, B, beta, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
- * @brief General matrix-matrix multiply with implicit `beta = 0`: `C = alpha * A * op(B)` (GEMM).
+ * @brief GEMM with implicit `beta = 0`: `C = alpha * op(A) * op(B)` (overwrite).
  *
  * Runtime-size overload that overwrites C (the existing C is not read), avoiding
- * the `beta * C` term. Single-block, flat-element parallelism; uniform storage
- * order. NumPy equivalent: `C = alpha * A @ B`.
+ * the `beta * C` term. NumPy: `C = alpha * opA(A) @ opB(B)`.
  *
  * @tparam T  Scalar type.
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (pure-SIMT path requires B square).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
- * @param m,n,k  Dimensions: A is m x n, B is n x k (or k x n when TRANSPOSE_B), C is m x (TRANSPOSE_B ? n : k).
+ * @tparam TRANSPOSE_A  If true, `A` is `k×m` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `n×k` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
+ * @param m,n,k  Dimensions: `C` is `m×n`, contraction `k`.
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param C      Output result matrix (overwritten).
  */
-template <typename T, bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
+template <typename T, bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm(uint32_t m, uint32_t n, uint32_t k,
-                     T alpha, T *A, T *B, T *C)
+                     T alpha, const T *A, const T *B, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(rank, size, m, n, k, alpha, A, B, C);
-}
-
-/**
- * @brief GEMM with per-matrix layout control: `C = alpha * A * op(B) + beta * C`.
- *
- * Like `gemm` but the storage order of A, B and C is set independently rather
- * than by a single uniform flag. Runtime-size, single-block. NumPy equivalent:
- * `C = alpha * A @ B + beta * C`.
- *
- * @tparam T  Scalar type.
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
- * @tparam ROW_MAJOR_A/ROW_MAJOR_B/ROW_MAJOR_C  Storage order per matrix (false = column-major).
- * @param m,n,k  Dimensions: A is m x n, B is n x k (or k x n when TRANSPOSE_B), C is m x (TRANSPOSE_B ? n : k).
- * @param alpha  Scalar multiplier on the product.
- * @param A,B    Input matrices.
- * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
- * @param C      In/out result matrix.
- */
-template <typename T, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C>
-__device__ void gemm_ex(uint32_t m, uint32_t n, uint32_t k,
-                        T alpha, T *A, T *B, T beta, T *C)
-{
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR_A, ROW_MAJOR_B, ROW_MAJOR_C>(rank, size, m, n, k, alpha, A, B, beta, C);
-}
-
-/**
- * @brief GEMM with per-matrix layout control and implicit `beta = 0`: `C = alpha * A * op(B)`.
- *
- * Per-matrix-layout overload that overwrites C (the existing C is not read).
- * Runtime-size, single-block. NumPy equivalent: `C = alpha * A @ B`.
- *
- * @tparam T  Scalar type.
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
- * @tparam ROW_MAJOR_A/ROW_MAJOR_B/ROW_MAJOR_C  Storage order per matrix (false = column-major).
- * @param m,n,k  Dimensions: A is m x n, B is n x k (or k x n when TRANSPOSE_B), C is m x (TRANSPOSE_B ? n : k).
- * @param alpha  Scalar multiplier on the product.
- * @param A,B    Input matrices.
- * @param C      Output result matrix (overwritten).
- */
-template <typename T, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C>
-__device__ void gemm_ex(uint32_t m, uint32_t n, uint32_t k,
-                        T alpha, T *A, T *B, T *C)
-{
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR_A, ROW_MAJOR_B, ROW_MAJOR_C>(rank, size, m, n, k, alpha, A, B, C);
+    gemm_impl<T, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(rank, size, m, n, k, alpha, A, B, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 // ─── compile-time size variants ───────────────────────────────────────────────
 
 /**
- * @brief Compile-time-size GEMM: `C = alpha * A * op(B) + beta * C` (GEMM).
+ * @brief Compile-time-size GEMM: `C = alpha * op(A) * op(B) + beta * C` (GEMM).
  *
- * Dimensions are template parameters so the compiler unrolls the inner loops and
+ * Dimensions are template parameters so the compiler unrolls the inner loop and
  * replaces the `el % M` / `el / M` index math with magic-number multiplies.
- * Single-block, flat-element parallelism, uniform storage order. NumPy
- * equivalent: `C = alpha * A @ B + beta * C`.
+ * Standard BLAS convention: `C` is `M×N`, contraction `K`. NumPy:
+ * `C = alpha * opA(A) @ opB(B) + beta * C`; Eigen:
+ * `C.noalias() = alpha*(opA(A)*opB(B)) + beta*C;`.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K`.
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ` (else `A` is `M×K`).
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ` (else `B` is `K×N`).
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major / Fortran, LDC=M).
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C      In/out result matrix.
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
-__device__ void gemm(T alpha, T *A, T *B, T beta, T *C)
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
+__device__ void gemm(T alpha, const T *A, const T *B, T beta, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(rank, size, alpha, A, B, beta, C);
+    gemm_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(rank, size, alpha, A, B, beta, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
- * @brief Compile-time-size GEMM with implicit `beta = 0`: `C = alpha * A * op(B)`.
+ * @brief Compile-time-size GEMM with implicit `beta = 0`: `C = alpha * op(A) * op(B)`.
  *
  * Compile-time-size overload that overwrites C (the existing C is not read).
- * Single-block, flat-element parallelism, uniform storage order. NumPy
- * equivalent: `C = alpha * A @ B`.
+ * NumPy: `C = alpha * opA(A) @ opB(B)`.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K`.
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param C      Output result matrix (overwritten).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
-__device__ void gemm(T alpha, T *A, T *B, T *C)
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
+__device__ void gemm(T alpha, const T *A, const T *B, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(rank, size, alpha, A, B, C);
+    gemm_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(rank, size, alpha, A, B, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 // ─── single-warp compile-time GEMM ───────────────────────────────────────────
 namespace warp {
     /**
-     * @brief Single-warp compile-time-size GEMM: `C = alpha * A * op(B) + beta * C`.
+     * @brief Single-warp compile-time-size GEMM: `C = alpha * op(A) * op(B) + beta * C`.
      *
      * One 32-lane warp computes the product with flat per-element parallelism
-     * (lanes stride over the `M * Ccols` outputs) — same semantics as the
-     * block-scoped compile-time `gemm`, but scoped to a single warp for
+     * (lanes stride over the `M*N` outputs, serial-K inner loop) — same semantics
+     * as the block-scoped compile-time `gemm`, but scoped to a single warp for
      * warp-per-problem kernels (e.g. 4×4 homogeneous-transform multiplies). No
-     * inter-lane communication, no sync. `C` must not alias `A`/`B`. NumPy:
-     * `C = alpha * A @ op(B) + beta * C`.
+     * inter-lane communication, no sync. `C` must not alias `A`/`B`.
      *
      * @tparam T  Scalar type.
-     * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
-     * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
-     * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+     * @tparam M,N,K  `C` is `M×N`, contraction `K`.
+     * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+     * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+     * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
      * @param alpha  Scalar multiplier on the product.
      * @param A,B    Input matrices.
      * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
      * @param C      In/out result matrix.
      */
     template <typename T, uint32_t M, uint32_t N, uint32_t K,
-              bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
-    __device__ void gemm(T alpha, T *A, T *B, T beta, T *C)
+              bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false>
+    __device__ void gemm(T alpha, const T *A, const T *B, T beta, T *C)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
-        gemm_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(lane, 32u, alpha, A, B, beta, C);
+        gemm_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(lane, 32u, alpha, A, B, beta, C);
     }
 
     /**
-     * @brief Single-warp compile-time-size GEMM with implicit `beta = 0`: `C = alpha * A * op(B)`.
+     * @brief Single-warp compile-time-size GEMM with implicit `beta = 0`: `C = alpha * op(A) * op(B)`.
      *
      * Overwrites C (the existing C is not read). Otherwise identical to the
-     * beta overload above. NumPy: `C = alpha * A @ op(B)`.
+     * beta overload above.
      *
      * @tparam T  Scalar type.
-     * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
-     * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
-     * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+     * @tparam M,N,K  `C` is `M×N`, contraction `K`.
+     * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+     * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+     * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
      * @param alpha  Scalar multiplier on the product.
      * @param A,B    Input matrices.
      * @param C      Output result matrix (overwritten).
      */
     template <typename T, uint32_t M, uint32_t N, uint32_t K,
-              bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
-    __device__ void gemm(T alpha, T *A, T *B, T *C)
+              bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false>
+    __device__ void gemm(T alpha, const T *A, const T *B, T *C)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
-        gemm_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(lane, 32u, alpha, A, B, C);
+        gemm_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(lane, 32u, alpha, A, B, C);
     }
 }
 
-// ─── tiled GEMM (shared-memory staging, column-major only) ───────────────────
+// ─── tiled GEMM (shared-memory staging, column-major, no transpose) ──────────
 /**
  * @brief Tiled GEMM with shared-memory staging: `C = alpha * A * B + beta * C`.
  *
- * Column-major only. Stages `TILE`-wide column blocks of A and the matching rows
- * of B into the caller-provided shared-memory scratch, accumulating the product
- * across tiles. Single-block; best when A/B columns can be reused from shared
- * memory. NumPy equivalent: `C = alpha * A @ B + beta * C`.
+ * Standard convention, column-major, no transpose. `C` is `m×n`, contraction
+ * `k`. Stages `TILE`-wide column blocks of A (`m×TILE`) and the matching row
+ * blocks of B (`TILE×n`) into the caller-provided shared scratch, accumulating
+ * across tiles. Single-block; best when A/B values can be reused from shared
+ * memory. NumPy: `C = alpha * A @ B + beta * C`.
  *
  * @tparam T  Scalar type.
  * @tparam TILE  Column-block width staged per pass.
- * @param m,n,k  Dimensions: A is m x n, B is n x k, C is m x k.
+ * @param m,n,k  Dimensions: A is m×k, B is k×n, C is m×n.
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices (column-major).
  * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C      In/out result matrix.
  * @param s_A    Shared scratch of `m * TILE` elements for the A tile.
- * @param s_B    Shared scratch of `TILE * k` elements for the B tile.
+ * @param s_B    Shared scratch of `TILE * n` elements for the B tile.
  */
 template <typename T, int TILE = 8>
 __device__ void gemm_tiled(uint32_t m, uint32_t n, uint32_t k,
-                            T alpha, T *A, T *B, T beta, T *C,
+                            T alpha, const T *A, const T *B, T beta, T *C,
                             T *s_A, T *s_B)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    uint32_t mk   = m * k;
-    bool valid    = (rank < mk);
+    uint32_t mn   = m * n;
+    bool valid    = (rank < mn);
     uint32_t crow = valid ? (rank % m) : 0;
     uint32_t ccol = valid ? (rank / m) : 0;
     T acc = static_cast<T>(0);
 
-    for (uint32_t t = 0; t < n; t += TILE) {
-        uint32_t tile_end = (t + TILE < n) ? (t + TILE) : n;
+    for (uint32_t t = 0; t < k; t += TILE) {
+        uint32_t tile_end = (t + TILE < k) ? (t + TILE) : k;
         uint32_t tile_w   = tile_end - t;
+        // stage A columns [t, t+tile_w):  A is m×k col-major (LDA=m)
         for (uint32_t i = rank; i < m * tile_w; i += size) {
             uint32_t ar = i % m, ac = i / m;
             s_A[ar + ac*m] = A[ar + (t+ac)*m];
         }
-        for (uint32_t i = rank; i < tile_w * k; i += size) {
+        // stage B rows [t, t+tile_w):  B is k×n col-major (LDB=k)
+        for (uint32_t i = rank; i < tile_w * n; i += size) {
             uint32_t br = i % tile_w, bc = i / tile_w;
-            s_B[br + bc*tile_w] = B[(t+br) + bc*n];
+            s_B[br + bc*tile_w] = B[(t+br) + bc*k];
         }
         __syncthreads();
         if (valid) {
@@ -377,17 +328,18 @@ __device__ void gemm_tiled(uint32_t m, uint32_t n, uint32_t k,
     if (valid) C[crow + ccol*m] = alpha*acc + beta*C[crow + ccol*m];
 }
 
-// ─── auto-dispatch: tiled when scratch provided and m*k <= blockDim ──────────
+// ─── auto-dispatch: tiled when scratch provided and m*n <= blockDim ──────────
 /**
  * @brief Auto-dispatching GEMM: `C = alpha * A * B + beta * C` (column-major).
  *
  * Selects `gemm_tiled` when shared-memory scratch is provided and one output
- * element fits per thread (`m * k <= blockDim`); otherwise falls back to the
- * plain `gemm`. Single-block. NumPy equivalent: `C = alpha * A @ B + beta * C`.
+ * element fits per thread (`m * n <= blockDim`); otherwise falls back to the
+ * plain `gemm`. Standard convention: C is m×n, contraction k. Single-block.
+ * NumPy: `C = alpha * A @ B + beta * C`.
  *
  * @tparam T  Scalar type.
  * @tparam TILE  Tile width passed through to `gemm_tiled`.
- * @param m,n,k  Dimensions: A is m x n, B is n x k, C is m x k.
+ * @param m,n,k  Dimensions: A is m×k, B is k×n, C is m×n.
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices (column-major).
  * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
@@ -397,14 +349,14 @@ __device__ void gemm_tiled(uint32_t m, uint32_t n, uint32_t k,
  */
 template <typename T, int TILE = 8>
 __device__ void gemm_dispatch(uint32_t m, uint32_t n, uint32_t k,
-                               T alpha, T *A, T *B, T beta, T *C,
+                               T alpha, const T *A, const T *B, T beta, T *C,
                                T *s_A = nullptr, T *s_B = nullptr)
 {
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    if (s_A != nullptr && m*k <= size)
+    if (s_A != nullptr && m*n <= size)
         gemm_tiled<T, TILE>(m, n, k, alpha, A, B, beta, C, s_A, s_B);
     else
-        gemm<T, false>(m, n, k, alpha, A, B, beta, C);
+        gemm<T>(m, n, k, alpha, A, B, beta, C);
 }
 
 namespace high_speed {
@@ -412,22 +364,22 @@ namespace high_speed {
      * @brief High-speed (tiled) GEMM: `C = alpha * A * B + beta * C` (column-major).
      *
      * `glass::high_speed::gemm` — a thin alias that always takes the shared-memory
-     * tiled path (`gemm_tiled`). Requires the caller to supply scratch. NumPy
-     * equivalent: `C = alpha * A @ B + beta * C`.
+     * tiled path (`gemm_tiled`). Requires the caller to supply scratch. Standard
+     * convention: C is m×n, contraction k. NumPy: `C = alpha * A @ B + beta * C`.
      *
      * @tparam T  Scalar type.
      * @tparam TILE  Tile width passed through to `gemm_tiled`.
-     * @param m,n,k  Dimensions: A is m x n, B is n x k, C is m x k.
+     * @param m,n,k  Dimensions: A is m×k, B is k×n, C is m×n.
      * @param alpha  Scalar multiplier on the product.
      * @param A,B    Input matrices (column-major).
      * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
      * @param C      In/out result matrix.
      * @param s_A    Shared scratch of `m * TILE` elements for the A tile.
-     * @param s_B    Shared scratch of `TILE * k` elements for the B tile.
+     * @param s_B    Shared scratch of `TILE * n` elements for the B tile.
      */
     template <typename T, int TILE = 8>
     __device__ void gemm(uint32_t m, uint32_t n, uint32_t k,
-                         T alpha, T *A, T *B, T beta, T *C,
+                         T alpha, const T *A, const T *B, T beta, T *C,
                          T *s_A, T *s_B)
     {
         gemm_tiled<T, TILE>(m, n, k, alpha, A, B, beta, C, s_A, s_B);

--- a/src/base/L3/gemm_batched_indexed.cuh
+++ b/src/base/L3/gemm_batched_indexed.cuh
@@ -13,7 +13,7 @@
 // One block-stride loop over the flattened `pairs*DIM*DIM` output elements:
 // thread `rank` owns global element e, decoded as pair = e/(DIM*DIM),
 // el = e%(DIM*DIM), row = el%DIM, col = el/DIM.  This is the indexed/gather
-// analogue of row_strided_gemm — useful for assembling many independent 4x4
+// analogue of gemm_strided — useful for assembling many independent 4x4
 // (e.g. SE(3) / spatial-transform) products selected by index lists, computing
 // all `pairs` concurrently in a single block.
 //
@@ -61,7 +61,7 @@
  * matrices selected by index into flat base buffers (`a_idx[p]` is a MATRIX
  * index, so the matrix lives at offset `a_idx[p] * DIM * DIM`), computing all
  * pairs concurrently in a single block. This is the indexed/gather analogue of
- * `row_strided_gemm`, useful for assembling many independent small (e.g. 4x4
+ * `gemm_strided`, useful for assembling many independent small (e.g. 4x4
  * SE(3)) products from index lists. No alpha/beta — a pure overwrite
  * (`C = op(A) * op(B)`) unless `ATOMIC_C` is set.
  *
@@ -89,7 +89,7 @@
  */
 template <typename T, uint32_t DIM = 4, bool TRANSPOSE_A = false,
           bool TRANSPOSE_B = false, bool ATOMIC_C = false, typename IDX_T = int>
-__device__ void indexed_batched_gemm(
+__device__ void gemm_batched_indexed(
     uint32_t pairs, const IDX_T* a_idx, const IDX_T* b_idx, const IDX_T* c_idx,
     const T* A_base, const T* B_base, T* C_base)
 {

--- a/src/base/L3/gemm_reduced.cuh
+++ b/src/base/L3/gemm_reduced.cuh
@@ -51,37 +51,35 @@ __host__ __device__ constexpr bool suggested_use_reduced() {
     return (n_out <= blockDim / 32u) && (K_contract >= 32u);
 }
 
-// Core: explicit (rank,size), compile-time dims + per-matrix layout flags,
-// HAS_BETA selects whether C is read (false ⇒ overwrite, never touches C).
-template <typename T, uint32_t M, uint32_t N, uint32_t K, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C, bool HAS_BETA>
+// Core: explicit (rank,size), compile-time dims + standard-BLAS layout flags
+// (C is M×N, contraction K; op(A) M×K, op(B) K×N — see gemm.cuh). HAS_BETA
+// selects whether C is read (false ⇒ overwrite, never touches C).
+template <typename T, uint32_t M, uint32_t N, uint32_t K,
+          bool TRANSPOSE_A, bool TRANSPOSE_B, bool ROW_MAJOR_C, bool HAS_BETA>
 __device__ void gemm_reduced_impl_ct(uint32_t rank, uint32_t size,
                                       T alpha, T *A, T *B, T beta, T *C)
 {
-    constexpr uint32_t C_cols = TRANSPOSE_B ? N : K;
-    constexpr uint32_t maxel  = M * C_cols;
+    constexpr uint32_t maxel = M * N;
 
     if (size < 32u) {
         // Sub-warp fallback: each thread owns whole outputs (strided by size).
         // Reproduce the 32-lane tree in registers so the rounding matches the
         // full-warp path exactly — invariant across the 32-thread boundary.
         for (uint32_t el = rank; el < maxel; el += size) {
-            const uint32_t row = el % M, col = el / M;
+            const uint32_t m = el % M, n = el / M;
             T p[32];
             #pragma unroll
             for (uint32_t v = 0; v < 32u; ++v) {
                 T acc = static_cast<T>(0);
-                for (uint32_t ind = v; ind < N; ind += 32u) {
-                    T a = ROW_MAJOR_A ? A[row*N + ind] : A[ind*M + row];
-                    T b;
-                    if (TRANSPOSE_B) b = ROW_MAJOR_B ? B[col*N + ind] : B[ind*N + col];
-                    else             b = ROW_MAJOR_B ? B[ind*K + col] : B[col*N + ind];
+                for (uint32_t k = v; k < K; k += 32u) {
+                    T a = TRANSPOSE_A ? A[k + m*K] : A[m + k*M];
+                    T b = TRANSPOSE_B ? B[n + k*N] : B[k + n*K];
                     acc += a * b;
                 }
                 p[v] = acc;
             }
             T res = reduced_tree32<T>(p);
-            const uint32_t cidx = ROW_MAJOR_C ? (row*C_cols + col) : (col*M + row);
+            const uint32_t cidx = ROW_MAJOR_C ? (m*N + n) : (m + n*M);
             C[cidx] = HAS_BETA ? (alpha*res + beta*C[cidx]) : (alpha*res);
         }
         return;
@@ -94,18 +92,16 @@ __device__ void gemm_reduced_impl_ct(uint32_t rank, uint32_t size,
     const uint32_t lane    = rank & 31u;
     if (warp < n_warps) {
         for (uint32_t el = warp; el < maxel; el += n_warps) {
-            const uint32_t row = el % M, col = el / M;
+            const uint32_t m = el % M, n = el / M;
             T partial = static_cast<T>(0);
-            for (uint32_t ind = lane; ind < N; ind += 32u) {
-                T a = ROW_MAJOR_A ? A[row*N + ind] : A[ind*M + row];
-                T b;
-                if (TRANSPOSE_B) b = ROW_MAJOR_B ? B[col*N + ind] : B[ind*N + col];
-                else             b = ROW_MAJOR_B ? B[ind*K + col] : B[col*N + ind];
+            for (uint32_t k = lane; k < K; k += 32u) {
+                T a = TRANSPOSE_A ? A[k + m*K] : A[m + k*M];
+                T b = TRANSPOSE_B ? B[n + k*N] : B[k + n*K];
                 partial += a * b;
             }
             T res = warp::reduce<T>(partial);   // full mask: warp is full
             if (lane == 0) {
-                const uint32_t cidx = ROW_MAJOR_C ? (row*C_cols + col) : (col*M + row);
+                const uint32_t cidx = ROW_MAJOR_C ? (m*N + n) : (m + n*M);
                 C[cidx] = HAS_BETA ? (alpha*res + beta*C[cidx]) : (alpha*res);
             }
         }
@@ -127,9 +123,10 @@ __device__ void gemm_reduced_impl_ct(uint32_t rank, uint32_t size,
  * warp idles; below 32 threads a register path reproduces the same rounding).
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (requires B square: N == K).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K`. op(A) is `M×K`, op(B) is `K×N` (see gemm.cuh).
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major / Fortran).
  * @tparam TRAILING_SYNC  Emit a trailing `__syncthreads()` (default true) so callers can read C safely.
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
@@ -137,12 +134,12 @@ __device__ void gemm_reduced_impl_ct(uint32_t rank, uint32_t size,
  * @param C      In/out result matrix.
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm_reduced(T alpha, T *A, T *B, T beta, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR, true>(
+    gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C, true>(
         rank, size, alpha, A, B, beta, C);
     if constexpr (TRAILING_SYNC) __syncthreads();
 }
@@ -154,21 +151,22 @@ __device__ void gemm_reduced(T alpha, T *A, T *B, T beta, T *C)
  * Otherwise identical to the beta overload above.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (requires B square: N == K).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K`. op(A) is `M×K`, op(B) is `K×N` (see gemm.cuh).
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major / Fortran).
  * @tparam TRAILING_SYNC  Emit a trailing `__syncthreads()` (default true).
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param C      Output result matrix (overwritten).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm_reduced(T alpha, T *A, T *B, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR, false>(
+    gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C, false>(
         rank, size, alpha, A, B, static_cast<T>(0), C);
     if constexpr (TRAILING_SYNC) __syncthreads();
 }
@@ -184,9 +182,10 @@ namespace warp {
      * 32-lane warp. `C` must not alias `A`/`B`.
      *
      * @tparam T  Scalar type.
-     * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
-     * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (requires B square: N == K).
-     * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+     * @tparam M,N,K  `C` is `M×N`, contraction `K`. op(A) is `M×K`, op(B) is `K×N` (see gemm.cuh).
+     * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+     * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+     * @tparam ROW_MAJOR_C  Output storage order (false = column-major / Fortran).
      * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true) so lanes can read C safely.
      * @param alpha  Scalar multiplier on the product.
      * @param A,B    Input matrices.
@@ -194,11 +193,11 @@ namespace warp {
      * @param C      In/out result matrix.
      */
     template <typename T, uint32_t M, uint32_t N, uint32_t K,
-              bool TRANSPOSE_B = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+              bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
     __device__ void gemm_reduced(T alpha, T *A, T *B, T beta, T *C)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR, true>(
+        gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C, true>(
             lane, 32u, alpha, A, B, beta, C);
         if constexpr (TRAILING_SYNC) __syncwarp();
     }
@@ -210,20 +209,21 @@ namespace warp {
      * overload above; the caller must run a full 32-lane warp.
      *
      * @tparam T  Scalar type.
-     * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
-     * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (requires B square: N == K).
-     * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
+     * @tparam M,N,K  `C` is `M×N`, contraction `K`. op(A) is `M×K`, op(B) is `K×N` (see gemm.cuh).
+     * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+     * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+     * @tparam ROW_MAJOR_C  Output storage order (false = column-major / Fortran).
      * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true).
      * @param alpha  Scalar multiplier on the product.
      * @param A,B    Input matrices.
      * @param C      Output result matrix (overwritten).
      */
     template <typename T, uint32_t M, uint32_t N, uint32_t K,
-              bool TRANSPOSE_B = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+              bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
     __device__ void gemm_reduced(T alpha, T *A, T *B, T *C)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR, false>(
+        gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C, false>(
             lane, 32u, alpha, A, B, static_cast<T>(0), C);
         if constexpr (TRAILING_SYNC) __syncwarp();
     }

--- a/src/base/L3/gemm_strided.cuh
+++ b/src/base/L3/gemm_strided.cuh
@@ -1,76 +1,79 @@
 #pragma once
 #include <cstdint>
 
-// Compile-time-size GEMM with explicit column-major leading dimensions for A and B.
-// A[i][j] = A_ptr[i + j*A_RS]; B[j][l] = B_ptr[j + l*B_RS].
-// Output C is standard column-major with LDC=M.
-// When A_RS==M and B_RS==N this is identical to glass::gemm<T,M,N,K>.
+// Compile-time-size GEMM (standard BLAS convention) with explicit column-major
+// leading dimensions for A and B.
+//   C is M×N, contraction K.
+//   A is M×K column-major with leading dim A_RS:  A[m][k] = A[m + k*A_RS].
+//   B is K×N column-major with leading dim B_RS:  B[k][n] = B[k + n*B_RS].
+//   Output C is standard column-major with LDC = M.
+// When A_RS==M and B_RS==K this is identical to glass::gemm<T,M,N,K>.
 //
 // Uses flat-element parallelism (same as gemm_impl_ct): each thread owns one
-// output element el in [rank..M*K) step size.  row=el%M and col=el/M use
-// compiler magic-multiply since M is compile-time.  The inner N-loop is fully
-// unrolled since N, A_RS, B_RS are all compile-time constants.
+// output element el in [rank..M*N) step size.  row=el%M and col=el/M use the
+// compiler magic-multiply since M is compile-time.  The inner K-loop is fully
+// unrolled since K, A_RS, B_RS are all compile-time constants.
 
 /**
  * @brief Strided compile-time GEMM: `C = alpha * A * B + beta * C` with custom leading dims.
  *
- * Column-major GEMM where A and B carry explicit leading dimensions (column
- * strides): `A[i][j] = A[i + j*A_RS]`, `B[j][l] = B[j + l*B_RS]`. Output C is
- * standard column-major with LDC = M. When `A_RS == M` and `B_RS == N` this is
- * identical to `glass::gemm<T,M,N,K>`. Single-block, flat-element parallelism;
- * the inner N-loop is fully unrolled. NumPy equivalent:
- * `C = alpha * A @ B + beta * C` on the strided sub-views.
+ * Column-major GEMM (standard convention: C is M×N, contraction K) where A and B
+ * carry explicit leading dimensions (column strides): `A[m][k] = A[m + k*A_RS]`,
+ * `B[k][n] = B[k + n*B_RS]`. Output C is standard column-major with LDC = M. When
+ * `A_RS == M` and `B_RS == K` this is identical to `glass::gemm<T,M,N,K>`.
+ * Single-block, flat-element parallelism; the inner K-loop is fully unrolled.
+ * NumPy: `C = alpha * A @ B + beta * C` on the strided sub-views.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K, C is M x K.
+ * @tparam M,N,K  Compile-time dimensions: A is M×K, B is K×N, C is M×N (contraction K).
  * @tparam A_RS  Column stride (leading dimension) of A (default M).
- * @tparam B_RS  Column stride (leading dimension) of B (default N).
- * @param A,B    Input matrices (column-major, strided).
- * @param C      In/out result matrix (column-major, LDC = M).
+ * @tparam B_RS  Column stride (leading dimension) of B (default K).
  * @param alpha  Scalar multiplier on the product.
+ * @param A,B    Input matrices (column-major, strided).
  * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
+ * @param C      In/out result matrix (column-major, LDC = M).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          uint32_t A_RS = M, uint32_t B_RS = N>
-__device__ void row_strided_gemm(const T* A, const T* B, T* C, T alpha, T beta)
+          uint32_t A_RS = M, uint32_t B_RS = K>
+__device__ void gemm_strided(T alpha, const T* A, const T* B, T beta, T* C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t el = rank; el < M * K; el += size) {
-        uint32_t row = el % M, col = el / M;
+    for (uint32_t el = rank; el < M * N; el += size) {
+        uint32_t m = el % M, n = el / M;
         T res = static_cast<T>(0);
-        for (uint32_t ind = 0; ind < N; ind++)
-            res += A[row + ind * A_RS] * B[ind + col * B_RS];
-        C[el] = alpha * res + beta * C[el];
+        for (uint32_t k = 0; k < K; k++)
+            res += A[m + k * A_RS] * B[k + n * B_RS];
+        C[m + n * M] = alpha * res + beta * C[m + n * M];
     }
 }
 
 /**
  * @brief Strided compile-time GEMM with implicit `beta = 0`: `C = alpha * A * B`.
  *
- * Same as the four-scalar overload but overwrites C (the existing C is not
- * read). Column-major with explicit leading dims `A_RS` / `B_RS` for A and B;
- * LDC = M. NumPy equivalent: `C = alpha * A @ B`.
+ * Same as the beta overload but overwrites C (the existing C is not read).
+ * Column-major with explicit leading dims `A_RS` / `B_RS`; LDC = M. NumPy:
+ * `C = alpha * A @ B`.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K, C is M x K.
+ * @tparam M,N,K  Compile-time dimensions: A is M×K, B is K×N, C is M×N (contraction K).
  * @tparam A_RS  Column stride (leading dimension) of A (default M).
- * @tparam B_RS  Column stride (leading dimension) of B (default N).
+ * @tparam B_RS  Column stride (leading dimension) of B (default K).
+ * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices (column-major, strided).
  * @param C      Output result matrix (overwritten; column-major, LDC = M).
- * @param alpha  Scalar multiplier on the product.
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          uint32_t A_RS = M, uint32_t B_RS = N>
-__device__ void row_strided_gemm(const T* A, const T* B, T* C, T alpha)
+          uint32_t A_RS = M, uint32_t B_RS = K>
+__device__ void gemm_strided(T alpha, const T* A, const T* B, T* C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t el = rank; el < M * K; el += size) {
-        uint32_t row = el % M, col = el / M;
+    for (uint32_t el = rank; el < M * N; el += size) {
+        uint32_t m = el % M, n = el / M;
         T res = static_cast<T>(0);
-        for (uint32_t ind = 0; ind < N; ind++)
-            res += A[row + ind * A_RS] * B[ind + col * B_RS];
-        C[el] = alpha * res;
+        for (uint32_t k = 0; k < K; k++)
+            res += A[m + k * A_RS] * B[k + n * B_RS];
+        C[m + n * M] = alpha * res;
     }
 }

--- a/src/base/L3/inv.cuh
+++ b/src/base/L3/inv.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
 
 /**
@@ -13,31 +14,38 @@
  * @param dimA    Matrix dimension (A is dimA x dimA).
  * @param A       In/out augmented `[A | I]` buffer (column-major, dimA x 2*dimA);
  *                on return its right half holds `A^-1`.
- * @param s_temp  Shared scratch of `(2*dimA + 1) * sizeof(T)` bytes.
+ * @param s_scratch  Shared scratch of `(2*dimA + 1) * sizeof(T)` bytes.
  */
 // Gauss-Jordan inversion of an augmented dimA×(2*dimA) matrix in-place.
 // Expected layout: column-major [A | I]; on return columns dimA..2*dimA-1 hold A^-1.
-// s_temp: (2*dimA+1)*sizeof(T) bytes.
-template <typename T>
-__device__ void invertMatrix(uint32_t dimA, T *A, T *s_temp)
+// s_scratch: (2*dimA+1)*sizeof(T) bytes.
+// Shared body: Gauss-Jordan inversion; barrier policy supplies rank/size + the
+// two per-pivot syncs, shared by the glass:: and cgrps:: surfaces.
+template <typename Bar, typename T>
+__device__ void invertMatrix_impl(Bar bar, uint32_t dimA, T *A, T *s_scratch)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    uint32_t rank = bar.rank(), size = bar.size();
     for (unsigned pivRC = 0; pivRC < dimA; pivRC++) {
         unsigned pivOff = pivRC * dimA;
         T pvInv = static_cast<T>(1) / A[pivRC + pivOff];
-        for (unsigned ind = rank; ind < 2*dimA+1; ind++) {
+        for (unsigned ind = rank; ind < 2*dimA+1; ind += size) {
             unsigned AInd = (ind < dimA) ? (ind + pivOff) : (pivRC + pivOff + (ind-dimA)*dimA);
-            s_temp[ind] = A[AInd];
+            s_scratch[ind] = A[AInd];
         }
-        __syncthreads();
+        bar.sync();
         for (unsigned ind = rank; ind < dimA*(dimA+1); ind += size) {
             unsigned row = ind % dimA, col = ind / dimA, coff = ind - row;
             if (row == pivRC) A[row + pivOff + coff] *= pvInv;
-            else A[row + pivOff + coff] -= s_temp[row]*pvInv*s_temp[dimA+col];
+            else A[row + pivOff + coff] -= s_scratch[row]*pvInv*s_scratch[dimA+col];
         }
-        __syncthreads();
+        bar.sync();
     }
+}
+
+template <typename T>
+__device__ void invertMatrix(uint32_t dimA, T *A, T *s_scratch)
+{
+    invertMatrix_impl<BlockBarrier, T>(BlockBarrier{}, dimA, A, s_scratch);
 }
 
 /**
@@ -50,16 +58,33 @@ __device__ void invertMatrix(uint32_t dimA, T *A, T *s_temp)
  * @tparam N  Matrix dimension (A is N x N).
  * @param A       In/out augmented `[A | I]` buffer (column-major, N x 2*N);
  *                on return its right half holds `A^-1`.
- * @param s_temp  Shared scratch of `(2*N + 1) * sizeof(T)` bytes.
+ * @param s_scratch  Shared scratch of `(2*N + 1) * sizeof(T)` bytes.
  */
 template <typename T, uint32_t N>
-__device__ void invertMatrix(T *A, T *s_temp)
+__device__ void invertMatrix(T *A, T *s_scratch)
 {
-    invertMatrix<T>(N, A, s_temp);
+    invertMatrix<T>(N, A, s_scratch);
 }
 
 /**
- * @brief Scratch element count (in units of `T`) for `invertMatrix_pivoted`.
+ * @brief Scratch size in bytes for `invertMatrix` (augmented `[A | I]`).
+ *
+ * The unpivoted Gauss-Jordan path saves the active pivot column + row window plus
+ * one slot: `2*dimA + 1` elements of `T`. Allocate
+ * `invertMatrix_scratch_bytes<T>(dimA)` for the `s_scratch` argument.
+ *
+ * @tparam T  Scalar type.
+ * @param dimA  Matrix dimension (A is dimA x dimA).
+ * @return Bytes to allocate for `invertMatrix`'s `s_scratch`.
+ */
+template <typename T>
+__host__ __device__ constexpr std::size_t invertMatrix_scratch_bytes(uint32_t dimA)
+{
+    return static_cast<std::size_t>(2 * dimA + 1) * sizeof(T);
+}
+
+/**
+ * @brief Scratch size in bytes for `invertMatrix_pivoted`.
  *
  * Row pivoting permutes the already-built inverse columns, so (unlike the
  * unpivoted path) the elimination cannot use the reduced active-column window —
@@ -71,12 +96,12 @@ __device__ void invertMatrix(T *A, T *s_temp)
  *
  * @tparam T  Scalar type.
  * @param dimA  Matrix dimension (A is dimA x dimA).
- * @return Element count (of `T`) to allocate for `invertMatrix_pivoted`'s `s_temp`.
+ * @return Bytes to allocate for `invertMatrix_pivoted`'s `s_scratch`.
  */
 template <typename T>
-constexpr uint32_t invertMatrix_pivoted_scratch_size(uint32_t dimA)
+__host__ __device__ constexpr std::size_t invertMatrix_pivoted_scratch_bytes(uint32_t dimA)
 {
-    return 3 * dimA + 1;
+    return static_cast<std::size_t>(3 * dimA + 1) * sizeof(T);
 }
 
 /**
@@ -100,7 +125,7 @@ constexpr uint32_t invertMatrix_pivoted_scratch_size(uint32_t dimA)
  *
  * @par Parallelism / barriers
  * Single-block, strided (`ind += size`), thread-count invariant. Per pivot step:
- *   1. save the pivot column + pivot row + augmented column into `s_temp`;
+ *   1. save the pivot column + pivot row + augmented column into `s_scratch`;
  *   2. block-wide argmax over the pivot-column tail `[k, dimA)` (deterministic
  *      lower-index tie-break, matching `glass::iamax`) chooses the pivot row `r`,
  *      broadcast to all threads through a shared slot + `__syncthreads()` (never
@@ -112,7 +137,7 @@ constexpr uint32_t invertMatrix_pivoted_scratch_size(uint32_t dimA)
  * are block-visible before they are consumed.
  *
  * @par Scratch
- * `s_temp` must hold `invertMatrix_pivoted_scratch_size<T>(dimA)` = `3*dimA + 1`
+ * `s_scratch` must hold `invertMatrix_pivoted_scratch_bytes<T>(dimA)` = `3*dimA + 1`
  * elements of `T`: `dimA` for the pivot column, `2*dimA` for the full pivot row,
  * and one trailing slot to broadcast the chosen pivot-row index.
  *
@@ -120,21 +145,21 @@ constexpr uint32_t invertMatrix_pivoted_scratch_size(uint32_t dimA)
  * @param dimA    Matrix dimension (A is dimA x dimA).
  * @param A       In/out augmented `[A | I]` buffer (column-major, dimA x 2*dimA);
  *                on return its right half holds `A^-1`.
- * @param s_temp  Shared scratch of `(3*dimA + 1) * sizeof(T)` bytes.
+ * @param s_scratch  Shared scratch of `(3*dimA + 1) * sizeof(T)` bytes.
  */
 template <typename T>
-__device__ void invertMatrix_pivoted(uint32_t dimA, T *A, T *s_temp)
+__device__ void invertMatrix_pivoted(uint32_t dimA, T *A, T *s_scratch)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
     const unsigned W = 2*dimA;          // augmented width
-    // s_temp layout (3*dimA + 1 slots):
+    // s_scratch layout (3*dimA + 1 slots):
     //   [0 .. dimA)       pivot column
     //   [dimA .. 3*dimA)  full pivot row (all 2*dimA augmented columns)
     //   [3*dimA]          broadcast slot for the chosen pivot-row index
-    T *s_pcol = s_temp;
-    T *s_prow = &s_temp[dimA];
-    T *s_piv  = &s_temp[3*dimA];
+    T *s_pcol = s_scratch;
+    T *s_prow = &s_scratch[dimA];
+    T *s_piv  = &s_scratch[3*dimA];
     for (unsigned pivRC = 0; pivRC < dimA; pivRC++) {
         unsigned pivOff = pivRC * dimA;
 
@@ -193,13 +218,13 @@ __device__ void invertMatrix_pivoted(uint32_t dimA, T *A, T *s_temp)
  * @tparam N  Matrix dimension (A is N x N).
  * @param A       In/out augmented `[A | I]` buffer (column-major, N x 2*N);
  *                on return its right half holds `A^-1`.
- * @param s_temp  Shared scratch of `(3*N + 1) * sizeof(T)` bytes
- *                (= `invertMatrix_pivoted_scratch_size<T>(N)`).
+ * @param s_scratch  Shared scratch of `(3*N + 1) * sizeof(T)` bytes
+ *                (= `invertMatrix_pivoted_scratch_bytes<T>(N)`).
  */
 template <typename T, uint32_t N>
-__device__ void invertMatrix_pivoted(T *A, T *s_temp)
+__device__ void invertMatrix_pivoted(T *A, T *s_scratch)
 {
-    invertMatrix_pivoted<T>(N, A, s_temp);
+    invertMatrix_pivoted<T>(N, A, s_scratch);
 }
 
 /**
@@ -216,7 +241,7 @@ __device__ void invertMatrix_pivoted(T *A, T *s_temp)
  * (Q_k, Q_kp1, R_k → K=3).
  *
  * Scratch layout: matrix `m` owns the contiguous span
- * `[Σ_{j<m}(2*dims[j]+1), Σ_{j<=m}(2*dims[j]+1))` of `s_temp` (each matrix needs
+ * `[Σ_{j<m}(2*dims[j]+1), Σ_{j<=m}(2*dims[j]+1))` of `s_scratch` (each matrix needs
  * `2*dims[m]+1` slots: `dims[m]` for its pivot column, `dims[m]+1` for its pivot
  * row plus the augmented column). The per-matrix base offset is the prefix sum
  * `Σ_{j<m}(2*dims[j]+1)`, recomputed locally per thread by scanning `dims[]`
@@ -230,10 +255,10 @@ __device__ void invertMatrix_pivoted(T *A, T *s_temp)
  * @param MAX_DIM  `max(dims[0..K-1])` — the shared pivot-loop length (precondition).
  * @param mats     Array of K in/out augmented `[V | I]` buffers (column-major,
  *                 `dims[m] x 2*dims[m]`); on return each right half holds its inverse.
- * @param s_temp   Shared scratch of `(Σ_m (2*dims[m]+1)) * sizeof(T)` bytes.
+ * @param s_scratch   Shared scratch of `(Σ_m (2*dims[m]+1)) * sizeof(T)` bytes.
  */
 template <typename T>
-__device__ void invertMatrix(uint32_t K, const uint32_t *dims, uint32_t MAX_DIM, T **mats, T *s_temp)
+__device__ void invertMatrix(uint32_t K, const uint32_t *dims, uint32_t MAX_DIM, T **mats, T *s_scratch)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -245,7 +270,7 @@ __device__ void invertMatrix(uint32_t K, const uint32_t *dims, uint32_t MAX_DIM,
             uint32_t dim = dims[m];
             if (pivRC < dim) {
                 T *M = mats[m];
-                T *s_mem = &s_temp[sOff];
+                T *s_mem = &s_scratch[sOff];
                 unsigned pivOff = pivRC * dim;
                 // pivot column (dim entries) + pivot row & augmented column (dim+1 entries)
                 for (unsigned ind = rank; ind < dim; ind += size)
@@ -262,7 +287,7 @@ __device__ void invertMatrix(uint32_t K, const uint32_t *dims, uint32_t MAX_DIM,
             uint32_t dim = dims[m];
             if (pivRC < dim) {
                 T *M = mats[m];
-                T *s_mem = &s_temp[sOff];
+                T *s_mem = &s_scratch[sOff];
                 unsigned pivOff = pivRC * dim;
                 for (unsigned ind = rank; ind < dim*(dim + 1); ind += size) {
                     unsigned row = ind % dim, col = ind / dim;
@@ -288,14 +313,14 @@ __device__ void invertMatrix(uint32_t K, const uint32_t *dims, uint32_t MAX_DIM,
  * @param dimA,dimB  Matrix dimensions.
  * @param MAX_DIM    `max(dimA, dimB)` — the shared pivot-loop length.
  * @param A,B        In/out augmented `[V | I]` buffers (column-major, dim x 2*dim).
- * @param s_temp     Shared scratch of `(2*dimA + 2*dimB + 2) * sizeof(T)` bytes.
+ * @param s_scratch     Shared scratch of `(2*dimA + 2*dimB + 2) * sizeof(T)` bytes.
  */
 template <typename T>
-__device__ void invertMatrix(uint32_t dimA, uint32_t dimB, uint32_t MAX_DIM, T *A, T *B, T *s_temp)
+__device__ void invertMatrix(uint32_t dimA, uint32_t dimB, uint32_t MAX_DIM, T *A, T *B, T *s_scratch)
 {
     uint32_t dims[2] = {dimA, dimB};
     T *mats[2] = {A, B};
-    invertMatrix<T>(2, dims, MAX_DIM, mats, s_temp);
+    invertMatrix<T>(2, dims, MAX_DIM, mats, s_scratch);
 }
 
 /**
@@ -310,14 +335,14 @@ __device__ void invertMatrix(uint32_t dimA, uint32_t dimB, uint32_t MAX_DIM, T *
  * @param dimA,dimB,dimC  Matrix dimensions.
  * @param MAX_DIM         `max(dimA, dimB, dimC)` — the shared pivot-loop length.
  * @param A,B,C           In/out augmented `[V | I]` buffers (column-major, dim x 2*dim).
- * @param s_temp          Shared scratch of `(2*dimA + 2*dimB + 2*dimC + 3) * sizeof(T)` bytes.
+ * @param s_scratch          Shared scratch of `(2*dimA + 2*dimB + 2*dimC + 3) * sizeof(T)` bytes.
  */
 template <typename T>
-__device__ void invertMatrix(uint32_t dimA, uint32_t dimB, uint32_t dimC, uint32_t MAX_DIM, T *A, T *B, T *C, T *s_temp)
+__device__ void invertMatrix(uint32_t dimA, uint32_t dimB, uint32_t dimC, uint32_t MAX_DIM, T *A, T *B, T *C, T *s_scratch)
 {
     uint32_t dims[3] = {dimA, dimB, dimC};
     T *mats[3] = {A, B, C};
-    invertMatrix<T>(3, dims, MAX_DIM, mats, s_temp);
+    invertMatrix<T>(3, dims, MAX_DIM, mats, s_scratch);
 }
 
 
@@ -335,13 +360,13 @@ __device__ void invertMatrix(uint32_t dimA, uint32_t dimB, uint32_t dimC, uint32
  * @param dimA    Matrix dimension (A is dimA x dimA).
  * @param A       In/out column-major dimA x dimA matrix; on return holds `A^{-1}`.
  * @param Ainv    Workspace column-major dimA x dimA; on return also holds `A^{-1}`.
- * @param s_temp  Shared scratch of `3 * dimA * sizeof(T)` bytes.
+ * @param s_scratch  Shared scratch of `3 * dimA * sizeof(T)` bytes.
  */
 // Block-cooperative Gauss-Jordan inversion of a dimA×dimA matrix.
 //   A:    in/out, column-major dimA×dimA.  On return: A := A^{-1}.
 //   Ainv: workspace, column-major dimA×dimA (overwritten).  On return: A^{-1}.
 //          (Some callers want A unchanged + a separate inverse — they get both.)
-//   s_temp: shared scratch of size (3*dimA)*sizeof(T).
+//   s_scratch: shared scratch of size (3*dimA)*sizeof(T).
 // Pivot loop is serial (pivot-to-pivot data dependency); within each pivot, the
 // dimA save and the dimA*dimA cell update are parallelized across the block.
 //
@@ -349,8 +374,25 @@ __device__ void invertMatrix(uint32_t dimA, uint32_t dimB, uint32_t dimC, uint32
 // [I | A^{-1}] reduction but without materializing the augmented layout. A and
 // Ainv are tracked in separate buffers so callers that need A^{-1} alongside
 // the original A get it without extra copies.
+
+/**
+ * @brief Scratch size in bytes for `invertMatrix_dense`.
+ *
+ * The dual-buffer dense path saves one `3*dimA`-element pivot working set. Allocate
+ * `invertMatrix_dense_scratch_bytes<T>(dimA)` for the `s_scratch` argument.
+ *
+ * @tparam T  Scalar type.
+ * @param dimA  Matrix dimension (A is dimA x dimA).
+ * @return Bytes to allocate for `invertMatrix_dense`'s `s_scratch`.
+ */
 template <typename T>
-__device__ void invertMatrix_dense(uint32_t dimA, T *A, T *Ainv, T *s_temp)
+__host__ __device__ constexpr std::size_t invertMatrix_dense_scratch_bytes(uint32_t dimA)
+{
+    return static_cast<std::size_t>(3 * dimA) * sizeof(T);
+}
+
+template <typename T>
+__device__ void invertMatrix_dense(uint32_t dimA, T *A, T *Ainv, T *s_scratch)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -365,23 +407,23 @@ __device__ void invertMatrix_dense(uint32_t dimA, T *A, T *Ainv, T *s_temp)
         // Block-cooperative save: pivot row of A, pivot row of Ainv, pivot column of A.
         // 3*dimA entries → block-strided thread distribution.
         for (uint32_t ind = rank; ind < dimA; ind += size) {
-            s_temp[ind]            = A[pivRC + dimA * ind];          // pivot row of A
-            s_temp[ind + dimA]     = Ainv[pivRC + dimA * ind];        // pivot row of Ainv
-            s_temp[ind + dimA * 2] = A[ind + pivColOffset];           // pivot column of A
+            s_scratch[ind]            = A[pivRC + dimA * ind];          // pivot row of A
+            s_scratch[ind + dimA]     = Ainv[pivRC + dimA * ind];        // pivot row of Ainv
+            s_scratch[ind + dimA * 2] = A[ind + pivColOffset];           // pivot column of A
         }
         __syncthreads();
-        T pvInv = static_cast<T>(1) / s_temp[pivRC];
+        T pvInv = static_cast<T>(1) / s_scratch[pivRC];
         // Block-cooperative Gauss-Jordan update across dimA*dimA cells.
         // Each thread owns a unique (row, col) so writes are race-free.
         for (uint32_t ind = rank; ind < dimA * dimA; ind += size) {
             uint32_t row = ind % dimA, col = ind / dimA;
             if (row == pivRC) {
-                A[row + dimA * col]    = s_temp[col] * pvInv;
-                Ainv[row + dimA * col] = s_temp[col + dimA] * pvInv;
+                A[row + dimA * col]    = s_scratch[col] * pvInv;
+                Ainv[row + dimA * col] = s_scratch[col + dimA] * pvInv;
             } else {
-                T multiplier = s_temp[row + dimA * 2] * pvInv;
-                A[row + dimA * col]    -= multiplier * s_temp[col];
-                Ainv[row + dimA * col] -= multiplier * s_temp[col + dimA];
+                T multiplier = s_scratch[row + dimA * 2] * pvInv;
+                A[row + dimA * col]    -= multiplier * s_scratch[col];
+                Ainv[row + dimA * col] -= multiplier * s_scratch[col + dimA];
             }
         }
         __syncthreads();
@@ -399,10 +441,10 @@ __device__ void invertMatrix_dense(uint32_t dimA, T *A, T *Ainv, T *s_temp)
  * @tparam N  Matrix dimension (A is N x N).
  * @param A       In/out column-major N x N matrix; on return holds `A^{-1}`.
  * @param Ainv    Workspace column-major N x N; on return also holds `A^{-1}`.
- * @param s_temp  Shared scratch of `3 * N * sizeof(T)` bytes.
+ * @param s_scratch  Shared scratch of `3 * N * sizeof(T)` bytes.
  */
 template <typename T, uint32_t N>
-__device__ void invertMatrix_dense(T *A, T *Ainv, T *s_temp)
+__device__ void invertMatrix_dense(T *A, T *Ainv, T *s_scratch)
 {
-    invertMatrix_dense<T>(N, A, Ainv, s_temp);
+    invertMatrix_dense<T>(N, A, Ainv, s_scratch);
 }

--- a/src/base/L3/ldlt.cuh
+++ b/src/base/L3/ldlt.cuh
@@ -78,7 +78,7 @@
  * @param n       Matrix dimension (A is n x n).
  * @param A       In/out n x n matrix (column-major); on return its diagonal holds
  *                `D` and its strict lower triangle holds `L`.
- * @param s_temp  Shared scratch advertised as `(n + 1)` elements, used by the
+ * @param s_scratch  Shared scratch advertised as `(n + 1)` elements, used by the
  *                pivot path: slot [0] broadcasts the chosen pivot index and slots
  *                [1..n] hold the working-diagonal magnitudes fed to the no-scratch
  *                `glass::low_memory::iamax` argmax (so the scratch stays within
@@ -90,8 +90,26 @@
  * @param s_fail     Optional flag (CHECK only): 1 on a zero/NaN pivot, else 0. Ignored when null.
  * @param s_inertia  Optional 3 ints (CHECK only): `{n_pos, n_neg, n_zero}` pivot-sign counts. Ignored when null.
  */
+/**
+ * @brief Scratch size in bytes for `ldlt`.
+ *
+ * The pivot path uses `n + 1` scratch elements (one broadcast slot for the chosen
+ * pivot index + the `n` working-diagonal magnitudes fed to the argmax); the
+ * non-pivoted path does not read it. Allocate `ldlt_scratch_bytes<T>(n)` bytes the
+ * `s_scratch` argument so it is sized for both paths.
+ *
+ * @tparam T  Scalar type.
+ * @param n  Matrix dimension (A is n x n).
+ * @return Bytes to allocate for `ldlt`'s `s_scratch`.
+ */
+template <typename T>
+__host__ __device__ constexpr std::size_t ldlt_scratch_bytes(uint32_t n)
+{
+    return static_cast<std::size_t>(n + 1) * sizeof(T);
+}
+
 template <typename T, bool CHECK = false>
-__device__ void ldlt(uint32_t n, T *A, T *s_temp, bool pivot = false, uint32_t *piv = nullptr,
+__device__ void ldlt(uint32_t n, T *A, T *s_scratch, bool pivot = false, uint32_t *piv = nullptr,
                      int *s_fail = nullptr, int *s_inertia = nullptr)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
@@ -102,18 +120,18 @@ __device__ void ldlt(uint32_t n, T *A, T *s_temp, bool pivot = false, uint32_t *
             if (s_inertia) { s_inertia[0] = 0; s_inertia[1] = 0; s_inertia[2] = 0; }
         }
     }
-    // s_temp layout (pivot path only): [0] holds the broadcast pivot index (read
+    // s_scratch layout (pivot path only): [0] holds the broadcast pivot index (read
     // as uint32_t); [1 .. n] hold the n-j working-diagonal magnitudes argmax'd by
     // the no-scratch glass::low_memory::iamax (thread-0 serial scan — keeps the
     // scratch within the advertised (n+1) elements regardless of block size).
-    if (!pivot) { (void)s_temp; (void)piv; }
+    if (!pivot) { (void)s_scratch; (void)piv; }
     for (uint32_t j = 0; j < n; j++) {
         if (pivot) {
             // --- symmetric 1x1 pivot selection over the remaining diagonal ---
             // Working diagonal of index i (i>=j): D_eff_i = A_ii - sum_{m<j} L_im^2 D_m.
             // Each thread fills s_diag[i-j] for its strided i; barrier; argmax;
             // broadcast the winner via s_idx (shared) so every thread agrees.
-            T *s_diag = s_temp + 1;          // length (n - j) working-diag scratch
+            T *s_diag = s_scratch + 1;          // length (n - j) working-diag scratch
             for (uint32_t i = j + rank; i < n; i += size) {
                 T d = A[i*n + i];
                 for (uint32_t m = 0; m < j; m++) {
@@ -126,7 +144,7 @@ __device__ void ldlt(uint32_t n, T *A, T *s_temp, bool pivot = false, uint32_t *
             // No-scratch argmax (thread 0 serial scan) over the working diagonals;
             // writes the winning index into s_idx[0] and ends on __syncthreads(),
             // so the pivot index is block-visible without a racy re-read.
-            uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_temp);
+            uint32_t *s_idx = reinterpret_cast<uint32_t *>(s_scratch);
             low_memory::iamax<T>(n - j, s_diag, s_idx);
             uint32_t p = j + s_idx[0];        // absolute pivot row/col
             if (rank == 0) piv[j] = p;
@@ -200,7 +218,7 @@ __device__ void ldlt(uint32_t n, T *A, T *s_temp, bool pivot = false, uint32_t *
  * @tparam CHECK  If true, report zero/NaN pivots and the inertia (default false, compiles out).
  * @param A       In/out N x N matrix (column-major); diagonal holds `D`, strict
  *                lower holds `L` on return.
- * @param s_temp  Shared scratch advertised as `(N + 1)` elements (used by the
+ * @param s_scratch  Shared scratch advertised as `(N + 1)` elements (used by the
  *                pivot path; non-pivoted path accepts `nullptr`).
  * @param pivot   If true, apply symmetric 1×1 diagonal pivoting (no 2×2 path).
  * @param piv     Out pivot array of `N` entries (pivot path only); may be `nullptr`.
@@ -208,10 +226,10 @@ __device__ void ldlt(uint32_t n, T *A, T *s_temp, bool pivot = false, uint32_t *
  * @param s_inertia  Optional 3 ints (CHECK only): `{n_pos, n_neg, n_zero}`. Ignored when null.
  */
 template <typename T, uint32_t N, bool CHECK = false>
-__device__ void ldlt(T *A, T *s_temp, bool pivot = false, uint32_t *piv = nullptr,
+__device__ void ldlt(T *A, T *s_scratch, bool pivot = false, uint32_t *piv = nullptr,
                      int *s_fail = nullptr, int *s_inertia = nullptr)
 {
-    ldlt<T, CHECK>(N, A, s_temp, pivot, piv, s_fail, s_inertia);
+    ldlt<T, CHECK>(N, A, s_scratch, pivot, piv, s_fail, s_inertia);
 }
 
 /**
@@ -308,4 +326,106 @@ template <typename T, uint32_t N>
 __device__ void ldlt_solve(const T *LD, T *b, const uint32_t *piv = nullptr)
 {
     ldlt_solve<T>(N, LD, b, piv);
+}
+
+namespace warp {
+    /**
+     * @brief Single-warp in-place LDLᵀ factorization (LAPACK `sytrf`, lower, NON-pivoted).
+     *
+     * Warp-per-problem parity with the block `glass::ldlt`: one 32-lane warp factors
+     * the symmetric (possibly INDEFINITE) `A = L D Lᵀ` in place — lane 0 runs the
+     * serial diagonal recurrence `D_j = A_jj − Σ_{k<j} L_jk² D_k` (broadcasting `D_j`
+     * from its register via `__shfl_sync`, never a shared re-read — immune to the
+     * `__restrict__` stale-cache miscompile), lanes fill the trailing column
+     * `L_ij = (A_ij − Σ_{k<j} L_ik D_k L_jk)/D_j` strided by 32. On return the diagonal
+     * slots hold `D`, the strict lower triangle holds unit-`L`. No square root, so it
+     * factors KKT / saddle-point systems Cholesky cannot. No shared scratch, no
+     * `__syncthreads`. **Non-pivoted** (symmetric 1×1 pivoting is deferred — it needs a
+     * `warp::iamax` over the working diagonal; the block path covers the pivoted case).
+     *
+     * `CHECK` (compile-out) reports a zero/NaN pivot via `s_fail` and the inertia
+     * `{n_pos, n_neg, n_zero}` via `s_inertia` (lane 0 writes both). NumPy:
+     * `lu, d, _ = scipy.linalg.ldl(A, lower=True)` ⇒ `A == lu @ np.diag(d) @ lu.T`.
+     *
+     * @tparam T      Scalar type (use `double` for ill-conditioned A).
+     * @tparam N      Dimension (A is N x N).
+     * @tparam CHECK  If true, report zero/NaN pivot + inertia (default false, compiles out).
+     * @param A         In/out N x N symmetric matrix (column-major, lower); on return holds L (strict-lower, unit) and D (diagonal).
+     * @param s_fail    Optional flag (CHECK only): set to 1 on a zero/NaN pivot, else 0.
+     * @param s_inertia Optional length-3 `{n_pos, n_neg, n_zero}` pivot-sign counts (CHECK only).
+     */
+    template <typename T, uint32_t N, bool CHECK = false>
+    __device__ void ldlt(T *A, int *s_fail = nullptr, int *s_inertia = nullptr)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        if constexpr (CHECK) {
+            if (lane == 0) {
+                if (s_fail) *s_fail = 0;
+                if (s_inertia) { s_inertia[0] = 0; s_inertia[1] = 0; s_inertia[2] = 0; }
+            }
+        }
+        for (uint32_t j = 0; j < N; j++) {
+            T Dj = static_cast<T>(0);
+            if (lane == 0) {                          // serial diagonal pivot D_j
+                T sum = static_cast<T>(0);
+                for (uint32_t k = 0; k < j; k++) {
+                    T Ljk = A[k*N + j];               // L_jk (strict-lower, row j, col k)
+                    sum += Ljk * Ljk * A[k*N + k];    // * D_k
+                }
+                A[j*N + j] -= sum;                    // overwrite diagonal with D_j
+                Dj = A[j*N + j];
+                if constexpr (CHECK) {
+                    if (s_fail && (Dj == static_cast<T>(0) || isnan(Dj))) *s_fail = 1;
+                    if (s_inertia) {
+                        if (Dj > static_cast<T>(0)) s_inertia[0]++;
+                        else if (Dj < static_cast<T>(0)) s_inertia[1]++;
+                        else s_inertia[2]++;
+                    }
+                }
+            }
+            Dj = __shfl_sync(0xffffffffu, Dj, 0);     // broadcast finished D_j from lane 0's register
+            for (uint32_t i = j + 1 + lane; i < N; i += 32) {   // parallel trailing column
+                T sum = static_cast<T>(0);
+                for (uint32_t k = 0; k < j; k++)
+                    sum += A[k*N + i] * A[k*N + k] * A[k*N + j];  // L_ik * D_k * L_jk
+                A[j*N + i] = (A[j*N + i] - sum) / Dj;
+            }
+            __syncwarp();
+        }
+    }
+
+    /**
+     * @brief Single-warp LDLᵀ solve `A x = b` in place from an `ldlt` factor (NON-pivoted).
+     *
+     * Warp parity with block `glass::ldlt_solve`: one 32-lane warp runs the three
+     * sweeps — forward unit-`L` (`L y = b`), diagonal scale (`z = y / D`), back
+     * unit-`Lᵀ` (`Lᵀ x = z`) — over the factor `LD` from `warp::ldlt`. `b` is
+     * overwritten with `x`. No shared scratch; `__syncwarp` between dependent sweeps.
+     * Non-pivoted (matches the non-pivoted `warp::ldlt`). NumPy: `x = np.linalg.solve(A, b)`.
+     *
+     * @tparam T  Scalar type.
+     * @tparam N  Dimension (LD is N x N, b length N).
+     * @param LD  LDLᵀ factor from `warp::ldlt` (column-major; unit-L strict-lower, D diagonal).
+     * @param b   In/out right-hand side; on return holds the solution x.
+     */
+    template <typename T, uint32_t N>
+    __device__ void ldlt_solve(const T *LD, T *b)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (uint32_t col = 0; col < N; col++) {               // forward: L y = b (unit L)
+            T factor = b[col];
+            for (uint32_t row = col + 1 + lane; row < N; row += 32)
+                b[row] -= LD[col*N + row] * factor;            // L_{row,col}
+            __syncwarp();
+        }
+        for (uint32_t i = lane; i < N; i += 32)                // diagonal scale z = y / D
+            b[i] /= LD[i*N + i];
+        __syncwarp();
+        for (int32_t col = (int32_t)N - 1; col >= 0; col--) {  // back: Lᵀ x = z (unit Lᵀ)
+            T factor = b[col];
+            for (uint32_t i = lane; i < (uint32_t)col; i += 32)
+                b[i] -= LD[i*N + col] * factor;                // (Lᵀ)_{i,col} = L_{col,i}
+            __syncwarp();
+        }
+    }
 }

--- a/src/base/L3/posv.cuh
+++ b/src/base/L3/posv.cuh
@@ -12,6 +12,27 @@
  */
 
 /**
+ * @brief Add a diagonal regularization shift to A in place (single-block helper).
+ *
+ * `REG_DIAG=false` adds `rho·I` (Marquardt shift); `REG_DIAG=true` adds
+ * `rho·diag(A)`, i.e. scales each diagonal by `(1+rho)` (Levenberg shift —
+ * scale-invariant across rows of very different magnitude, e.g. mixed
+ * prismatic/revolute Jacobians). Trailing `__syncthreads()` so the shifted A is
+ * block-visible before factoring. Internal; used by the flagged `posv` overloads.
+ */
+template <typename T, bool REG_DIAG = false>
+__device__ void _posv_regularize(uint32_t n, T *A, T rho)
+{
+    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    for (uint32_t i = rank; i < n; i += size) {
+        if constexpr (REG_DIAG) A[i*n + i] += rho * A[i*n + i];   // rho*diag(A)
+        else                    A[i*n + i] += rho;                // rho*I
+    }
+    __syncthreads();
+}
+
+/**
  * @brief Solve the SPD system `A x = b` in one block (LAPACK posv).
  *
  * Factors `A = L Lᵀ` in place via Cholesky, then forward-solves `L y = b` and
@@ -19,6 +40,13 @@
  * `b` holds the solution `x`. `A` must be symmetric positive-definite; behaviour
  * on non-SPD input is undefined (the Cholesky step produces NaN, no info flag).
  * Thread-count invariant. NumPy equivalent: `x = np.linalg.solve(A, b)` (A SPD).
+ *
+ * @note Regularize / check / Levenberg flags live on the **multi-RHS** overload
+ * (`b` is an `n×1` column-major `B`, so the single-RHS flagged solve is
+ * `posv<T, N, 1, REGULARIZE, CHECK, REG_DIAG>(A, b, rho, s_fail)`). The single-RHS
+ * overload deliberately carries no flag template params: a flagged single-RHS
+ * form (`<T, N, bool…>`) would be ambiguous with `<T, N, NRHS, bool…>` at
+ * `NRHS∈{0,1}` (identical resolved signature), so flags are routed through NRHS.
  *
  * @tparam T  Scalar type (e.g. `float`, `double`).
  * @param n  Dimension (`A` is `n×n`, `b` has length `n`).
@@ -37,7 +65,9 @@ __device__ void posv(uint32_t n, T *A, T *b)
  * @brief Compile-time-size SPD solve `A x = b` (LAPACK posv).
  *
  * Same as the runtime `posv` with the dimension as a template parameter.
- * NumPy equivalent: `x = np.linalg.solve(A, b)` (A SPD).
+ * NumPy equivalent: `x = np.linalg.solve(A, b)` (A SPD). For the regularized /
+ * checked / Levenberg path use the multi-RHS overload with NRHS=1, e.g.
+ * `posv<T, N, 1, true, true, true>(A, b, rho, s_fail)`.
  *
  * @tparam T  Scalar type.
  * @tparam N  Dimension (`A` is `N×N`, `b` has length `N`).
@@ -95,18 +125,20 @@ __device__ void potrs(const T *L, T *b) { potrs<T>(N, L, b); }
  * `trsv` self-syncs, so no extra barrier is needed between columns. Thread-count
  * invariant. NumPy equivalent: `X = np.linalg.solve(A, B)` (A SPD, B `n×nrhs`).
  *
- * @par Regularize + check (`REGULARIZE` / `CHECK`, both compile-out, default off)
- * `REGULARIZE` adds `rho·I` to `A`'s diagonal before factoring — the
- * Levenberg-style shift used to push a borderline-indefinite Hessian (e.g. `Huu`)
+ * @par Regularize + check (`REGULARIZE` / `CHECK` / `REG_DIAG`, all compile-out, default off)
+ * `REGULARIZE` adds a shift to `A`'s diagonal before factoring — `rho·I`
+ * (Marquardt) by default, or `rho·diag(A)` (Levenberg, scale-invariant) when
+ * `REG_DIAG` is also set — used to push a borderline-indefinite Hessian (e.g. `Huu`)
  * back to SPD; `CHECK` forwards to the checked Cholesky and sets `*s_fail = 1` on
- * a non-PD pivot, so a caller can escalate `rho` and retry. Both default false and
+ * a non-PD pivot, so a caller can escalate `rho` and retry. All default false and
  * compile out (`if constexpr`), leaving the unflagged instantiation byte-identical
  * to the original. This is the fused "regularize → factor → solve" path: e.g.
- * `posv<T, N, NRHS, true, true>(A, B, rho, s_fail)`.
+ * `posv<T, N, NRHS, true, true>(A, B, rho, s_fail)` (add a trailing `true` for Levenberg).
  *
  * @tparam T     Scalar type (e.g. `float`, `double`).
- * @tparam REGULARIZE  If true, add `rho·I` to A before factoring (default false, compiles out).
+ * @tparam REGULARIZE  If true, shift A before factoring (default false, compiles out).
  * @tparam CHECK  If true, report a non-PD pivot via `s_fail` (default false, compiles out).
+ * @tparam REG_DIAG    With REGULARIZE: shift by `rho·diag(A)` instead of `rho·I` (default false).
  * @param n      Dimension (`A` is `n×n`, each column of `B` has length `n`).
  * @param nrhs   Number of right-hand sides (columns of `B`).
  * @param A      In/out SPD matrix (column-major); overwritten with its factor `L`.
@@ -114,15 +146,10 @@ __device__ void potrs(const T *L, T *b) { potrs<T>(N, L, b); }
  * @param rho    Diagonal shift added to A when REGULARIZE (ignored otherwise).
  * @param s_fail Optional non-PD flag when CHECK (set to 1 on a non-PD pivot, else 0).
  */
-template <typename T, bool REGULARIZE = false, bool CHECK = false>
+template <typename T, bool REGULARIZE = false, bool CHECK = false, bool REG_DIAG = false>
 __device__ void posv(uint32_t n, uint32_t nrhs, T *A, T *B, T rho = T(0), int *s_fail = nullptr)
 {
-    if constexpr (REGULARIZE) {                   // A += rho*I (Levenberg shift)
-        uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-        uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-        for (uint32_t i = rank; i < n; i += size) A[i*n + i] += rho;
-        __syncthreads();
-    }
+    if constexpr (REGULARIZE) _posv_regularize<T, REG_DIAG>(n, A, rho);  // rho*I or rho*diag(A)
     cholDecomp_InPlace<T, CHECK>(n, A, s_fail);   // A -> L (lower); trailing __syncthreads
     for (uint32_t c = 0; c < nrhs; c++) {
         T *Bc = B + c * n;                        // column c (column-major)
@@ -139,24 +166,28 @@ __device__ void posv(uint32_t n, uint32_t nrhs, T *A, T *B, T rho = T(0), int *s
  * `B + c*N`). Factored once, solved per column. NumPy equivalent:
  * `X = np.linalg.solve(A, B)` (A SPD).
  *
- * The optional `REGULARIZE` / `CHECK` flags (default off, compile out) add a
- * `rho·I` shift before factoring and report a non-PD pivot via `s_fail` — the
+ * The optional `REGULARIZE` / `CHECK` / `REG_DIAG` flags (default off, compile out)
+ * add a diagonal shift before factoring and report a non-PD pivot via `s_fail` — the
  * fused regularize→factor→solve path `posv<T, N, NRHS, true, true>(A, B, rho, s_fail)`.
+ * `REG_DIAG` (appended last so existing `<…, true, true>` callers are unaffected)
+ * switches the shift from `rho·I` to `rho·diag(A)` (Levenberg). A flagged single-RHS
+ * solve is just NRHS=1: `posv<T, N, 1, true, true, true>(A, b, rho, s_fail)`.
  *
  * @tparam T     Scalar type.
  * @tparam N     Dimension (`A` is `N×N`, each column of `B` has length `N`).
  * @tparam NRHS  Number of right-hand sides (columns of `B`).
- * @tparam REGULARIZE  If true, add `rho·I` to A before factoring (default false, compiles out).
+ * @tparam REGULARIZE  If true, shift A before factoring (default false, compiles out).
  * @tparam CHECK  If true, report a non-PD pivot via `s_fail` (default false, compiles out).
+ * @tparam REG_DIAG    With REGULARIZE: shift by `rho·diag(A)` instead of `rho·I` (default false).
  * @param A  In/out SPD matrix (column-major); overwritten with its factor `L`.
  * @param B  In/out right-hand sides (`N×NRHS`, column-major); on return holds `X`.
  * @param rho    Diagonal shift added to A when REGULARIZE (ignored otherwise).
  * @param s_fail Optional non-PD flag when CHECK (set to 1 on a non-PD pivot, else 0).
  */
-template <typename T, uint32_t N, uint32_t NRHS, bool REGULARIZE = false, bool CHECK = false>
+template <typename T, uint32_t N, uint32_t NRHS, bool REGULARIZE = false, bool CHECK = false, bool REG_DIAG = false>
 __device__ void posv(T *A, T *B, T rho = T(0), int *s_fail = nullptr)
 {
-    posv<T, REGULARIZE, CHECK>(N, NRHS, A, B, rho, s_fail);
+    posv<T, REGULARIZE, CHECK, REG_DIAG>(N, NRHS, A, B, rho, s_fail);
 }
 
 /**

--- a/src/base/L3/riccati.cuh
+++ b/src/base/L3/riccati.cuh
@@ -9,14 +9,14 @@
 // block, column-major. Requires congruence.cuh + posv.cuh (included first).
 
 /**
- * @brief Shared-memory floats needed by `riccati_gain` `s_temp`.
+ * @brief Shared-memory floats needed by `riccati_gain` `s_scratch`.
  *
  * Holds the NU×NU control-Hessian `S = R + BᵀPB` plus the larger of the two
  * congruence/bilinear products (`P·B` is NX×NU, `P·A` is NX×NX).
  *
  * @tparam NX  State dimension.
  * @tparam NU  Control dimension.
- * @return Number of `T` elements for `s_temp`.
+ * @return Number of `T` elements for `s_scratch`.
  */
 template <uint32_t NX, uint32_t NU>
 __host__ __device__ constexpr uint32_t riccati_smem_count() {
@@ -43,17 +43,17 @@ __host__ __device__ constexpr uint32_t riccati_smem_count() {
  * @param B  Control Jacobian (NX×NU, column-major).
  * @param R  Control cost (NU×NU, SPD, column-major).
  * @param Kgain  Out gain `K` (NU×NX, column-major).
- * @param s_temp  Shared scratch of `riccati_smem_count<NX,NU>()` elements.
+ * @param s_scratch  Shared scratch of `riccati_smem_count<NX,NU>()` elements.
  * @param rho     Diagonal shift on `S` when REGULARIZE (ignored otherwise).
  * @param s_fail  Optional flag: set to 1 if `S` (after the shift) is not PD, else 0.
  */
 template <typename T, uint32_t NX, uint32_t NU,
           bool REGULARIZE = false, bool TRAILING_SYNC = true>
 __device__ void riccati_gain(const T* P, const T* A, const T* B, const T* R,
-                             T* Kgain, T* s_temp, T rho = T(0), int* s_fail = nullptr)
+                             T* Kgain, T* s_scratch, T rho = T(0), int* s_fail = nullptr)
 {
-    T* S   = s_temp;                 // NU x NU control Hessian
-    T* scr = s_temp + NU*NU;         // congruence/bilinear product scratch
+    T* S   = s_scratch;                 // NU x NU control Hessian
+    T* scr = s_scratch + NU*NU;         // congruence/bilinear product scratch
 
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
@@ -68,4 +68,46 @@ __device__ void riccati_gain(const T* P, const T* A, const T* B, const T* R,
     posv<T, NU, NX, REGULARIZE, /*CHECK=*/true>(S, Kgain, rho, s_fail);
 
     if constexpr (TRAILING_SYNC) __syncthreads();
+}
+
+namespace warp {
+    /**
+     * @brief Single-warp LQR/iLQR feedback gain `K = (R + BᵀPB)⁻¹ (BᵀPA)`.
+     *
+     * Warp-per-knot parity with the block `glass::riccati_gain`: one 32-lane warp
+     * forms `S = R + BᵀPB` (`warp::congruence_sym`), `G = BᵀPA` (`warp::bilinear`),
+     * then solves `S·K = G` for the `NU×NX` gain with the checked, optionally
+     * regularized `warp::posv` (NRHS=NX). Every sub-op is `__syncwarp`-scoped, so
+     * independent warps may run distinct knots of a batched backward pass
+     * concurrently in one block. On return `Kgain` holds `K`; `P,A,B,R` unchanged.
+     *
+     * @tparam T  Scalar type (prefer `double` for ill-conditioned `S`).
+     * @tparam NX  State dimension (`P`,`A` are NX×NX, `B` is NX×NU).
+     * @tparam NU  Control dimension (`R` is NU×NU, `K` is NU×NX). Assumes `NX >= NU`.
+     * @tparam REGULARIZE  If true, add `rho·I` to `S` before the solve (default false).
+     * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true).
+     * @param P,A,B,R  Inputs (column-major; see the block overload).
+     * @param Kgain  Out gain `K` (NU×NX, column-major).
+     * @param s_scratch Shared scratch of `riccati_smem_count<NX,NU>()` elements (per warp).
+     * @param rho    Diagonal shift on `S` when REGULARIZE (ignored otherwise).
+     * @param s_fail Optional flag: set to 1 if `S` (after the shift) is not PD, else 0.
+     */
+    template <typename T, uint32_t NX, uint32_t NU,
+              bool REGULARIZE = false, bool TRAILING_SYNC = true>
+    __device__ void riccati_gain(const T* P, const T* A, const T* B, const T* R,
+                                 T* Kgain, T* s_scratch, T rho = T(0), int* s_fail = nullptr)
+    {
+        T* S   = s_scratch;                 // NU x NU control Hessian
+        T* scr = s_scratch + NU*NU;         // congruence/bilinear product scratch
+
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (uint32_t i = lane; i < NU*NU; i += 32) S[i] = R[i];   // S = R
+        __syncwarp();
+
+        congruence_sym<T, NX, NU, /*ACCUMULATE=*/true>(static_cast<T>(1), B, P, static_cast<T>(1), S, scr);
+        bilinear<T, NX, NU, NX>(static_cast<T>(1), B, P, A, static_cast<T>(0), Kgain, scr);
+        posv<T, NU, NX, REGULARIZE, /*CHECK=*/true>(S, Kgain, rho, s_fail);
+
+        if constexpr (TRAILING_SYNC) __syncwarp();
+    }
 }

--- a/src/base/L3/syrk.cuh
+++ b/src/base/L3/syrk.cuh
@@ -19,16 +19,16 @@ __device__ __forceinline__ bool syrk_in_canonical(FillMode fill, uint32_t row, u
 
 // ─── syrk core impl: explicit rank/size + layout flags ───────────────────────
 // C = alpha * op(A) * op(A)^T + beta * C, C is n x n symmetric.
-//   TRANS == false: op(A) = A   (A is n x k) → C = alpha*A*A^T + beta*C
-//   TRANS == true : op(A) = A^T (A is k x n) → C = alpha*A^T*A + beta*C
+//   TRANSPOSE == false: op(A) = A   (A is n x k) → C = alpha*A*A^T + beta*C
+//   TRANSPOSE == true : op(A) = A^T (A is k x n) → C = alpha*A^T*A + beta*C
 // Flat-element parallelism over the n*n grid exactly like gemm_impl: each thread
 // owns disjoint output cells, so NO interior barrier is needed (guide §1a
 // counter-note). The k-loop runs only in the canonical triangle (the symmetry
 // win); off-triangle cells are filled by the mirror write of their transpose.
-template <typename T, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syrk_impl(uint32_t rank, uint32_t size,
                           uint32_t n, uint32_t k,
-                          T alpha, T *A, T beta, T *C)
+                          T alpha, const T *A, T beta, T *C)
 {
     const uint32_t maxel = n * n;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -36,10 +36,10 @@ __device__ void syrk_impl(uint32_t rank, uint32_t size,
         if (!syrk_in_canonical(FILL, row, col)) continue;  // mirror handles it
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < k; i++) {
-            // TRANS=false: A is n x k → A[row,i], A[col,i].
-            // TRANS=true : A is k x n → A[i,row], A[i,col].
+            // TRANSPOSE=false: A is n x k → A[row,i], A[col,i].
+            // TRANSPOSE=true : A is k x n → A[i,row], A[i,col].
             T ar, ac;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*n + row] : A[row*k + i];
                 ac = ROW_MAJOR ? A[i*n + col] : A[col*k + i];
             } else {
@@ -58,10 +58,10 @@ __device__ void syrk_impl(uint32_t rank, uint32_t size,
 }
 
 // beta = 0 form: never reads C.
-template <typename T, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syrk_impl(uint32_t rank, uint32_t size,
                           uint32_t n, uint32_t k,
-                          T alpha, T *A, T *C)
+                          T alpha, const T *A, T *C)
 {
     const uint32_t maxel = n * n;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -70,7 +70,7 @@ __device__ void syrk_impl(uint32_t rank, uint32_t size,
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < k; i++) {
             T ar, ac;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*n + row] : A[row*k + i];
                 ac = ROW_MAJOR ? A[i*n + col] : A[col*k + i];
             } else {
@@ -90,9 +90,9 @@ __device__ void syrk_impl(uint32_t rank, uint32_t size,
 
 // compile-time impl: N, K as template params so el%N / el/N use magic-number
 // multiply instead of MUFU.RCP (mirrors gemm_impl_ct).
-template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syrk_impl_ct(uint32_t rank, uint32_t size,
-                             T alpha, T *A, T beta, T *C)
+                             T alpha, const T *A, T beta, T *C)
 {
     constexpr uint32_t maxel = N * N;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -101,7 +101,7 @@ __device__ void syrk_impl_ct(uint32_t rank, uint32_t size,
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < K; i++) {
             T ar, ac;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*N + row] : A[row*K + i];
                 ac = ROW_MAJOR ? A[i*N + col] : A[col*K + i];
             } else {
@@ -119,9 +119,9 @@ __device__ void syrk_impl_ct(uint32_t rank, uint32_t size,
     }
 }
 
-template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syrk_impl_ct(uint32_t rank, uint32_t size,
-                             T alpha, T *A, T *C)
+                             T alpha, const T *A, T *C)
 {
     constexpr uint32_t maxel = N * N;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -130,7 +130,7 @@ __device__ void syrk_impl_ct(uint32_t rank, uint32_t size,
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < K; i++) {
             T ar, ac;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*N + row] : A[row*K + i];
                 ac = ROW_MAJOR ? A[i*N + col] : A[col*K + i];
             } else {
@@ -151,12 +151,12 @@ __device__ void syrk_impl_ct(uint32_t rank, uint32_t size,
 // ─── syr2k core impl: explicit rank/size + layout flags ──────────────────────
 // C = alpha*(op(A)*op(B)^T + op(B)*op(A)^T) + beta*C, C n x n symmetric.
 // Symmetric by construction: cell (row,col) is the symmetric dot
-//   Σ_i ( a(row,i)*b(col,i) + b(row,i)*a(col,i) )  [TRANS=false reading semantics]
+//   Σ_i ( a(row,i)*b(col,i) + b(row,i)*a(col,i) )  [TRANSPOSE=false reading semantics]
 // which equals cell (col,row), so the same mirror-write trick applies.
-template <typename T, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syr2k_impl(uint32_t rank, uint32_t size,
                            uint32_t n, uint32_t k,
-                           T alpha, T *A, T *B, T beta, T *C)
+                           T alpha, const T *A, const T *B, T beta, T *C)
 {
     const uint32_t maxel = n * n;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -165,7 +165,7 @@ __device__ void syr2k_impl(uint32_t rank, uint32_t size,
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < k; i++) {
             T ar, ac, br, bc;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*n + row] : A[row*k + i];
                 ac = ROW_MAJOR ? A[i*n + col] : A[col*k + i];
                 br = ROW_MAJOR ? B[i*n + row] : B[row*k + i];
@@ -187,10 +187,10 @@ __device__ void syr2k_impl(uint32_t rank, uint32_t size,
     }
 }
 
-template <typename T, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syr2k_impl(uint32_t rank, uint32_t size,
                            uint32_t n, uint32_t k,
-                           T alpha, T *A, T *B, T *C)
+                           T alpha, const T *A, const T *B, T *C)
 {
     const uint32_t maxel = n * n;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -199,7 +199,7 @@ __device__ void syr2k_impl(uint32_t rank, uint32_t size,
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < k; i++) {
             T ar, ac, br, bc;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*n + row] : A[row*k + i];
                 ac = ROW_MAJOR ? A[i*n + col] : A[col*k + i];
                 br = ROW_MAJOR ? B[i*n + row] : B[row*k + i];
@@ -221,9 +221,9 @@ __device__ void syr2k_impl(uint32_t rank, uint32_t size,
     }
 }
 
-template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syr2k_impl_ct(uint32_t rank, uint32_t size,
-                              T alpha, T *A, T *B, T beta, T *C)
+                              T alpha, const T *A, const T *B, T beta, T *C)
 {
     constexpr uint32_t maxel = N * N;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -232,7 +232,7 @@ __device__ void syr2k_impl_ct(uint32_t rank, uint32_t size,
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < K; i++) {
             T ar, ac, br, bc;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*N + row] : A[row*K + i];
                 ac = ROW_MAJOR ? A[i*N + col] : A[col*K + i];
                 br = ROW_MAJOR ? B[i*N + row] : B[row*K + i];
@@ -254,9 +254,9 @@ __device__ void syr2k_impl_ct(uint32_t rank, uint32_t size,
     }
 }
 
-template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <typename T, uint32_t N, uint32_t K, FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __device__ void syr2k_impl_ct(uint32_t rank, uint32_t size,
-                              T alpha, T *A, T *B, T *C)
+                              T alpha, const T *A, const T *B, T *C)
 {
     constexpr uint32_t maxel = N * N;
     for (uint32_t el = rank; el < maxel; el += size) {
@@ -265,7 +265,7 @@ __device__ void syr2k_impl_ct(uint32_t rank, uint32_t size,
         T res = static_cast<T>(0);
         for (uint32_t i = 0; i < K; i++) {
             T ar, ac, br, bc;
-            if (TRANS) {
+            if (TRANSPOSE) {
                 ar = ROW_MAJOR ? A[i*N + row] : A[row*K + i];
                 ac = ROW_MAJOR ? A[i*N + col] : A[col*K + i];
                 br = ROW_MAJOR ? B[i*N + row] : B[row*K + i];
@@ -302,24 +302,25 @@ __device__ void syr2k_impl_ct(uint32_t rank, uint32_t size,
  *
  * @tparam T  Scalar type.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op(A)=A (A is n x k); if true, op(A)=A^T (A is k x n).
+ * @tparam TRANSPOSE  If false, op(A)=A (A is n x k); if true, op(A)=A^T (A is k x n).
  * @tparam ROW_MAJOR  Storage order for A and C (false = column-major / Fortran).
  * @param n  Dimension of the symmetric result C (n x n).
  * @param k  Contraction length.
  * @param alpha  Scalar multiplier on the product.
- * @param A  Input matrix (n x k if TRANS=false, else k x n).
+ * @param A  Input matrix (n x k if TRANSPOSE=false, else k x n).
  * @param beta  Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C  In/out n x n symmetric result matrix.
  *
- * NumPy equivalent: TRANS=false → `alpha * A @ A.T + beta * C`;
- * TRANS=true → `alpha * A.T @ A + beta * C`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha * A @ A.T + beta * C`;
+ * TRANSPOSE=true → `alpha * A.T @ A + beta * C`.
  */
-template <typename T, FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syrk(uint32_t n, uint32_t k, T alpha, T *A, T beta, T *C)
+template <typename T, FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syrk(uint32_t n, uint32_t k, T alpha, const T *A, T beta, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syrk_impl<T, FILL, TRANS, ROW_MAJOR>(rank, size, n, k, alpha, A, beta, C);
+    syrk_impl<T, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, n, k, alpha, A, beta, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -333,22 +334,23 @@ __device__ void syrk(uint32_t n, uint32_t k, T alpha, T *A, T beta, T *C)
  *
  * @tparam T  Scalar type.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op(A)=A (A is n x k); if true, op(A)=A^T (A is k x n).
+ * @tparam TRANSPOSE  If false, op(A)=A (A is n x k); if true, op(A)=A^T (A is k x n).
  * @tparam ROW_MAJOR  Storage order for A and C (false = column-major / Fortran).
  * @param n  Dimension of the symmetric result C (n x n).
  * @param k  Contraction length.
  * @param alpha  Scalar multiplier on the product.
- * @param A  Input matrix (n x k if TRANS=false, else k x n).
+ * @param A  Input matrix (n x k if TRANSPOSE=false, else k x n).
  * @param C  Output n x n symmetric result matrix (overwritten, not read).
  *
- * NumPy equivalent: TRANS=false → `alpha * A @ A.T`; TRANS=true → `alpha * A.T @ A`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha * A @ A.T`; TRANSPOSE=true → `alpha * A.T @ A`.
  */
-template <typename T, FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syrk(uint32_t n, uint32_t k, T alpha, T *A, T *C)
+template <typename T, FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syrk(uint32_t n, uint32_t k, T alpha, const T *A, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syrk_impl<T, FILL, TRANS, ROW_MAJOR>(rank, size, n, k, alpha, A, C);
+    syrk_impl<T, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, n, k, alpha, A, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 // ─── syrk compile-time size variants ─────────────────────────────────────────
@@ -366,23 +368,24 @@ __device__ void syrk(uint32_t n, uint32_t k, T alpha, T *A, T *C)
  * @tparam N  Compile-time dimension of the symmetric result C (N x N).
  * @tparam K  Compile-time contraction length.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op(A)=A (A is N x K); if true, op(A)=A^T (A is K x N).
+ * @tparam TRANSPOSE  If false, op(A)=A (A is N x K); if true, op(A)=A^T (A is K x N).
  * @tparam ROW_MAJOR  Storage order for A and C (false = column-major / Fortran).
  * @param alpha  Scalar multiplier on the product.
- * @param A  Input matrix (N x K if TRANS=false, else K x N).
+ * @param A  Input matrix (N x K if TRANSPOSE=false, else K x N).
  * @param beta  Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C  In/out N x N symmetric result matrix.
  *
- * NumPy equivalent: TRANS=false → `alpha * A @ A.T + beta * C`;
- * TRANS=true → `alpha * A.T @ A + beta * C`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha * A @ A.T + beta * C`;
+ * TRANSPOSE=true → `alpha * A.T @ A + beta * C`.
  */
 template <typename T, uint32_t N, uint32_t K,
-          FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syrk(T alpha, T *A, T beta, T *C)
+          FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syrk(T alpha, const T *A, T beta, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syrk_impl_ct<T, N, K, FILL, TRANS, ROW_MAJOR>(rank, size, alpha, A, beta, C);
+    syrk_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, alpha, A, beta, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -396,21 +399,22 @@ __device__ void syrk(T alpha, T *A, T beta, T *C)
  * @tparam N  Compile-time dimension of the symmetric result C (N x N).
  * @tparam K  Compile-time contraction length.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op(A)=A (A is N x K); if true, op(A)=A^T (A is K x N).
+ * @tparam TRANSPOSE  If false, op(A)=A (A is N x K); if true, op(A)=A^T (A is K x N).
  * @tparam ROW_MAJOR  Storage order for A and C (false = column-major / Fortran).
  * @param alpha  Scalar multiplier on the product.
- * @param A  Input matrix (N x K if TRANS=false, else K x N).
+ * @param A  Input matrix (N x K if TRANSPOSE=false, else K x N).
  * @param C  Output N x N symmetric result matrix (overwritten, not read).
  *
- * NumPy equivalent: TRANS=false → `alpha * A @ A.T`; TRANS=true → `alpha * A.T @ A`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha * A @ A.T`; TRANSPOSE=true → `alpha * A.T @ A`.
  */
 template <typename T, uint32_t N, uint32_t K,
-          FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syrk(T alpha, T *A, T *C)
+          FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syrk(T alpha, const T *A, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syrk_impl_ct<T, N, K, FILL, TRANS, ROW_MAJOR>(rank, size, alpha, A, C);
+    syrk_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, alpha, A, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 // ─── syr2k runtime variants ──────────────────────────────────────────────────
@@ -425,24 +429,25 @@ __device__ void syrk(T alpha, T *A, T *C)
  *
  * @tparam T  Scalar type.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op = identity (A,B are n x k); if true, op = transpose (A,B are k x n).
+ * @tparam TRANSPOSE  If false, op = identity (A,B are n x k); if true, op = transpose (A,B are k x n).
  * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
  * @param n  Dimension of the symmetric result C (n x n).
  * @param k  Contraction length.
  * @param alpha  Scalar multiplier on the symmetrized product.
- * @param A,B  Input matrices (n x k if TRANS=false, else k x n).
+ * @param A,B  Input matrices (n x k if TRANSPOSE=false, else k x n).
  * @param beta  Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C  In/out n x n symmetric result matrix.
  *
- * NumPy equivalent: TRANS=false → `alpha*(A@B.T + B@A.T) + beta*C`;
- * TRANS=true → `alpha*(A.T@B + B.T@A) + beta*C`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha*(A@B.T + B@A.T) + beta*C`;
+ * TRANSPOSE=true → `alpha*(A.T@B + B.T@A) + beta*C`.
  */
-template <typename T, FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syr2k(uint32_t n, uint32_t k, T alpha, T *A, T *B, T beta, T *C)
+template <typename T, FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syr2k(uint32_t n, uint32_t k, T alpha, const T *A, const T *B, T beta, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syr2k_impl<T, FILL, TRANS, ROW_MAJOR>(rank, size, n, k, alpha, A, B, beta, C);
+    syr2k_impl<T, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, n, k, alpha, A, B, beta, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -454,23 +459,24 @@ __device__ void syr2k(uint32_t n, uint32_t k, T alpha, T *A, T *B, T beta, T *C)
  *
  * @tparam T  Scalar type.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op = identity (A,B are n x k); if true, op = transpose (A,B are k x n).
+ * @tparam TRANSPOSE  If false, op = identity (A,B are n x k); if true, op = transpose (A,B are k x n).
  * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
  * @param n  Dimension of the symmetric result C (n x n).
  * @param k  Contraction length.
  * @param alpha  Scalar multiplier on the symmetrized product.
- * @param A,B  Input matrices (n x k if TRANS=false, else k x n).
+ * @param A,B  Input matrices (n x k if TRANSPOSE=false, else k x n).
  * @param C  Output n x n symmetric result matrix (overwritten, not read).
  *
- * NumPy equivalent: TRANS=false → `alpha*(A@B.T + B@A.T)`;
- * TRANS=true → `alpha*(A.T@B + B.T@A)`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha*(A@B.T + B@A.T)`;
+ * TRANSPOSE=true → `alpha*(A.T@B + B.T@A)`.
  */
-template <typename T, FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syr2k(uint32_t n, uint32_t k, T alpha, T *A, T *B, T *C)
+template <typename T, FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syr2k(uint32_t n, uint32_t k, T alpha, const T *A, const T *B, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syr2k_impl<T, FILL, TRANS, ROW_MAJOR>(rank, size, n, k, alpha, A, B, C);
+    syr2k_impl<T, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, n, k, alpha, A, B, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 // ─── syr2k compile-time size variants ────────────────────────────────────────
@@ -487,23 +493,24 @@ __device__ void syr2k(uint32_t n, uint32_t k, T alpha, T *A, T *B, T *C)
  * @tparam N  Compile-time dimension of the symmetric result C (N x N).
  * @tparam K  Compile-time contraction length.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op = identity (A,B are N x K); if true, op = transpose (A,B are K x N).
+ * @tparam TRANSPOSE  If false, op = identity (A,B are N x K); if true, op = transpose (A,B are K x N).
  * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
  * @param alpha  Scalar multiplier on the symmetrized product.
- * @param A,B  Input matrices (N x K if TRANS=false, else K x N).
+ * @param A,B  Input matrices (N x K if TRANSPOSE=false, else K x N).
  * @param beta  Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C  In/out N x N symmetric result matrix.
  *
- * NumPy equivalent: TRANS=false → `alpha*(A@B.T + B@A.T) + beta*C`;
- * TRANS=true → `alpha*(A.T@B + B.T@A) + beta*C`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha*(A@B.T + B@A.T) + beta*C`;
+ * TRANSPOSE=true → `alpha*(A.T@B + B.T@A) + beta*C`.
  */
 template <typename T, uint32_t N, uint32_t K,
-          FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syr2k(T alpha, T *A, T *B, T beta, T *C)
+          FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syr2k(T alpha, const T *A, const T *B, T beta, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syr2k_impl_ct<T, N, K, FILL, TRANS, ROW_MAJOR>(rank, size, alpha, A, B, beta, C);
+    syr2k_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, alpha, A, B, beta, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
 /**
@@ -517,20 +524,80 @@ __device__ void syr2k(T alpha, T *A, T *B, T beta, T *C)
  * @tparam N  Compile-time dimension of the symmetric result C (N x N).
  * @tparam K  Compile-time contraction length.
  * @tparam FILL  Which triangle of C to write (Lower / Upper / Full).
- * @tparam TRANS  If false, op = identity (A,B are N x K); if true, op = transpose (A,B are K x N).
+ * @tparam TRANSPOSE  If false, op = identity (A,B are N x K); if true, op = transpose (A,B are K x N).
  * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major / Fortran).
  * @param alpha  Scalar multiplier on the symmetrized product.
- * @param A,B  Input matrices (N x K if TRANS=false, else K x N).
+ * @param A,B  Input matrices (N x K if TRANSPOSE=false, else K x N).
  * @param C  Output N x N symmetric result matrix (overwritten, not read).
  *
- * NumPy equivalent: TRANS=false → `alpha*(A@B.T + B@A.T)`;
- * TRANS=true → `alpha*(A.T@B + B.T@A)`.
+ * NumPy equivalent: TRANSPOSE=false → `alpha*(A@B.T + B@A.T)`;
+ * TRANSPOSE=true → `alpha*(A.T@B + B.T@A)`.
  */
 template <typename T, uint32_t N, uint32_t K,
-          FillMode FILL = FillMode::Full, bool TRANS = false, bool ROW_MAJOR = false>
-__device__ void syr2k(T alpha, T *A, T *B, T *C)
+          FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void syr2k(T alpha, const T *A, const T *B, T *C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    syr2k_impl_ct<T, N, K, FILL, TRANS, ROW_MAJOR>(rank, size, alpha, A, B, C);
+    syr2k_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(rank, size, alpha, A, B, C);
+    if constexpr (TRAILING_SYNC) __syncthreads();
+}
+
+namespace warp {
+    // Single-warp SYRK / SYR2K: one 32-lane warp owns the symmetric output via the
+    // SAME validated `syrk_impl_ct` / `syr2k_impl_ct` flat-element kernels, just
+    // dispatched with (lane, 32) instead of (rank, blockDim). Each output element is
+    // written once (no cross-lane reduction — the K contraction is a per-lane serial
+    // loop), so this is bit-identical to the block form restricted to one warp. For
+    // warp-per-problem normal-equation builds (e.g. HJCD's JᵀJ). Full 32 lanes
+    // required; independent warps may run distinct problems. No `__syncwarp` needed
+    // (no inter-lane dependency); compile-time size only, mirroring `warp::gemm`.
+
+    /**
+     * @brief Single-warp SYRK `C = alpha*op(A)*op(A)ᵀ + beta*C` (compile-time size).
+     * @see ::syrk  (block form; identical math, `(lane,32)` element striping)
+     */
+    template <typename T, uint32_t N, uint32_t K,
+              FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false>
+    __device__ void syrk(T alpha, const T *A, T beta, T *C)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        syrk_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(lane, 32, alpha, A, beta, C);
+    }
+
+    /**
+     * @brief Single-warp SYRK with implicit `beta = 0`: `C = alpha*op(A)*op(A)ᵀ` (overwrite).
+     * @see ::syrk
+     */
+    template <typename T, uint32_t N, uint32_t K,
+              FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false>
+    __device__ void syrk(T alpha, const T *A, T *C)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        syrk_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(lane, 32, alpha, A, C);
+    }
+
+    /**
+     * @brief Single-warp SYR2K `C = alpha*(op(A)op(B)ᵀ + op(B)op(A)ᵀ) + beta*C` (compile-time size).
+     * @see ::syr2k
+     */
+    template <typename T, uint32_t N, uint32_t K,
+              FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false>
+    __device__ void syr2k(T alpha, const T *A, const T *B, T beta, T *C)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        syr2k_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(lane, 32, alpha, A, B, beta, C);
+    }
+
+    /**
+     * @brief Single-warp SYR2K with implicit `beta = 0` (overwrite).
+     * @see ::syr2k
+     */
+    template <typename T, uint32_t N, uint32_t K,
+              FillMode FILL = FillMode::Full, bool TRANSPOSE = false, bool ROW_MAJOR = false>
+    __device__ void syr2k(T alpha, const T *A, const T *B, T *C)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        syr2k_impl_ct<T, N, K, FILL, TRANSPOSE, ROW_MAJOR>(lane, 32, alpha, A, B, C);
+    }
 }

--- a/src/base/L3/syrk_reduced.cuh
+++ b/src/base/L3/syrk_reduced.cuh
@@ -17,14 +17,14 @@
 
 namespace detail {
     // C = alpha * A op(A) (+ beta*C), A is ROWS×COLS column-major.
-    // TRANS=false (A·Aᵀ): C is ROWS×ROWS, contract c over COLS, A[i + c*ROWS].
-    // TRANS=true  (Aᵀ·A): C is COLS×COLS, contract c over ROWS, A[c + i*ROWS].
+    // TRANSPOSE=false (A·Aᵀ): C is ROWS×ROWS, contract c over COLS, A[i + c*ROWS].
+    // TRANSPOSE=true  (Aᵀ·A): C is COLS×COLS, contract c over ROWS, A[c + i*ROWS].
     // Lower triangle computed and mirrored (output is full symmetric).
-    template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANS, bool HAS_BETA>
+    template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANSPOSE, bool HAS_BETA>
     __device__ void syrk_reduced_impl(uint32_t rank, uint32_t size, T alpha, const T* A, T beta, T* C)
     {
-        constexpr uint32_t OUT  = TRANS ? COLS : ROWS;
-        constexpr uint32_t CDIM = TRANS ? ROWS : COLS;
+        constexpr uint32_t OUT  = TRANSPOSE ? COLS : ROWS;
+        constexpr uint32_t CDIM = TRANSPOSE ? ROWS : COLS;
         constexpr uint32_t maxel = OUT * OUT;
 
         if (size < 32u) {
@@ -36,8 +36,8 @@ namespace detail {
                 for (uint32_t vlane = 0; vlane < 32u; ++vlane) {
                     T acc = static_cast<T>(0);
                     for (uint32_t c = vlane; c < CDIM; c += 32u) {
-                        const T ai = TRANS ? A[c + i*ROWS] : A[i + c*ROWS];
-                        const T aj = TRANS ? A[c + j*ROWS] : A[j + c*ROWS];
+                        const T ai = TRANSPOSE ? A[c + i*ROWS] : A[i + c*ROWS];
+                        const T aj = TRANSPOSE ? A[c + j*ROWS] : A[j + c*ROWS];
                         acc += ai * aj;
                     }
                     p[vlane] = acc;
@@ -60,8 +60,8 @@ namespace detail {
                 if (i < j) continue;
                 T partial = static_cast<T>(0);
                 for (uint32_t c = lane; c < CDIM; c += 32u) {
-                    const T ai = TRANS ? A[c + i*ROWS] : A[i + c*ROWS];
-                    const T aj = TRANS ? A[c + j*ROWS] : A[j + c*ROWS];
+                    const T ai = TRANSPOSE ? A[c + i*ROWS] : A[i + c*ROWS];
+                    const T aj = TRANSPOSE ? A[c + j*ROWS] : A[j + c*ROWS];
                     partial += ai * aj;
                 }
                 const T res = warp::reduce<T>(partial);
@@ -88,19 +88,19 @@ namespace detail {
  *
  * @tparam T  Scalar type.
  * @tparam ROWS,COLS  A is ROWS x COLS (column-major).
- * @tparam TRANS  If true, `C = AᵀA` (COLS x COLS); else `C = AAᵀ` (ROWS x ROWS).
+ * @tparam TRANSPOSE  If true, `C = AᵀA` (COLS x COLS); else `C = AAᵀ` (ROWS x ROWS).
  * @tparam TRAILING_SYNC  Emit a trailing `__syncthreads()` (default true).
  * @param alpha  Scalar on the product.
  * @param A      Input matrix (ROWS x COLS, column-major).
  * @param beta   Scalar on the existing C (read; caller must initialize it).
- * @param C      In/out symmetric result (full storage; OUT x OUT, OUT = TRANS?COLS:ROWS).
+ * @param C      In/out symmetric result (full storage; OUT x OUT, OUT = TRANSPOSE?COLS:ROWS).
  */
-template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void syrk_reduced(T alpha, const T* A, T beta, T* C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    detail::syrk_reduced_impl<T, ROWS, COLS, TRANS, true>(rank, size, alpha, A, beta, C);
+    detail::syrk_reduced_impl<T, ROWS, COLS, TRANSPOSE, true>(rank, size, alpha, A, beta, C);
     if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
@@ -109,16 +109,16 @@ __device__ void syrk_reduced(T alpha, const T* A, T beta, T* C)
  *
  * Overwrites C (not read). Otherwise identical to the beta overload.
  *
- * @tparam T,ROWS,COLS,TRANS,TRAILING_SYNC  See the beta overload.
+ * @tparam T,ROWS,COLS,TRANSPOSE,TRAILING_SYNC  See the beta overload.
  * @param alpha,A  See the beta overload.
  * @param C  Output (overwritten; full symmetric).
  */
-template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void syrk_reduced(T alpha, const T* A, T* C)
 {
     uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
     uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    detail::syrk_reduced_impl<T, ROWS, COLS, TRANS, false>(rank, size, alpha, A, static_cast<T>(0), C);
+    detail::syrk_reduced_impl<T, ROWS, COLS, TRANSPOSE, false>(rank, size, alpha, A, static_cast<T>(0), C);
     if constexpr (TRAILING_SYNC) __syncthreads();
 }
 
@@ -128,29 +128,29 @@ namespace warp {
      *
      * Warp-per-problem analogue of `glass::syrk_reduced`; one full 32-lane warp.
      *
-     * @tparam T,ROWS,COLS,TRANS  See glass::syrk_reduced.
+     * @tparam T,ROWS,COLS,TRANSPOSE  See glass::syrk_reduced.
      * @tparam TRAILING_SYNC  Emit a trailing `__syncwarp()` (default true).
      * @param alpha,A,beta,C  See glass::syrk_reduced.
      */
-    template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANS = false, bool TRAILING_SYNC = true>
+    template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
     __device__ void syrk_reduced(T alpha, const T* A, T beta, T* C)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        detail::syrk_reduced_impl<T, ROWS, COLS, TRANS, true>(lane, 32u, alpha, A, beta, C);
+        detail::syrk_reduced_impl<T, ROWS, COLS, TRANSPOSE, true>(lane, 32u, alpha, A, beta, C);
         if constexpr (TRAILING_SYNC) __syncwarp();
     }
 
     /**
      * @brief Single-warp contraction-parallel SYRK, implicit `beta = 0`: `C = alpha * A·op(A)`.
      *
-     * @tparam T,ROWS,COLS,TRANS,TRAILING_SYNC  See the beta overload.
+     * @tparam T,ROWS,COLS,TRANSPOSE,TRAILING_SYNC  See the beta overload.
      * @param alpha,A,C  See the beta overload.
      */
-    template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANS = false, bool TRAILING_SYNC = true>
+    template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
     __device__ void syrk_reduced(T alpha, const T* A, T* C)
     {
         uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31u;
-        detail::syrk_reduced_impl<T, ROWS, COLS, TRANS, false>(lane, 32u, alpha, A, static_cast<T>(0), C);
+        detail::syrk_reduced_impl<T, ROWS, COLS, TRANSPOSE, false>(lane, 32u, alpha, A, static_cast<T>(0), C);
         if constexpr (TRAILING_SYNC) __syncwarp();
     }
 }

--- a/src/base/L3/trsm.cuh
+++ b/src/base/L3/trsm.cuh
@@ -1,4 +1,5 @@
 #pragma once
+#include "../barrier.cuh"
 #include <cstdint>
 #include "chol_InPlace.cuh"  // warp::cholDecomp_InPlace, composed by warp::posv
 
@@ -14,20 +15,27 @@
  * @param L  Lower-triangular matrix (column-major).
  * @param b  In/out right-hand side; on return holds the solution x.
  */
+// Shared body: forward-substitution lower-triangular solve; barrier policy
+// supplies rank/size + the two per-column syncs, shared by glass:: and cgrps::.
+template <typename Bar, typename T>
+__device__ void trsm_impl(Bar bar, uint32_t n, T *L, T *b)
+{
+    uint32_t rank = bar.rank(), size = bar.size();
+    for (uint32_t col = 0; col < n; col++) {
+        if (rank == 0) b[col] /= L[col*n + col];
+        bar.sync();
+        T factor = b[col];
+        for (uint32_t row = rank + col + 1; row < n; row += size)
+            b[row] -= L[col*n + row] * factor;
+        bar.sync();
+    }
+}
+
 // Solve lower-triangular Lx=b in-place (column-major L, result overwrites b)
 template <typename T>
 __device__ void trsm(uint32_t n, T *L, T *b)
 {
-    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
-    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
-    for (uint32_t col = 0; col < n; col++) {
-        if (rank == 0) b[col] /= L[col*n + col];
-        __syncthreads();
-        T factor = b[col];
-        for (uint32_t row = rank + col + 1; row < n; row += size)
-            b[row] -= L[col*n + row] * factor;
-        __syncthreads();
-    }
+    trsm_impl<BlockBarrier, T>(BlockBarrier{}, n, L, b);
 }
 
 /**
@@ -187,7 +195,7 @@ namespace warp {
     }
 
     // ── unit-diagonal lower variants (the existing warp::trsm/trsm_transpose are
-    //    non-unit only); needed so trsv can offer the full {LOWER,UNIT,TRANS} matrix.
+    //    non-unit only); needed so trsv can offer the full {LOWER,UNIT,TRANSPOSE} matrix.
     /**
      * @brief Single-warp unit-lower solve `L x = b` (forward substitution), compile-time size.
      *
@@ -249,30 +257,30 @@ namespace warp {
      * @brief Single-warp triangular solve `op(A) x = b` (TRSV), flagged dispatch, compile-time size.
      *
      * Thin compile-time-flagged wrapper selecting the right single-warp triangular
-     * solve for any `{LOWER, UNIT, TRANS}` combination, dispatching to the lower
+     * solve for any `{LOWER, UNIT, TRANSPOSE}` combination, dispatching to the lower
      * `warp::trsm`/`warp::trsm_transpose` (and their unit-diagonal twins) or the
      * upper `warp::trsm_upper`/`warp::trsm_upper_transpose`. Solves in place
      * (`b` overwritten with `x`); `A` is column-major and only the named triangle is
      * read. One 32-lane warp, no shared scratch, no `__syncthreads`; this is its OWN
      * warp implementation and does not share an impl with the block trsv. SciPy:
-     * `x = scipy.linalg.solve_triangular(A, b, lower=LOWER, trans=TRANS, unit_diagonal=UNIT)`.
+     * `x = scipy.linalg.solve_triangular(A, b, lower=LOWER, trans=TRANSPOSE, unit_diagonal=UNIT)`.
      *
      * @tparam T      Scalar type.
      * @tparam N      Dimension (A is N x N, b has length N).
      * @tparam LOWER  When true, `A` is lower-triangular (default true); else upper.
      * @tparam UNIT   When true, `A` has an implicit unit diagonal (default false).
-     * @tparam TRANS  When true, solve `Aᵀ x = b` instead of `A x = b` (default false).
+     * @tparam TRANSPOSE  When true, solve `Aᵀ x = b` instead of `A x = b` (default false).
      * @param A  Triangular matrix (column-major); only the `LOWER`/upper triangle read.
      * @param b  In/out right-hand side; on return holds the solution x.
      */
-    template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANS = false>
+    template <typename T, uint32_t N, bool LOWER = true, bool UNIT = false, bool TRANSPOSE = false>
     __device__ void trsv(T *A, T *b)
     {
         if (LOWER) {
-            if (!TRANS) { if (UNIT) trsm_unit<T, N>(A, b);           else trsm<T, N>(A, b); }
+            if (!TRANSPOSE) { if (UNIT) trsm_unit<T, N>(A, b);           else trsm<T, N>(A, b); }
             else        { if (UNIT) trsm_transpose_unit<T, N>(A, b); else trsm_transpose<T, N>(A, b); }
         } else {
-            if (!TRANS) trsm_upper<T, N, UNIT>(A, b);
+            if (!TRANSPOSE) trsm_upper<T, N, UNIT>(A, b);
             else        trsm_upper_transpose<T, N, UNIT>(A, b);
         }
     }
@@ -282,8 +290,8 @@ namespace warp {
      *
      * One 32-lane warp solves the symmetric-positive-definite system `A x = b` in
      * place: it factors `A = L Lᵀ` with `warp::cholDecomp_InPlace` (lower triangle
-     * overwrites `A`), then a forward solve `L y = b` (`trsv<…,LOWER,!TRANS>`) and a
-     * back solve `Lᵀ x = y` (`trsv<…,LOWER,TRANS>`). On return `b` holds `x` and the
+     * overwrites `A`), then a forward solve `L y = b` (`trsv<…,LOWER,!TRANSPOSE>`) and a
+     * back solve `Lᵀ x = y` (`trsv<…,LOWER,TRANSPOSE>`). On return `b` holds `x` and the
      * lower triangle of `A` holds `L`. This is the composed warp-per-problem solve —
      * the proof that the warp L1/L2/L3 glue closes the gap. No shared scratch, no
      * `__syncthreads`; every pivot broadcast from a register (§1g). `A` must be SPD
@@ -299,7 +307,65 @@ namespace warp {
     __device__ void posv(T *A, T *b)
     {
         cholDecomp_InPlace<T, N>(A);
-        trsv<T, N, /*LOWER=*/true, /*UNIT=*/false, /*TRANS=*/false>(A, b);  // forward: L y = b
-        trsv<T, N, /*LOWER=*/true, /*UNIT=*/false, /*TRANS=*/true>(A, b);   // back:   Lᵀ x = y
+        trsv<T, N, /*LOWER=*/true, /*UNIT=*/false, /*TRANSPOSE=*/false>(A, b);  // forward: L y = b
+        trsv<T, N, /*LOWER=*/true, /*UNIT=*/false, /*TRANSPOSE=*/true>(A, b);   // back:   Lᵀ x = y
+    }
+
+    /**
+     * @brief Add a diagonal regularization shift to A in place (single-warp helper).
+     *
+     * Lane-strided over the `n` diagonal entries; `REG_DIAG=false` adds `rho·I`
+     * (Marquardt), `REG_DIAG=true` adds `rho·diag(A)` (Levenberg). Trailing
+     * `__syncwarp()` so the shifted A is warp-visible before factoring. Internal.
+     */
+    template <typename T, bool REG_DIAG = false>
+    __device__ void _posv_regularize(uint32_t n, T *A, T rho)
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        for (uint32_t i = lane; i < n; i += 32) {
+            if constexpr (REG_DIAG) A[i*n + i] += rho * A[i*n + i];   // rho*diag(A)
+            else                    A[i*n + i] += rho;                // rho*I
+        }
+        __syncwarp();
+    }
+
+    /**
+     * @brief Single-warp regularized/checked multi-RHS SPD solve `A X = B` (LAPACK posv).
+     *
+     * Warp-per-problem parity with the block multi-RHS `glass::posv`: one 32-lane
+     * warp optionally shifts `A`'s diagonal (`REGULARIZE`: `rho·I`, or `rho·diag(A)`
+     * when `REG_DIAG`), factors `A = L Lᵀ` via `warp::cholDecomp_InPlace<…,CHECK>`
+     * (reporting a non-PD pivot through `s_fail`), then forward/back-solves each of
+     * the `NRHS` columns of `B` (column-major, column `c` at `B + c*N`). On return
+     * `A` holds `L` and `B` holds `X`. No shared scratch, no `__syncthreads`.
+     *
+     * A flagged **single**-RHS solve is just NRHS=1 — the form HJCD's LM step wants:
+     * `warp::posv<T, DIM, 1, REGULARIZE=true, CHECK=true, REG_DIAG=true>(A, b, lambda, &s_fail)`
+     * folds the `A += lambda*diag(A)` damping and the non-PD net into one call. (The
+     * unflagged 2-arg `warp::posv<T,N>(A,b)` stays; flags cannot live on it without
+     * colliding with this overload at NRHS in {0,1}.)
+     *
+     * @tparam T     Scalar type (use `double` for ill-conditioned A).
+     * @tparam N     Dimension (A is N x N, each column of B has length N).
+     * @tparam NRHS  Number of right-hand sides (columns of B).
+     * @tparam REGULARIZE  If true, shift A before factoring (default false, compiles out).
+     * @tparam CHECK  If true, report a non-PD pivot via `s_fail` (default false, compiles out).
+     * @tparam REG_DIAG    With REGULARIZE: shift by `rho·diag(A)` instead of `rho·I` (default false).
+     * @param A  In/out SPD matrix (column-major); on return its lower triangle holds L.
+     * @param B  In/out right-hand sides (N x NRHS, column-major); on return holds X.
+     * @param rho    Diagonal shift applied when REGULARIZE (ignored otherwise).
+     * @param s_fail Optional non-PD flag when CHECK (set to 1 on a non-PD pivot, else 0).
+     */
+    template <typename T, uint32_t N, uint32_t NRHS,
+              bool REGULARIZE = false, bool CHECK = false, bool REG_DIAG = false>
+    __device__ void posv(T *A, T *B, T rho = T(0), int *s_fail = nullptr)
+    {
+        if constexpr (REGULARIZE) _posv_regularize<T, REG_DIAG>(N, A, rho);  // rho*I or rho*diag(A)
+        cholDecomp_InPlace<T, N, CHECK>(A, s_fail);
+        for (uint32_t c = 0; c < NRHS; c++) {
+            T *Bc = B + c * N;                                              // column c (column-major)
+            trsv<T, N, /*LOWER=*/true, /*UNIT=*/false, /*TRANSPOSE=*/false>(A, Bc);  // forward: L y = b
+            trsv<T, N, /*LOWER=*/true, /*UNIT=*/false, /*TRANSPOSE=*/true>(A, Bc);   // back:   Lᵀ x = y
+        }
     }
 }

--- a/src/base/banded/block_access.cuh
+++ b/src/base/banded/block_access.cuh
@@ -1,0 +1,131 @@
+#pragma once
+#include <cstdint>
+
+/**
+ * @file block_access.cuh
+ * @brief Dense d×d block ↔ block-tridiagonal `[L|D|R]` strip movers
+ *        (`store_block` / `load_block`).
+ *
+ * GLASS owns the block-tridiagonal `[L|D|R]` strip layout used by `bdmv` / `pcg`:
+ * each block-row is a `d × (3*d)` **row-major** tile, so the `(y,x)` entry of the
+ * slot-`s` block lives at `strip[y*band_width + s*d + x]` (`band_width = 3*d`).
+ * Consumers (e.g. GATO's Schur assembly) repeatedly hand-roll the transpose /
+ * negate remap between a dense d×d block and this strip; these two functions are
+ * that remap, once, correctly.
+ *
+ * Each `(y,x)` element is written by exactly one thread/lane, so there is no race
+ * and the ops are trivially thread-count invariant. Block + `warp::`.
+ *
+ * `TRANSPOSE=false` moves the dense block as `src[y*d + x]` (the "store it as laid
+ * out" case); `TRANSPOSE=true` moves `src[x*d + y]` (store/load the transpose —
+ * GATO's `phi_k` vs `phi_kᵀ`). `scale` folds in a multiplier (`-1` negates, GATO's
+ * common case). `store_block` writes the strip from a dense block; `load_block` is
+ * the exact inverse (strip → dense). With matching `TRANSPOSE`/`scale=1`,
+ * `load_block ∘ store_block` is the identity.
+ */
+
+/**
+ * @brief Which sub-block of a `[L|D|R]` block-row strip a mover targets.
+ *
+ * Column offset within the row-major strip: `LEFT` at `0`, `MAIN` at `d`,
+ * `RIGHT` at `2*d` (matching `bdmv`'s `[L|D|R]` order).
+ */
+enum class BandSlot : uint32_t { LEFT = 0, MAIN = 1, RIGHT = 2 };
+
+/**
+ * @brief Store a dense d×d block into a `[L|D|R]` strip slot:
+ *        `strip[y*band_width + slot*d + x] = scale * src[(TRANSPOSE? x*d+y : y*d+x)]`.
+ *
+ * @tparam T             Scalar type (e.g. `float`, `double`).
+ * @tparam d             Block dimension (the `L`/`D`/`R` blocks are `d×d`).
+ * @tparam band_width    Row length of the strip (default `3*d`).
+ * @tparam TRANSPOSE     Store the transpose of the dense block (default false).
+ * @tparam TRAILING_SYNC Emit a trailing `__syncthreads()` (default true).
+ * @param dst_strip  Start of the block-row strip (row-major, row length `band_width`).
+ * @param slot       Which sub-block (`LEFT`/`MAIN`/`RIGHT`) to write.
+ * @param src        Dense d×d source block (read-only).
+ * @param scale      Multiplier folded into the store (e.g. `-1` to negate).
+ */
+template <typename T, uint32_t d, uint32_t band_width = 3 * d,
+          bool TRANSPOSE = false, bool TRAILING_SYNC = true>
+__device__ void store_block(T* dst_strip, BandSlot slot, const T* src, T scale = T(1))
+{
+    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    const uint32_t off = static_cast<uint32_t>(slot) * d;
+    for (uint32_t k = rank; k < d * d; k += size) {
+        uint32_t x = k % d, y = k / d;
+        dst_strip[y * band_width + off + x] = scale * src[TRANSPOSE ? (x * d + y) : (y * d + x)];
+    }
+    if constexpr (TRAILING_SYNC) __syncthreads();
+}
+
+/**
+ * @brief Load a dense d×d block from a `[L|D|R]` strip slot (inverse of `store_block`):
+ *        `dst[(TRANSPOSE? x*d+y : y*d+x)] = scale * strip[y*band_width + slot*d + x]`.
+ *
+ * @tparam T             Scalar type (e.g. `float`, `double`).
+ * @tparam d             Block dimension.
+ * @tparam band_width    Row length of the strip (default `3*d`).
+ * @tparam TRANSPOSE     Load the transpose (default false).
+ * @tparam TRAILING_SYNC Emit a trailing `__syncthreads()` (default true).
+ * @param dst        Dense d×d destination block (overwritten).
+ * @param src_strip  Start of the block-row strip (row-major, row length `band_width`).
+ * @param slot       Which sub-block (`LEFT`/`MAIN`/`RIGHT`) to read.
+ * @param scale      Multiplier folded into the load.
+ */
+template <typename T, uint32_t d, uint32_t band_width = 3 * d,
+          bool TRANSPOSE = false, bool TRAILING_SYNC = true>
+__device__ void load_block(T* dst, const T* src_strip, BandSlot slot, T scale = T(1))
+{
+    uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+    uint32_t size = blockDim.x * blockDim.y * blockDim.z;
+    const uint32_t off = static_cast<uint32_t>(slot) * d;
+    for (uint32_t k = rank; k < d * d; k += size) {
+        uint32_t x = k % d, y = k / d;
+        dst[TRANSPOSE ? (x * d + y) : (y * d + x)] = scale * src_strip[y * band_width + off + x];
+    }
+    if constexpr (TRAILING_SYNC) __syncthreads();
+}
+
+namespace warp {
+    /**
+     * @brief Single-warp `store_block` — one 32-lane warp strides the `d*d` block.
+     *
+     * Warp form of `store_block`; `TRAILING_SYNC` gates a closing `__syncwarp()`.
+     * Each element written once. Full 32 lanes required.
+     * @see ::store_block
+     */
+    template <typename T, uint32_t d, uint32_t band_width = 3 * d,
+              bool TRANSPOSE = false, bool TRAILING_SYNC = true>
+    __device__ void store_block(T* dst_strip, BandSlot slot, const T* src, T scale = T(1))
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        const uint32_t off = static_cast<uint32_t>(slot) * d;
+        for (uint32_t k = lane; k < d * d; k += 32) {
+            uint32_t x = k % d, y = k / d;
+            dst_strip[y * band_width + off + x] = scale * src[TRANSPOSE ? (x * d + y) : (y * d + x)];
+        }
+        if constexpr (TRAILING_SYNC) __syncwarp();
+    }
+
+    /**
+     * @brief Single-warp `load_block` — one 32-lane warp strides the `d*d` block.
+     *
+     * Warp form of `load_block`; `TRAILING_SYNC` gates a closing `__syncwarp()`.
+     * Full 32 lanes required.
+     * @see ::load_block
+     */
+    template <typename T, uint32_t d, uint32_t band_width = 3 * d,
+              bool TRANSPOSE = false, bool TRAILING_SYNC = true>
+    __device__ void load_block(T* dst, const T* src_strip, BandSlot slot, T scale = T(1))
+    {
+        uint32_t lane = (threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y) & 31;
+        const uint32_t off = static_cast<uint32_t>(slot) * d;
+        for (uint32_t k = lane; k < d * d; k += 32) {
+            uint32_t x = k % d, y = k / d;
+            dst[TRANSPOSE ? (x * d + y) : (y * d + x)] = scale * src_strip[y * band_width + off + x];
+        }
+        if constexpr (TRAILING_SYNC) __syncwarp();
+    }
+}

--- a/src/base/barrier.cuh
+++ b/src/base/barrier.cuh
@@ -1,0 +1,36 @@
+#pragma once
+#include <cstdint>
+
+/**
+ * @file barrier.cuh
+ * @brief Barrier policy for the shared `*_impl` bodies (cgrps dedup + TRAILING_SYNC).
+ *
+ * Every public single-block op is written ONCE as a `*_impl(Bar bar, ...)` body
+ * templated on a *barrier policy* that carries the thread `rank()`/`size()` and a
+ * `sync()`. The plain `glass::` surface passes `BlockBarrier` (threadIdx/blockDim
+ * + `__syncthreads()`); the `glass::cgrps::` surface passes a `GroupBarrier`
+ * (cooperative-groups handle + `cooperative_groups::sync`, defined in
+ * `src/cgrps/`). Routing BOTH the internal and the trailing barrier through
+ * `bar.sync()` is what lets one body serve both surfaces — that barrier
+ * primitive is the only thing that ever differed between them.
+ *
+ * `BlockBarrier` names no cooperative-groups type, so `glass.cuh` stays
+ * dependency-free; the `GroupBarrier` twin is only compiled when a caller
+ * includes `<cooperative_groups.h>` via `glass-cgrps.cuh`.
+ *
+ * Uniformity rule (project-wide): every public op takes `bool TRAILING_SYNC=true`
+ * and ends on `if constexpr (TRAILING_SYNC) bar.sync();`, so the result is valid
+ * for ALL threads by default. Callers that own the following barrier pass
+ * `false` to elide it. For ops that already ended on a barrier this is
+ * byte-identical; for the elementwise/reduce-tail ops it adds a strictly-safer
+ * trailing barrier.
+ */
+struct BlockBarrier {
+    __device__ __forceinline__ uint32_t rank() const {
+        return threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
+    }
+    __device__ __forceinline__ uint32_t size() const {
+        return blockDim.x * blockDim.y * blockDim.z;
+    }
+    __device__ __forceinline__ void sync() const { __syncthreads(); }
+};

--- a/src/base/pcg/solve.cuh
+++ b/src/base/pcg/solve.cuh
@@ -19,7 +19,7 @@
  * Convergence is tested on the preconditioned residual `rho = rᵀ z`:
  * `|rho| < abs_tol + rel_tol * |rho_init|`.
  *
- * Shared scratch: pass `s_mem` of `pcg_smem_size<T,state_size,knot_points>(threads)`
+ * Shared scratch: pass `s_mem` of `pcg_scratch_bytes<T,state_size,knot_points>(threads)`
  * elements (5 padded vectors + the warp-dot scratch). Five scalars live in
  * static `__shared__`. Requires `blockDim.x` be a multiple of 32 (the warp dot).
  */
@@ -35,12 +35,12 @@
  * @tparam state_size   Block dimension.
  * @tparam knot_points  Number of block-rows.
  * @param threads  Launch thread count (`blockDim.x`).
- * @return Number of `T` elements of dynamic shared memory required.
+ * @return Bytes of dynamic shared memory required.
  */
 template <typename T, uint32_t state_size, uint32_t knot_points>
-__host__ __device__ inline constexpr uint32_t pcg_smem_size(uint32_t threads)
+__host__ __device__ inline constexpr std::size_t pcg_scratch_bytes(uint32_t threads)
 {
-    return 5u * ((knot_points + 2u) * state_size) + ((threads + 31u) / 32u);
+    return (static_cast<std::size_t>(5u * ((knot_points + 2u) * state_size)) + ((threads + 31u) / 32u)) * sizeof(T);
 }
 
 /**
@@ -54,7 +54,7 @@ __host__ __device__ inline constexpr uint32_t pcg_smem_size(uint32_t threads)
  * @param S          Block-tridiagonal SPD system, `[L|D|R]` row-major strips.
  * @param Pinv       Block-tridiagonal preconditioner, `[L|D|R]` row-major strips.
  * @param b          Padded right-hand side.
- * @param s_mem      Shared scratch of `pcg_smem_size<T,...>(blockDim.x)` elements.
+ * @param s_mem      Shared scratch of `pcg_scratch_bytes<T,...>(blockDim.x)` elements.
  * @param max_iters  Maximum CG iterations.
  * @param rel_tol    Relative tolerance on the preconditioned residual.
  * @param abs_tol    Absolute tolerance on the preconditioned residual.

--- a/src/cgrps/l1.cuh
+++ b/src/cgrps/l1.cuh
@@ -4,759 +4,266 @@
 #include <cooperative_groups.h>
 namespace cgrps = cooperative_groups;
 
-// L1 cgrps variants — same semantics as glass:: but thread rank/size from the group
+// L1 cooperative-groups surface. Each op is a thin wrapper over the shared
+// `glass::*_impl` body (src/base/L1/*.cuh), driven by a GroupBarrier instead of
+// BlockBarrier — identical numerics, with rank/size/sync taken from the
+// thread_group. Detailed semantics live on the matching `glass::` op; every op
+// carries the uniform `bool TRAILING_SYNC=true` flag (pass false to elide the
+// trailing barrier when the caller owns the next sync).
 
-/**
- * @brief AXPY: `y = alpha*x + y` (cooperative-groups variant).
- *
- * In-place vector update over the thread group. NumPy equivalent: `y += alpha*x`.
- *
- * @tparam T  Scalar type.
- * @param n      Vector length.
- * @param alpha  Scalar multiplier on x.
- * @param x      Input vector.
- * @param y      In/out vector (accumulated into).
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// Barrier policy for the cooperative-groups surface (found by enclosing-namespace
+// lookup from glass::cgrps::; the shared glass::*_impl bodies live in glass::).
+struct GroupBarrier {
+    cgrps::thread_group g;
+    __device__ __forceinline__ uint32_t rank() const { return g.thread_rank(); }
+    __device__ __forceinline__ uint32_t size() const { return g.size(); }
+    __device__ __forceinline__ void sync() const { cgrps::sync(g); }
+};
+
+// ── axpy / axpby ──────────────────────────────────────────────────────────────
+/** @brief AXPY `y = alpha*x + y` (cgrps variant; see glass::axpy). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void axpy(uint32_t n, T alpha, T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) y[i] = alpha*x[i] + y[i];
-}
+{ axpy_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, alpha, x, y); }
 
-/**
- * @brief Out-of-place AXPY: `z = alpha*x + y` (cooperative-groups variant).
- *
- * NumPy equivalent: `z = alpha*x + y`.
- *
- * @tparam T  Scalar type.
- * @param n      Vector length.
- * @param alpha  Scalar multiplier on x.
- * @param x,y    Input vectors.
- * @param z      Output vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Out-of-place AXPY `z = alpha*x + y` (cgrps variant; see glass::axpy). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void axpy(uint32_t n, T alpha, T *x, T *y, T *z,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) z[i] = alpha*x[i] + y[i];
-}
+{ axpy_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, alpha, x, y, z); }
 
-/**
- * @brief AXPBY: `z = alpha*x + beta*y` (cooperative-groups variant).
- *
- * NumPy equivalent: `z = alpha*x + beta*y`.
- *
- * @tparam T  Scalar type.
- * @param n      Vector length.
- * @param alpha  Scalar multiplier on x.
- * @param x      Input vector.
- * @param beta   Scalar multiplier on y.
- * @param y      Input vector.
- * @param z      Output vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief AXPBY `z = alpha*x + beta*y` (cgrps variant; see glass::axpby). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void axpby(uint32_t n, T alpha, T *x, T beta, T *y, T *z,
                       cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) z[i] = alpha*x[i] + beta*y[i];
-}
+{ axpby_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, alpha, x, beta, y, z); }
 
-/**
- * @brief Compile-time-size AXPY: `y = alpha*x + y` (cooperative-groups variant).
- *
- * NumPy equivalent: `y += alpha*x`.
- *
- * @tparam T  Scalar type.
- * @tparam N  Vector length.
- * @param alpha  Scalar multiplier on x.
- * @param x      Input vector.
- * @param y      In/out vector (accumulated into).
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T, uint32_t N>
+/** @brief Compile-time-size AXPY `y = alpha*x + y` (cgrps variant). */
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void axpy(T alpha, T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < N; i += g.size()) y[i] = alpha*x[i] + y[i];
-}
+{ axpy_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, alpha, x, y); }
 
-/**
- * @brief Compile-time-size out-of-place AXPY: `z = alpha*x + y` (cooperative-groups variant).
- *
- * NumPy equivalent: `z = alpha*x + y`.
- *
- * @tparam T  Scalar type.
- * @tparam N  Vector length.
- * @param alpha  Scalar multiplier on x.
- * @param x,y    Input vectors.
- * @param z      Output vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T, uint32_t N>
+/** @brief Compile-time-size out-of-place AXPY `z = alpha*x + y` (cgrps variant). */
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void axpy(T alpha, T *x, T *y, T *z,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < N; i += g.size()) z[i] = alpha*x[i] + y[i];
-}
+{ axpy_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, alpha, x, y, z); }
 
-/**
- * @brief Vector copy: `y = x` (cooperative-groups variant).
- *
- * NumPy equivalent: `y = x.copy()`.
- *
- * @tparam T  Scalar type.
- * @param n  Vector length.
- * @param x  Source vector.
- * @param y  Destination vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// ── copy ──────────────────────────────────────────────────────────────────────
+/** @brief Vector copy `y = x` (cgrps variant; see glass::copy). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void copy(uint32_t n, T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) y[i] = x[i];
-}
+{ copy_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x, y); }
 
-/**
- * @brief Scaled copy: `y = alpha*x` (cooperative-groups variant).
- *
- * NumPy equivalent: `y = alpha*x`.
- *
- * @tparam T  Scalar type.
- * @param n      Vector length.
- * @param alpha  Scalar multiplier on x.
- * @param x      Source vector.
- * @param y      Destination vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Scaled copy `y = alpha*x` (cgrps variant; see glass::copy). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void copy(uint32_t n, T alpha, T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) y[i] = alpha*x[i];
-}
+{ copy_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, alpha, x, y); }
 
-/**
- * @brief Compile-time-size vector copy: `y = x` (cooperative-groups variant).
- *
- * NumPy equivalent: `y = x.copy()`.
- *
- * @tparam T  Scalar type.
- * @tparam N  Vector length.
- * @param x  Source vector.
- * @param y  Destination vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T, uint32_t N>
+/** @brief Compile-time-size vector copy `y = x` (cgrps variant). */
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void copy(T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < N; i += g.size()) y[i] = x[i];
-}
+{ copy_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, x, y); }
 
-/**
- * @brief In-place scale: `x = alpha*x` (cooperative-groups variant).
- *
- * NumPy equivalent: `x *= alpha`.
- *
- * @tparam T  Scalar type.
- * @param n      Vector length.
- * @param alpha  Scalar multiplier.
- * @param x      In/out vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// ── scal ──────────────────────────────────────────────────────────────────────
+/** @brief In-place scale `x = alpha*x` (cgrps variant; see glass::scal). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void scal(uint32_t n, T alpha, T *x,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) x[i] = alpha*x[i];
-}
+{ scal_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, alpha, x); }
 
-/**
- * @brief Out-of-place scale: `y = alpha*x` (cooperative-groups variant).
- *
- * NumPy equivalent: `y = alpha*x`.
- *
- * @tparam T  Scalar type.
- * @param n      Vector length.
- * @param alpha  Scalar multiplier.
- * @param x      Source vector.
- * @param y      Destination vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Out-of-place scale `y = alpha*x` (cgrps variant; see glass::scal). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void scal(uint32_t n, T alpha, T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) y[i] = alpha*x[i];
-}
+{ scal_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, alpha, x, y); }
 
-/**
- * @brief Compile-time-size in-place scale: `x = alpha*x` (cooperative-groups variant).
- *
- * NumPy equivalent: `x *= alpha`.
- *
- * @tparam T  Scalar type.
- * @tparam N  Vector length.
- * @param alpha  Scalar multiplier.
- * @param x      In/out vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T, uint32_t N>
+/** @brief Compile-time-size in-place scale `x = alpha*x` (cgrps variant). */
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void scal(T alpha, T *x,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < N; i += g.size()) x[i] = alpha*x[i];
-}
+{ scal_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, alpha, x); }
 
-/**
- * @brief Swap two vectors element-wise: `x <-> y` (cooperative-groups variant).
- *
- * @tparam T  Scalar type.
- * @param n  Vector length.
- * @param x  In/out vector (swapped with y).
- * @param y  In/out vector (swapped with x).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// ── swap ──────────────────────────────────────────────────────────────────────
+/** @brief Swap two vectors `x <-> y` (cgrps variant; see glass::swap). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void swap(uint32_t n, T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) {
-        T tmp = x[i]; x[i] = y[i]; y[i] = tmp;
-    }
-}
+{ swap_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x, y); }
 
-/**
- * @brief Compile-time-size swap of two vectors: `x <-> y` (cooperative-groups variant).
- *
- * @tparam T  Scalar type.
- * @tparam N  Vector length.
- * @param x  In/out vector (swapped with y).
- * @param y  In/out vector (swapped with x).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T, uint32_t N>
+/** @brief Compile-time-size swap `x <-> y` (cgrps variant). */
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void swap(T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < N; i += g.size()) {
-        T tmp = x[i]; x[i] = y[i]; y[i] = tmp;
-    }
-}
+{ swap_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, x, y); }
 
-/**
- * @brief Element-wise clamp in place: `x = clamp(x, l, u)` (cooperative-groups variant).
- *
- * Lower/upper bounds are per-element vectors. NumPy equivalent: `x = np.clip(x, l, u)`.
- *
- * @tparam T  Scalar type.
- * @param n  Vector length.
- * @param x  In/out vector (clamped).
- * @param l  Per-element lower bounds.
- * @param u  Per-element upper bounds.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// ── clip / set_const / identity ───────────────────────────────────────────────
+/** @brief Element-wise clamp `x = clamp(x, l, u)` (cgrps variant; see glass::clip). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void clip(uint32_t n, T *x, T *l, T *u,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size())
-        x[i] = max(l[i], min(x[i], u[i]));
-}
+{ clip_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x, l, u); }
 
-/**
- * @brief Fill a vector with a constant: `x = [alpha, ...]` (cooperative-groups variant).
- *
- * NumPy equivalent: `x = np.full(n, alpha)`.
- *
- * @tparam T  Scalar type.
- * @param n      Vector length.
- * @param alpha  Fill value.
- * @param x      Output vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Fill with a constant `x = alpha` (cgrps variant; see glass::set_const). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void set_const(uint32_t n, T alpha, T *x,
                            cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) x[i] = alpha;
-}
+{ set_const_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, alpha, x); }
 
-/**
- * @brief Load the identity matrix: `A = I_n` (column-major, cooperative-groups variant).
- *
- * NumPy equivalent: `A = np.eye(n)`.
- *
- * @tparam T  Scalar type.
- * @param n  Matrix dimension (A is n x n).
- * @param A  Output matrix (column-major), set to the identity.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Load the identity `A = I_n` (cgrps variant; see glass::loadIdentity). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void loadIdentity(uint32_t n, T *A,
                               cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n*n; i += g.size()) {
-        uint32_t r = i % n, c = i / n;
-        A[i] = static_cast<T>(r == c);
-    }
-}
+{ loadIdentity_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, A); }
 
-/**
- * @brief Add a scaled identity to a matrix in place: `A += alpha*I` (cooperative-groups variant).
- *
- * Only the diagonal is modified. NumPy equivalent: `A += alpha*np.eye(n)`.
- *
- * @tparam T  Scalar type.
- * @param n      Matrix dimension (A is n x n, column-major).
- * @param A      In/out matrix.
- * @param alpha  Scalar added to each diagonal element.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Add a scaled identity `A += alpha*I` (cgrps variant; see glass::addI). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void addI(uint32_t n, T *A, T alpha,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n*n; i += g.size())
-        if (i % n == i / n) A[i] += alpha;
-}
+{ addI_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, A, alpha); }
 
-// reductions
-/**
- * @brief Sum reduction in place: `x[0] = sum(x)` (cooperative-groups variant).
- *
- * Halving (tree) reduction over the group; the result lands in `x[0]` and the
- * rest of `x` is overwritten. NumPy equivalent: `x[0] = np.sum(x)`.
- *
- * @tparam T  Scalar type.
- * @param n  Vector length.
- * @param x  In/out vector; on return `x[0]` holds the sum.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// ── reductions ────────────────────────────────────────────────────────────────
+/** @brief Sum reduction `x[0] = sum(x)` (cgrps variant; see glass::reduce). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void reduce(uint32_t n, T *x,
                        cgrps::thread_group g = cgrps::this_thread_block())
-{
-    uint32_t rank = g.thread_rank(), size = g.size();
-    uint32_t left = n;
-    while (left > 3) {
-        bool odd = left % 2;
-        left = (left - odd) / 2;
-        for (uint32_t i = rank; i < left; i += size) x[i] += x[i + left];
-        if (rank == 0 && odd) x[0] += x[2*left];
-        g.sync();
-    }
-    if (rank == 0) { for (uint32_t i = 1; i < left; i++) x[0] += x[i]; }
-}
+{ reduce_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x); }
 
-/**
- * @brief Compile-time-size sum reduction: `x[0] = sum(x)` (cooperative-groups variant).
- *
- * NumPy equivalent: `x[0] = np.sum(x)`.
- *
- * @tparam T  Scalar type.
- * @tparam N  Vector length.
- * @param x  In/out vector; on return `x[0]` holds the sum.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T, uint32_t N>
+/** @brief Compile-time-size sum reduction `x[0] = sum(x)` (cgrps variant). */
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void reduce(T *x, cgrps::thread_group g = cgrps::this_thread_block())
-{
-    reduce<T>(N, x, g);
-}
+{ reduce_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, x); }
 
-/**
- * @brief Dot product: `y[0] = dot(x, y)` (cooperative-groups variant).
- *
- * Destructive: `y` is used as scratch — it is multiplied element-wise by `x` and
- * then reduced, leaving the result in `y[0]`. NumPy equivalent:
- * `y[0] = np.dot(x, y)`.
- *
- * @tparam T  Scalar type.
- * @param n  Vector length.
- * @param x  Input vector.
- * @param y  In/out vector (overwritten; on return `y[0]` holds the dot product).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Dot product `y[0] = dot(x, y)` (destructive; cgrps variant; see glass::dot). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void dot(uint32_t n, T *x, T *y,
                     cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) y[i] *= x[i];
-    g.sync();
-    reduce<T>(n, y, g);
-}
+{ dot_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x, y); }
 
-/**
- * @brief Compile-time-size dot product: `y[0] = dot(x, y)` (cooperative-groups variant).
- *
- * Destructive: `y` is overwritten and the result lands in `y[0]`. NumPy
- * equivalent: `y[0] = np.dot(x, y)`.
- *
- * @tparam T  Scalar type.
- * @tparam N  Vector length.
- * @param x  Input vector.
- * @param y  In/out vector (overwritten; on return `y[0]` holds the dot product).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T, uint32_t N>
+/** @brief Compile-time-size dot product `y[0] = dot(x, y)` (cgrps variant). */
+template <typename T, uint32_t N, bool TRAILING_SYNC = true>
 __device__ void dot(T *x, T *y,
                     cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < N; i += g.size()) y[i] *= x[i];
-    g.sync();
-    reduce<T, N>(y, g);
-}
+{ dot_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, x, y); }
 
-/**
- * @brief Out-of-place transpose: `b = a^T` (column-major, cooperative-groups variant).
- *
- * `a` is N x M, `b` is M x N. NumPy equivalent: `b = a.T`.
- *
- * @tparam T  Scalar type.
- * @param N  Rows of a (columns of b).
- * @param M  Columns of a (rows of b).
- * @param a  Input matrix (column-major, N x M).
- * @param b  Output matrix (column-major, M x N).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// ── transpose ─────────────────────────────────────────────────────────────────
+/** @brief Out-of-place transpose `b = a^T` (cgrps variant; see glass::transpose). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void transpose(uint32_t N, uint32_t M, T *a, T *b,
                            cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < N*M; i += g.size()) {
-        uint32_t col = i / N, row = i % N;
-        b[col + M*row] = a[row + N*col];
-    }
-    g.sync();
-}
+{ transpose_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, M, a, b); }
 
-/**
- * @brief In-place square transpose: `a = a^T` for an N x N matrix (cooperative-groups variant).
- *
- * Swaps the strict upper/lower triangles in place.
- *
- * @tparam T  Scalar type.
- * @param N  Matrix dimension (a is N x N, column-major).
- * @param a  In/out matrix, transposed in place.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief In-place square transpose `a = a^T` (cgrps variant; see glass::transpose). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void transpose(uint32_t N, T *a,
                            cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t idx = g.thread_rank(); idx < N*N; idx += g.size()) {
-        uint32_t i = idx % N, j = idx / N;
-        if (i < j) {
-            uint32_t sw = i*N + j;
-            T tmp = a[idx]; a[idx] = a[sw]; a[sw] = tmp;
-        }
-    }
-    g.sync();
-}
+{ transpose_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a); }
 
-/**
- * @brief Element-wise maximum: `c = max(a, b)` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = np.maximum(a, b)`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+// ── elementwise logic ─────────────────────────────────────────────────────────
+/** @brief Element-wise max `c = max(a, b)` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_max(uint32_t N, T *a, T *b, T *c,
                                  cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = max(a[i], b[i]); }
+{ elementwise_max_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise minimum: `c = min(a, b)` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = np.minimum(a, b)`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise min `c = min(a, b)` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_min(uint32_t N, T *a, T *b, T *c,
                                  cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = min(a[i], b[i]); }
+{ elementwise_min_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise less-than: `c = (a < b)` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = a < b`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector (1/0 truth values).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise less-than `c = (a < b)` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_less_than(uint32_t N, T *a, T *b, T *c,
                                        cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i] < b[i]; }
+{ elementwise_less_than_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise greater-than: `c = (a > b)` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = a > b`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector (1/0 truth values).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise greater-than `c = (a > b)` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_more_than(uint32_t N, T *a, T *b, T *c,
                                        cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i] > b[i]; }
+{ elementwise_more_than_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise less-than-or-equal: `c = (a <= b)` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = a <= b`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector (1/0 truth values).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise less-than-or-equal `c = (a <= b)` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_less_than_or_eq(uint32_t N, T *a, T *b, T *c,
                                               cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i] <= b[i]; }
+{ elementwise_less_than_or_eq_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise logical AND: `c = (a && b)` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = np.logical_and(a, b)`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector (1/0 truth values).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise logical AND `c = (a && b)` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_and(uint32_t N, T *a, T *b, T *c,
                                  cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i] && b[i]; }
+{ elementwise_and_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise logical NOT: `c = !a` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = np.logical_not(a)`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a  Input vector.
- * @param c  Output vector (1/0 truth values).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise logical NOT `c = !a` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_not(uint32_t N, T *a, T *c,
                                  cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = !a[i]; }
+{ elementwise_not_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, c); }
 
-/**
- * @brief Element-wise absolute value: `b = |a|` (cooperative-groups variant).
- *
- * NumPy equivalent: `b = np.abs(a)`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a  Input vector.
- * @param b  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise absolute value `b = |a|` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_abs(uint32_t N, T *a, T *b,
                                  cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) b[i] = abs(a[i]); }
+{ elementwise_abs_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b); }
 
-/**
- * @brief Element-wise (Hadamard) product: `c = a * b` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = a * b`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise (Hadamard) product `c = a * b` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_mult(uint32_t N, T *a, T *b, T *c,
                                   cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i]*b[i]; }
+{ elementwise_mult_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise subtraction: `c = a - b` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = a - b`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise subtraction `c = a - b` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_sub(uint32_t N, T *a, T *b, T *c,
                                  cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i] - b[i]; }
+{ elementwise_sub_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise addition: `c = a + b` (cooperative-groups variant).
- *
- * NumPy equivalent: `c = a + b`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a,b  Input vectors.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise addition `c = a + b` (cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_add(uint32_t N, T *a, T *b, T *c,
                                  cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i] + b[i]; }
+{ elementwise_add_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise scalar multiply: `c = a * b` (scalar b, cooperative-groups variant).
- *
- * NumPy equivalent: `c = a * b`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a  Input vector.
- * @param b  Scalar multiplier.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise scalar multiply `c = a * b` (scalar b; cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_mult_scalar(uint32_t N, T *a, T b, T *c,
                                          cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = a[i]*b; }
+{ elementwise_mult_scalar_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise max against a scalar: `c = max(a, b)` (scalar b, cooperative-groups variant).
- *
- * NumPy equivalent: `c = np.maximum(a, b)`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a  Input vector.
- * @param b  Scalar threshold.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise max against a scalar `c = max(a, b)` (scalar b; cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_max_scalar(uint32_t N, T *a, T b, T *c,
                                         cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = max(a[i], b); }
+{ elementwise_max_scalar_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Element-wise min against a scalar: `c = min(a, b)` (scalar b, cooperative-groups variant).
- *
- * NumPy equivalent: `c = np.minimum(a, b)`.
- *
- * @tparam T  Scalar type.
- * @param N  Vector length.
- * @param a  Input vector.
- * @param b  Scalar threshold.
- * @param c  Output vector.
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-template <typename T>
+/** @brief Element-wise min against a scalar `c = min(a, b)` (scalar b; cgrps variant). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void elementwise_min_scalar(uint32_t N, T *a, T b, T *c,
                                         cgrps::thread_group g = cgrps::this_thread_block())
-{ for (uint32_t i = g.thread_rank(); i < N; i += g.size()) c[i] = min(a[i], b); }
+{ elementwise_min_scalar_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, N, a, b, c); }
 
-/**
- * @brief Euclidean (L2) norm in place: `x[0] = ||x||_2` (cooperative-groups variant).
- *
- * Destructive: squares each element in place, sum-reduces, then takes the square
- * root; the result lands in `x[0]`. NumPy equivalent: `x[0] = np.linalg.norm(x)`.
- *
- * @tparam T  Scalar type.
- * @param n  Vector length.
- * @param x  In/out vector (overwritten; on return `x[0]` holds the L2 norm).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-// l2norm: squares each element in-place, reduces, takes sqrt. Result in x[0].
-template <typename T>
-__device__ void l2norm(uint32_t n, T *x,
+// ── norms ─────────────────────────────────────────────────────────────────────
+/** @brief Euclidean (L2) norm `x[0] = ||x||_2` (destructive; cgrps variant; see glass::nrm2_impl). */
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void nrm2(uint32_t n, T *x,
                        cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) x[i] *= x[i];
-    g.sync();
-    reduce<T>(n, x, g);
-    if (g.thread_rank() == 0) x[0] = sqrtf(x[0]);
-}
+{ nrm2_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x); }
 
-/**
- * @brief Infinity norm in place: `x[0] = ||x||_inf` (cooperative-groups variant).
- *
- * Destructive halving reduction over absolute values; the max-abs result lands
- * in `x[0]`. NumPy equivalent: `x[0] = np.max(np.abs(x))`.
- *
- * @tparam T  Scalar type.
- * @param n  Vector length.
- * @param x  In/out vector (overwritten; on return `x[0]` holds the inf norm).
- * @param g  Cooperative thread group (defaults to the whole block).
- */
-// infnorm: max of absolute values. Result in x[0].
-template <typename T>
+/** @brief Infinity norm `x[0] = ||x||_inf` (destructive; cgrps variant; see glass::infnorm). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void infnorm(uint32_t n, T *x,
                          cgrps::thread_group g = cgrps::this_thread_block())
-{
-    uint32_t rank = g.thread_rank(), stride = g.size();
-    uint32_t left = n;
-    while (left > 3) {
-        bool odd = left % 2;
-        left = (left - odd) / 2;
-        for (uint32_t i = rank; i < left; i += stride)
-            x[i] = max(abs(x[i]), abs(x[i + left]));
-        if (rank == 0 && odd) x[0] = max(abs(x[0]), abs(x[2*left]));
-        g.sync();
-    }
-    if (rank == 0) { for (uint32_t i = 1; i < left; i++) x[0] = max(abs(x[0]), abs(x[i])); }
-}
+{ infnorm_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x); }
 
-/**
- * @brief Sum of absolute values: `out[0] = sum(|x|)` (cooperative-groups variant).
- *
- * Writes `|x|` into the size-n scratch `out`, then sum-reduces it; the result
- * lands in `out[0]` and `x` is left unmodified. NumPy equivalent:
- * `out[0] = np.sum(np.abs(x))`.
- *
- * @tparam T  Scalar type.
- * @param n    Vector length.
- * @param x    Input vector.
- * @param out  Size-n scratch/output; on return `out[0]` holds the result.
- * @param g    Cooperative thread group (defaults to the whole block).
- */
-// asum: sum of absolute values. out is size-n scratch+output; result in out[0].
-template <typename T>
+/** @brief Sum of absolute values `out[0] = sum(|x|)` (cgrps variant; see glass::asum_impl). */
+template <typename T, bool TRAILING_SYNC = true>
 __device__ void asum(uint32_t n, T *x, T *out,
                      cgrps::thread_group g = cgrps::this_thread_block())
-{
-    for (uint32_t i = g.thread_rank(); i < n; i += g.size()) out[i] = abs(x[i]);
-    g.sync();
-    reduce<T>(n, out, g);
-}
+{ asum_impl<GroupBarrier, T, TRAILING_SYNC>(GroupBarrier{g}, n, x, out); }

--- a/src/cgrps/l2.cuh
+++ b/src/cgrps/l2.cuh
@@ -23,11 +23,12 @@ namespace cgrps = cooperative_groups;
  * @param y      In/out result vector.
  * @param g      Cooperative thread group (defaults to the whole block).
  */
-template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(uint32_t m, uint32_t n, T alpha, T *A, T *x, T beta, T *y,
+template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(uint32_t m, uint32_t n, T alpha, const T *A, const T *x, T beta, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
     gemv_impl<T, TRANSPOSE, ROW_MAJOR>(g.thread_rank(), g.size(), m, n, alpha, A, x, beta, y);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
@@ -46,58 +47,12 @@ __device__ void gemv(uint32_t m, uint32_t n, T alpha, T *A, T *x, T beta, T *y,
  * @param y      Output result vector (overwritten).
  * @param g      Cooperative thread group (defaults to the whole block).
  */
-template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(uint32_t m, uint32_t n, T alpha, T *A, T *x, T *y,
+template <typename T, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(uint32_t m, uint32_t n, T alpha, const T *A, const T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
     gemv_impl<T, TRANSPOSE, ROW_MAJOR>(g.thread_rank(), g.size(), m, n, alpha, A, x, y);
-}
-
-/**
- * @brief GEMV with explicit layout control: `y = alpha * op(A) * x + beta * y` (cooperative-groups variant).
- *
- * Like `gemv` but exposes the A storage order as a named template parameter.
- * NumPy equivalent: `y = alpha * A @ x + beta * y` (or `A.T @ x` when TRANSPOSE).
- *
- * @tparam T  Scalar type.
- * @tparam TRANSPOSE  If true, computes `A^T * x`.
- * @tparam ROW_MAJOR_A  Storage order of A (false = column-major).
- * @param m,n   A is m x n.
- * @param alpha  Scalar multiplier on the product.
- * @param A      Input matrix.
- * @param x      Input vector.
- * @param beta   Scalar multiplier on the existing y (y is read; caller must initialize it).
- * @param y      In/out result vector.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T, bool TRANSPOSE, bool ROW_MAJOR_A>
-__device__ void gemv_ex(uint32_t m, uint32_t n, T alpha, T *A, T *x, T beta, T *y,
-                         cgrps::thread_group g = cgrps::this_thread_block())
-{
-    gemv_impl<T, TRANSPOSE, ROW_MAJOR_A>(g.thread_rank(), g.size(), m, n, alpha, A, x, beta, y);
-}
-
-/**
- * @brief GEMV with explicit layout control and implicit `beta = 0`: `y = alpha * op(A) * x`.
- *
- * Overwrites y (the existing y is not read). NumPy equivalent:
- * `y = alpha * A @ x` (or `A.T @ x` when TRANSPOSE).
- *
- * @tparam T  Scalar type.
- * @tparam TRANSPOSE  If true, computes `A^T * x`.
- * @tparam ROW_MAJOR_A  Storage order of A (false = column-major).
- * @param m,n   A is m x n.
- * @param alpha  Scalar multiplier on the product.
- * @param A      Input matrix.
- * @param x      Input vector.
- * @param y      Output result vector (overwritten).
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T, bool TRANSPOSE, bool ROW_MAJOR_A>
-__device__ void gemv_ex(uint32_t m, uint32_t n, T alpha, T *A, T *x, T *y,
-                         cgrps::thread_group g = cgrps::this_thread_block())
-{
-    gemv_impl<T, TRANSPOSE, ROW_MAJOR_A>(g.thread_rank(), g.size(), m, n, alpha, A, x, y);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
@@ -117,11 +72,12 @@ __device__ void gemv_ex(uint32_t m, uint32_t n, T alpha, T *A, T *x, T *y,
  * @param y      In/out result vector.
  * @param g      Cooperative thread group (defaults to the whole block).
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(T alpha, T *A, T *x, T beta, T *y,
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(T alpha, const T *A, const T *x, T beta, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
     gemv_impl<T, TRANSPOSE, ROW_MAJOR>(g.thread_rank(), g.size(), M, N, alpha, A, x, beta, y);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
@@ -140,11 +96,12 @@ __device__ void gemv(T alpha, T *A, T *x, T beta, T *y,
  * @param y      Output result vector (overwritten).
  * @param g      Cooperative thread group (defaults to the whole block).
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false>
-__device__ void gemv(T alpha, T *A, T *x, T *y,
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+__device__ void gemv(T alpha, const T *A, const T *x, T *y,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
     gemv_impl<T, TRANSPOSE, ROW_MAJOR>(g.thread_rank(), g.size(), M, N, alpha, A, x, y);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
@@ -161,8 +118,8 @@ __device__ void gemv(T alpha, T *A, T *x, T *y,
  * @param g      Cooperative thread group (defaults to the whole block).
  */
 // ger: A += alpha * x * y^T (column-major)
-template <typename T>
-__device__ void ger(uint32_t m, uint32_t n, T alpha, T *x, T *y, T *A,
+template <typename T, bool TRAILING_SYNC = true>
+__device__ void ger(uint32_t m, uint32_t n, T alpha, const T *x, const T *y, T *A,
                     cgrps::thread_group g = cgrps::this_thread_block())
 {
     for (uint32_t col = 0; col < n; col++) {
@@ -170,6 +127,7 @@ __device__ void ger(uint32_t m, uint32_t n, T alpha, T *x, T *y, T *A,
         for (uint32_t row = g.thread_rank(); row < m; row += g.size())
             A[row + col*m] += ay * x[row];
     }
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
@@ -184,8 +142,8 @@ __device__ void ger(uint32_t m, uint32_t n, T alpha, T *x, T *y, T *A,
  * @param A      In/out matrix (column-major).
  * @param g      Cooperative thread group (defaults to the whole block).
  */
-template <typename T, uint32_t M, uint32_t N>
-__device__ void ger(T alpha, T *x, T *y, T *A,
+template <typename T, uint32_t M, uint32_t N, bool TRAILING_SYNC = true>
+__device__ void ger(T alpha, const T *x, const T *y, T *A,
                     cgrps::thread_group g = cgrps::this_thread_block())
 {
     for (uint32_t col = 0; col < N; col++) {
@@ -193,6 +151,7 @@ __device__ void ger(T alpha, T *x, T *y, T *A,
         for (uint32_t row = g.thread_rank(); row < M; row += g.size())
             A[row + col*M] += ay * x[row];
     }
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 // ─── contraction-parallel GEMV (cooperative-groups variant) ──────────────────
@@ -204,29 +163,29 @@ __device__ void ger(T alpha, T *x, T *y, T *A,
  *
  * Cooperative-groups form of `glass::gemv_reduced`. See it for semantics.
  *
- * @tparam T,M,N,TRANS  See glass::gemv_reduced.
+ * @tparam T,M,N,TRANSPOSE  See glass::gemv_reduced.
  * @tparam TRAILING_SYNC  Emit a trailing `g.sync()` (default true).
  * @param alpha,A,x,beta,y  See glass::gemv_reduced.
  * @param g  Cooperative thread group (defaults to the whole block; pass a warp-multiple group).
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void gemv_reduced(T alpha, const T* A, const T* x, T beta, T* y,
                              cgrps::thread_group g = cgrps::this_thread_block())
 {
-    glass::detail::gemv_reduced_impl<T, M, N, TRANS, true>(g.thread_rank(), g.size(), alpha, A, x, beta, y);
+    glass::detail::gemv_reduced_impl<T, M, N, TRANSPOSE, true>(g.thread_rank(), g.size(), alpha, A, x, beta, y);
     if constexpr (TRAILING_SYNC) g.sync();
 }
 
 /**
  * @brief Contraction-parallel GEMV with implicit `beta = 0`: `y = alpha * op(A) * x` (cooperative-groups variant).
  *
- * @tparam T,M,N,TRANS,TRAILING_SYNC  See the beta overload.
+ * @tparam T,M,N,TRANSPOSE,TRAILING_SYNC  See the beta overload.
  * @param alpha,A,x,y,g  See the beta overload.
  */
-template <typename T, uint32_t M, uint32_t N, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t M, uint32_t N, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void gemv_reduced(T alpha, const T* A, const T* x, T* y,
                              cgrps::thread_group g = cgrps::this_thread_block())
 {
-    glass::detail::gemv_reduced_impl<T, M, N, TRANS, false>(g.thread_rank(), g.size(), alpha, A, x, static_cast<T>(0), y);
+    glass::detail::gemv_reduced_impl<T, M, N, TRANSPOSE, false>(g.thread_rank(), g.size(), alpha, A, x, static_cast<T>(0), y);
     if constexpr (TRAILING_SYNC) g.sync();
 }

--- a/src/cgrps/l3.cuh
+++ b/src/cgrps/l3.cuh
@@ -15,22 +15,24 @@ namespace cgrps = cooperative_groups;
  * NumPy equivalent: `C = alpha * A @ B + beta * C`.
  *
  * @tparam T  Scalar type.
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (pure-SIMT path requires B square).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major).
- * @param m,n,k  Dimensions: A is m x n, B is n x k (or k x n when TRANSPOSE_B), C is m x (TRANSPOSE_B ? n : k).
+ * @tparam TRANSPOSE_A  If true, `A` is `k×m` and `op(A)=Aᵀ` (else `A` is `m×k`).
+ * @tparam TRANSPOSE_B  If true, `B` is `n×k` and `op(B)=Bᵀ` (else `B` is `k×n`).
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
+ * @param m,n,k  Dimensions: `C` is `m×n`, contraction `k`.
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
  * @param C      In/out result matrix.
  * @param g      Cooperative thread group (defaults to the whole block).
  */
-template <typename T, bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
+template <typename T, bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm(uint32_t m, uint32_t n, uint32_t k,
-                     T alpha, T *A, T *B, T beta, T *C,
+                     T alpha, const T *A, const T *B, T beta, T *C,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(
+    gemm_impl<T, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(
         g.thread_rank(), g.size(), m, n, k, alpha, A, B, beta, C);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
@@ -40,59 +42,36 @@ __device__ void gemm(uint32_t m, uint32_t n, uint32_t k,
  * equivalent: `C = alpha * A @ B`.
  *
  * @tparam T  Scalar type.
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (pure-SIMT path requires B square).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major).
- * @param m,n,k  Dimensions: A is m x n, B is n x k (or k x n when TRANSPOSE_B), C is m x (TRANSPOSE_B ? n : k).
+ * @tparam TRANSPOSE_A  If true, `A` is `k×m` and `op(A)=Aᵀ` (else `A` is `m×k`).
+ * @tparam TRANSPOSE_B  If true, `B` is `n×k` and `op(B)=Bᵀ` (else `B` is `k×n`).
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
+ * @param m,n,k  Dimensions: `C` is `m×n`, contraction `k`.
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param C      Output result matrix (overwritten).
  * @param g      Cooperative thread group (defaults to the whole block).
  */
-template <typename T, bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
+template <typename T, bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm(uint32_t m, uint32_t n, uint32_t k,
-                     T alpha, T *A, T *B, T *C,
+                     T alpha, const T *A, const T *B, T *C,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(
+    gemm_impl<T, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(
         g.thread_rank(), g.size(), m, n, k, alpha, A, B, C);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
- * @brief GEMM with per-matrix layout control: `C = alpha * A * op(B) + beta * C` (cooperative-groups variant).
+ * @brief Compile-time-size GEMM: `C = alpha * op(A) * op(B) + beta * C` (cooperative-groups variant).
  *
- * Like `gemm` but the storage order of A, B and C is set independently. NumPy
- * equivalent: `C = alpha * A @ B + beta * C`.
- *
- * @tparam T  Scalar type.
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
- * @tparam ROW_MAJOR_A/ROW_MAJOR_B/ROW_MAJOR_C  Storage order per matrix (false = column-major).
- * @param m,n,k  Dimensions: A is m x n, B is n x k (or k x n when TRANSPOSE_B), C is m x (TRANSPOSE_B ? n : k).
- * @param alpha  Scalar multiplier on the product.
- * @param A,B    Input matrices.
- * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
- * @param C      In/out result matrix.
- * @param g      Cooperative thread group (defaults to the whole block).
- */
-template <typename T, bool TRANSPOSE_B,
-          bool ROW_MAJOR_A, bool ROW_MAJOR_B, bool ROW_MAJOR_C>
-__device__ void gemm_ex(uint32_t m, uint32_t n, uint32_t k,
-                         T alpha, T *A, T *B, T beta, T *C,
-                         cgrps::thread_group g = cgrps::this_thread_block())
-{
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR_A, ROW_MAJOR_B, ROW_MAJOR_C>(
-        g.thread_rank(), g.size(), m, n, k, alpha, A, B, beta, C);
-}
-
-/**
- * @brief Compile-time-size GEMM: `C = alpha * A * op(B) + beta * C` (cooperative-groups variant).
- *
- * Dimensions baked in as template parameters; uniform storage order. NumPy
- * equivalent: `C = alpha * A @ B + beta * C`.
+ * Dimensions baked in as template parameters; standard convention (C is M×N,
+ * contraction K). NumPy: `C = alpha * opA(A) @ opB(B) + beta * C`.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K` (see gemm.cuh).
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param beta   Scalar multiplier on the existing C (C is read; caller must initialize it).
@@ -100,35 +79,38 @@ __device__ void gemm_ex(uint32_t m, uint32_t n, uint32_t k,
  * @param g      Cooperative thread group (defaults to the whole block).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
-__device__ void gemm(T alpha, T *A, T *B, T beta, T *C,
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
+__device__ void gemm(T alpha, const T *A, const T *B, T beta, T *C,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(
-        g.thread_rank(), g.size(), M, N, K, alpha, A, B, beta, C);
+    gemm_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(
+        g.thread_rank(), g.size(), alpha, A, B, beta, C);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
- * @brief Compile-time-size GEMM with implicit `beta = 0`: `C = alpha * A * op(B)` (cooperative-groups variant).
+ * @brief Compile-time-size GEMM with implicit `beta = 0`: `C = alpha * op(A) * op(B)` (cooperative-groups variant).
  *
- * Overwrites C (the existing C is not read). NumPy equivalent: `C = alpha * A @ B`.
+ * Overwrites C (the existing C is not read). NumPy: `C = alpha * opA(A) @ opB(B)`.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T`.
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K` (see gemm.cuh).
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
  * @param C      Output result matrix (overwritten).
  * @param g      Cooperative thread group (defaults to the whole block).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false>
-__device__ void gemm(T alpha, T *A, T *B, T *C,
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
+__device__ void gemm(T alpha, const T *A, const T *B, T *C,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
-    gemm_impl<T, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR>(
-        g.thread_rank(), g.size(), M, N, K, alpha, A, B, C);
+    gemm_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(
+        g.thread_rank(), g.size(), alpha, A, B, C);
+    if constexpr (TRAILING_SYNC) cgrps::sync(g);
 }
 
 /**
@@ -142,30 +124,15 @@ __device__ void gemm(T alpha, T *A, T *B, T *C,
  * @param dimA    Matrix dimension (A is dimA x dimA).
  * @param A       In/out augmented `[A | I]` buffer (column-major, dimA x 2*dimA);
  *                on return its right half holds `A^-1`.
- * @param s_temp  Shared scratch of `(2*dimA + 1) * sizeof(T)` bytes.
+ * @param s_scratch  Shared scratch of `(2*dimA + 1) * sizeof(T)` bytes.
  * @param g       Cooperative thread group (defaults to the whole block).
  */
-// invertMatrix — no cgrps variant needed (already uses __syncthreads internally)
-// Exposed here for API completeness via glass::cgrps::invertMatrix
+// Delegates to the shared glass::invertMatrix_impl with a GroupBarrier.
 template <typename T>
-__device__ void invertMatrix(uint32_t dimA, T *A, T *s_temp,
+__device__ void invertMatrix(uint32_t dimA, T *A, T *s_scratch,
                               cgrps::thread_group g = cgrps::this_thread_block())
 {
-    for (unsigned pivRC = 0; pivRC < dimA; pivRC++) {
-        unsigned pivOff = pivRC * dimA;
-        T pvInv = static_cast<T>(1) / A[pivRC + pivOff];
-        for (unsigned ind = g.thread_rank(); ind < 2*dimA+1; ind++) {
-            unsigned AInd = (ind < dimA) ? (ind + pivOff) : (pivRC + pivOff + (ind-dimA)*dimA);
-            s_temp[ind] = A[AInd];
-        }
-        g.sync();
-        for (unsigned ind = g.thread_rank(); ind < dimA*(dimA+1); ind += g.size()) {
-            unsigned row = ind % dimA, col = ind / dimA, coff = ind - row;
-            if (row == pivRC) A[row + pivOff + coff] *= pvInv;
-            else A[row + pivOff + coff] -= s_temp[row]*pvInv*s_temp[dimA+col];
-        }
-        g.sync();
-    }
+    invertMatrix_impl<GroupBarrier, T>(GroupBarrier{g}, dimA, A, s_scratch);
 }
 
 /**
@@ -190,33 +157,17 @@ __device__ void invertMatrix(uint32_t dimA, T *A, T *s_temp,
 // CHECK (compile-out, default false): when true and s_fail non-null, rank 0 sets
 // *s_fail=1 on a non-PD / NaN pivot (else 0) — mirrors the base block overload.
 // s_fail is placed after g so existing (n, s_A[, g]) callers are unaffected.
+// Delegates to the shared glass::cholDecomp_InPlace_impl with a GroupBarrier.
+// NOTE on warp-tiled groups: the pivot is broadcast by re-reading shared after
+// the barrier. Safe for a block group (the default — a full block fence). A
+// shared re-read at warp scope can be cached stale by nvcc under caller
+// __restrict__ — prefer glass::warp::cholDecomp_InPlace there (it shfl-broadcasts).
 template <typename T, bool CHECK = false>
 __device__ void cholDecomp_InPlace(uint32_t n, T *s_A,
                                     cgrps::thread_group g = cgrps::this_thread_block(),
                                     int *s_fail = nullptr)
 {
-    if constexpr (CHECK) { if (g.thread_rank() == 0 && s_fail) *s_fail = 0; }
-    for (uint32_t row = 0; row < n; row++) {
-        if (g.thread_rank() == 0) {
-            T sum = static_cast<T>(0), val = s_A[n*row + row];
-            for (int32_t rl = 0; rl < (int32_t)row; rl++) sum += s_A[rl*n+row]*s_A[rl*n+row];
-            T d = val - sum;
-            if constexpr (CHECK) { if (s_fail && (d <= static_cast<T>(0) || isnan(d))) *s_fail = 1; }
-            s_A[row*n + row] = sqrtf(d);
-        }
-        g.sync();
-        // NOTE: the pivot s_A[row*n+row] is broadcast by re-reading shared after g.sync().
-        // Safe for a block group (the default — g.sync() is a full block fence). If this is
-        // ever called with a warp-tiled group, prefer g.shfl(pivot, 0) — a shared re-read at
-        // warp scope can be cached stale by nvcc under caller __restrict__ (see the
-        // glass::warp::cholDecomp_InPlace shfl fix in base/L3/chol_InPlace.cuh).
-        for (uint32_t col = g.thread_rank() + row + 1; col < n; col += g.size()) {
-            T sum = static_cast<T>(0);
-            for (uint32_t kk = 0; kk < row; kk++) sum += s_A[kk*n+col]*s_A[kk*n+row];
-            s_A[row*n+col] = (static_cast<T>(1)/s_A[row*n+row])*(s_A[row*n+col] - sum);
-        }
-        g.sync();
-    }
+    cholDecomp_InPlace_impl<GroupBarrier, T, CHECK>(GroupBarrier{g}, n, s_A, s_fail);
 }
 
 /**
@@ -232,21 +183,13 @@ __device__ void cholDecomp_InPlace(uint32_t n, T *s_A,
  * @param b  In/out right-hand side; on return holds the solution x.
  * @param g  Cooperative thread group (defaults to the whole block).
  */
-// trsm
+// Delegates to the shared glass::trsm_impl with a GroupBarrier. For a warp-tiled
+// group prefer glass::warp::trsm (register-broadcast pivot) — see base/L3/trsm.cuh.
 template <typename T>
 __device__ void trsm(uint32_t n, T *L, T *b,
                      cgrps::thread_group g = cgrps::this_thread_block())
 {
-    for (uint32_t col = 0; col < n; col++) {
-        if (g.thread_rank() == 0) b[col] /= L[col*n + col];
-        g.sync();
-        // broadcast via shared re-read; safe for a block group (full fence). For a warp-tiled
-        // group prefer g.shfl(b[col], 0) — see the glass::warp::trsm shfl fix (base/L3/trsm.cuh).
-        T factor = b[col];
-        for (uint32_t row = g.thread_rank() + col + 1; row < n; row += g.size())
-            b[row] -= L[col*n + row] * factor;
-        g.sync();
-    }
+    trsm_impl<GroupBarrier, T>(GroupBarrier{g}, n, L, b);
 }
 
 // ─── contraction-parallel GEMM (cooperative-groups variant) ──────────────────
@@ -262,9 +205,10 @@ __device__ void trsm(uint32_t n, T *L, T *b,
  * output and its lanes split the contraction. Pass a warp-multiple group.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (requires B square: N == K).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K` (see gemm.cuh).
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
  * @tparam TRAILING_SYNC  Emit a trailing `g.sync()` (default true).
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
@@ -273,11 +217,11 @@ __device__ void trsm(uint32_t n, T *L, T *b,
  * @param g      Cooperative thread group (defaults to the whole block).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm_reduced(T alpha, T *A, T *B, T beta, T *C,
                              cgrps::thread_group g = cgrps::this_thread_block())
 {
-    glass::gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR, true>(
+    glass::gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C, true>(
         g.thread_rank(), g.size(), alpha, A, B, beta, C);
     if constexpr (TRAILING_SYNC) g.sync();
 }
@@ -289,9 +233,10 @@ __device__ void gemm_reduced(T alpha, T *A, T *B, T beta, T *C,
  * overload above; pass a warp-multiple group.
  *
  * @tparam T  Scalar type.
- * @tparam M,N,K  Compile-time dimensions: A is M x N, B is N x K (or K x N when TRANSPOSE_B), C is M x (TRANSPOSE_B ? N : K).
- * @tparam TRANSPOSE_B  If true, computes `A @ B^T` (requires B square: N == K).
- * @tparam ROW_MAJOR  Storage order for A, B and C (false = column-major).
+ * @tparam M,N,K  `C` is `M×N`, contraction `K` (see gemm.cuh).
+ * @tparam TRANSPOSE_A  If true, `A` is `K×M` and `op(A)=Aᵀ`.
+ * @tparam TRANSPOSE_B  If true, `B` is `N×K` and `op(B)=Bᵀ`.
+ * @tparam ROW_MAJOR_C  Output storage order (false = column-major).
  * @tparam TRAILING_SYNC  Emit a trailing `g.sync()` (default true).
  * @param alpha  Scalar multiplier on the product.
  * @param A,B    Input matrices.
@@ -299,11 +244,11 @@ __device__ void gemm_reduced(T alpha, T *A, T *B, T beta, T *C,
  * @param g      Cooperative thread group (defaults to the whole block).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          bool TRANSPOSE_B = false, bool ROW_MAJOR = false, bool TRAILING_SYNC = true>
+          bool TRANSPOSE_A = false, bool TRANSPOSE_B = false, bool ROW_MAJOR_C = false, bool TRAILING_SYNC = true>
 __device__ void gemm_reduced(T alpha, T *A, T *B, T *C,
                              cgrps::thread_group g = cgrps::this_thread_block())
 {
-    glass::gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_B, ROW_MAJOR, ROW_MAJOR, ROW_MAJOR, false>(
+    glass::gemm_reduced_impl_ct<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C, false>(
         g.thread_rank(), g.size(), alpha, A, B, static_cast<T>(0), C);
     if constexpr (TRAILING_SYNC) g.sync();
 }
@@ -364,18 +309,18 @@ __device__ void vec_tensor_vec(const T* Tns, const T* u, const T* w, T* s,
  *
  * @tparam T,N,Kdim,ACCUMULATE  See glass::congruence_sym.
  * @tparam TRAILING_SYNC  Emit a trailing `g.sync()` (default true).
- * @param alpha,X,M,beta,Q,s_temp  See glass::congruence_sym.
+ * @param alpha,X,M,beta,Q,s_scratch  See glass::congruence_sym.
  * @param g  Cooperative thread group (defaults to the whole block; pass a warp-multiple group).
  */
 template <typename T, uint32_t N, uint32_t Kdim,
           bool ACCUMULATE = false, bool TRAILING_SYNC = true>
-__device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T* s_temp,
+__device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T* s_scratch,
                                cgrps::thread_group g = cgrps::this_thread_block())
 {
-    gemm(N, N, Kdim, static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(X), s_temp, g);
+    gemm(N, Kdim, N, static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(X), s_scratch, g);
     g.sync();
     glass::detail::xtY_impl<T, N, Kdim, Kdim, true, ACCUMULATE>(
-        g.thread_rank(), g.size(), alpha, X, s_temp, beta, Q);
+        g.thread_rank(), g.size(), alpha, X, s_scratch, beta, Q);
     if constexpr (TRAILING_SYNC) g.sync();
 }
 
@@ -386,18 +331,18 @@ __device__ void congruence_sym(T alpha, const T* X, const T* M, T beta, T* Q, T*
  *
  * @tparam T,N,P,Qd,ACCUMULATE  See glass::bilinear.
  * @tparam TRAILING_SYNC  Emit a trailing `g.sync()` (default true).
- * @param alpha,X,M,Y,beta,R,s_temp  See glass::bilinear.
+ * @param alpha,X,M,Y,beta,R,s_scratch  See glass::bilinear.
  * @param g  Cooperative thread group (defaults to the whole block; pass a warp-multiple group).
  */
 template <typename T, uint32_t N, uint32_t P, uint32_t Qd,
           bool ACCUMULATE = false, bool TRAILING_SYNC = true>
-__device__ void bilinear(T alpha, const T* X, const T* M, const T* Y, T beta, T* R, T* s_temp,
+__device__ void bilinear(T alpha, const T* X, const T* M, const T* Y, T beta, T* R, T* s_scratch,
                          cgrps::thread_group g = cgrps::this_thread_block())
 {
-    gemm(N, N, Qd, static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(Y), s_temp, g);
+    gemm(N, Qd, N, static_cast<T>(1), const_cast<T*>(M), const_cast<T*>(Y), s_scratch, g);
     g.sync();
     glass::detail::xtY_impl<T, N, P, Qd, false, ACCUMULATE>(
-        g.thread_rank(), g.size(), alpha, X, s_temp, beta, R);
+        g.thread_rank(), g.size(), alpha, X, s_scratch, beta, R);
     if constexpr (TRAILING_SYNC) g.sync();
 }
 
@@ -408,29 +353,29 @@ __device__ void bilinear(T alpha, const T* X, const T* M, const T* Y, T beta, T*
  *
  * Cooperative-groups form of `glass::syrk_reduced`. Pass a warp-multiple group.
  *
- * @tparam T,ROWS,COLS,TRANS  See glass::syrk_reduced.
+ * @tparam T,ROWS,COLS,TRANSPOSE  See glass::syrk_reduced.
  * @tparam TRAILING_SYNC  Emit a trailing `g.sync()` (default true).
  * @param alpha,A,beta,C  See glass::syrk_reduced.
  * @param g  Cooperative thread group (defaults to the whole block; pass a warp-multiple group).
  */
-template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void syrk_reduced(T alpha, const T* A, T beta, T* C,
                              cgrps::thread_group g = cgrps::this_thread_block())
 {
-    glass::detail::syrk_reduced_impl<T, ROWS, COLS, TRANS, true>(g.thread_rank(), g.size(), alpha, A, beta, C);
+    glass::detail::syrk_reduced_impl<T, ROWS, COLS, TRANSPOSE, true>(g.thread_rank(), g.size(), alpha, A, beta, C);
     if constexpr (TRAILING_SYNC) g.sync();
 }
 
 /**
  * @brief Contraction-parallel SYRK with implicit `beta = 0`: `C = alpha * A·op(A)` (cooperative-groups variant).
  *
- * @tparam T,ROWS,COLS,TRANS,TRAILING_SYNC  See the beta overload.
+ * @tparam T,ROWS,COLS,TRANSPOSE,TRAILING_SYNC  See the beta overload.
  * @param alpha,A,C,g  See the beta overload.
  */
-template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANS = false, bool TRAILING_SYNC = true>
+template <typename T, uint32_t ROWS, uint32_t COLS, bool TRANSPOSE = false, bool TRAILING_SYNC = true>
 __device__ void syrk_reduced(T alpha, const T* A, T* C,
                              cgrps::thread_group g = cgrps::this_thread_block())
 {
-    glass::detail::syrk_reduced_impl<T, ROWS, COLS, TRANS, false>(g.thread_rank(), g.size(), alpha, A, static_cast<T>(0), C);
+    glass::detail::syrk_reduced_impl<T, ROWS, COLS, TRANSPOSE, false>(g.thread_rank(), g.size(), alpha, A, static_cast<T>(0), C);
     if constexpr (TRAILING_SYNC) g.sync();
 }

--- a/src/nvidia/l1.cuh
+++ b/src/nvidia/l1.cuh
@@ -3,7 +3,7 @@
 #include <cassert>
 #include <cub/cub.cuh>
 
-// glass::nvidia L1 — CUB-backed reduce / dot / l2norm
+// glass::nvidia L1 — CUB-backed reduce / dot / nrm2
 // All functions are compile-time only: T, N, THREADS must be template parameters.
 // THREADS defaults to 256; set it to match your kernel's blockDim.x.
 //
@@ -47,7 +47,7 @@
  * @tparam THREADS       Block thread count (must equal blockDim.x).
  * @tparam TRAILING_SYNC Emit a trailing __syncthreads() before return (default true).
  * @param  x             Input array of length N; result lands in x[0].
- * @param  s_scratch     Shared scratch >= reduce_smem_size<T, THREADS>() bytes.
+ * @param  s_scratch     Shared scratch >= reduce_scratch_bytes<T, THREADS>() bytes.
  */
 template <typename T, uint32_t N, uint32_t THREADS = 256, bool TRAILING_SYNC = true>
 __device__ void reduce(T *x, T *s_scratch)
@@ -80,7 +80,7 @@ __device__ void reduce(T *x, T *s_scratch)
  * @param  x             First input vector (length N).
  * @param  y             Second input vector (length N).
  * @param  out           Output pointer for the resulting scalar.
- * @param  s_scratch     Shared scratch >= reduce_smem_size<T, THREADS>() bytes.
+ * @param  s_scratch     Shared scratch >= reduce_scratch_bytes<T, THREADS>() bytes.
  */
 template <typename T, uint32_t N, uint32_t THREADS = 256, bool TRAILING_SYNC = true>
 __device__ void dot(T *x, T *y, T *out, T *s_scratch)
@@ -112,10 +112,10 @@ __device__ void dot(T *x, T *y, T *out, T *s_scratch)
  * @tparam TRAILING_SYNC Emit a trailing __syncthreads() before return (default true).
  * @param  x             Input vector (length N).
  * @param  out           Output pointer for the resulting scalar norm.
- * @param  s_scratch     Shared scratch >= reduce_smem_size<T, THREADS>() bytes.
+ * @param  s_scratch     Shared scratch >= reduce_scratch_bytes<T, THREADS>() bytes.
  */
 template <typename T, uint32_t N, uint32_t THREADS = 256, bool TRAILING_SYNC = true>
-__device__ void l2norm(T *x, T *out, T *s_scratch)
+__device__ void nrm2(T *x, T *out, T *s_scratch)
 {
     _GLASS_ASSERT_THREADS_EQ(THREADS)
     using BlockReduce = cub::BlockReduce<T, THREADS>;
@@ -132,7 +132,7 @@ __device__ void l2norm(T *x, T *out, T *s_scratch)
 }
 
 /**
- * @brief Shared-memory bytes needed for the L1 reduce/dot/l2norm scratch (host-callable).
+ * @brief Shared-memory bytes needed for the L1 reduce/dot/nrm2 scratch (host-callable).
  *
  * Returns `sizeof(cub::BlockReduce<T, THREADS>::TempStorage)` — the size of
  * the `s_scratch` buffer these CUB-backed reductions require. constexpr.
@@ -142,7 +142,7 @@ __device__ void l2norm(T *x, T *out, T *s_scratch)
  * @return Required scratch size in bytes.
  */
 template <typename T, uint32_t THREADS = 256>
-inline constexpr std::size_t reduce_smem_size()
+inline constexpr std::size_t reduce_scratch_bytes()
 {
     return sizeof(typename cub::BlockReduce<T, THREADS>::TempStorage);
 }

--- a/src/nvidia/l2.cuh
+++ b/src/nvidia/l2.cuh
@@ -18,7 +18,7 @@
 //
 // Example (basic):
 //   DEFINE_NVIDIA_GEMV(6, 6)
-//   constexpr auto smem    = glass::nvidia::gemv_smem_size<float, 6, 6>();
+//   constexpr auto smem    = glass::nvidia::gemv_scratch_bytes<float, 6, 6>();
 //   constexpr auto threads = glass::nvidia::gemv_threads<float, 6, 6>();
 //   kernel<<<1, threads, smem>>>(...);
 //   glass::nvidia::gemv<float, 6, 6>(1.f, A, x, 0.f, y, smem_ptr);
@@ -114,7 +114,7 @@ template <typename T, uint32_t M, uint32_t N,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           uint32_t SM_VAL = SMS>
-constexpr std::size_t gemv_smem_size() { return 0; }
+constexpr std::size_t gemv_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuBLASDx wants for `gemv<...>` (host-callable).
@@ -216,7 +216,7 @@ constexpr uint32_t gemv_threads() { return 256; }
             ::template run<false>(alpha, A, x, beta, y, smem);                                  \
     }                                                                                           \
     template <>                                                                                 \
-    constexpr std::size_t gemv_smem_size<CT, M, N, 0,                                        \
+    constexpr std::size_t gemv_scratch_bytes<CT, M, N, 0,                                        \
                                           static_cast<layout>(LA),                              \
                                           static_cast<layout>(LB),                              \
                                           static_cast<layout>(LC), ARCH>()                      \
@@ -301,7 +301,7 @@ constexpr uint32_t gemv_threads() { return 256; }
             ::template run<false>(alpha, A, x, beta, y, smem);                                  \
     }                                                                                           \
     template <>                                                                                 \
-    constexpr std::size_t gemv_smem_size<CT, M, N, TC,                                       \
+    constexpr std::size_t gemv_scratch_bytes<CT, M, N, TC,                                       \
                                           static_cast<layout>(LA),                              \
                                           static_cast<layout>(LB),                              \
                                           static_cast<layout>(LC), ARCH>()                      \
@@ -357,7 +357,7 @@ constexpr uint32_t gemv_threads() { return 256; }
     _GLASS_GEMV_BD_E(M, N, TC, LA, LB, LC, float, SM)
 
 // ---------------------------------------------------------------------------
-// row_strided_gemv: packs strided A into compact shared scratch, then delegates
+// gemv_strided: packs strided A into compact shared scratch, then delegates
 // to the standard nvidia::gemv<...>. Forwards all template parameters
 // (BLOCK_THREADS, layouts, SM) to the inner call.
 //
@@ -405,12 +405,12 @@ template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE = M,
           layout LC = layout::col_major,
           uint32_t SM_VAL = SMS,
           bool TRAILING_SYNC = true>
-__device__ void row_strided_gemv(T alpha, T* A, T* x, T beta, T* y, char* smem)
+__device__ void gemv_strided(T alpha, T* A, T* x, T beta, T* y, char* smem)
 {
-    if constexpr (!should_use_cublasdx_row_strided_gemv<T, M, N, ROW_STRIDE, SM_VAL>()) {
-        // SIMT path: ::glass::row_strided_gemv uses the stride directly,
-        // no packing required. Arg order shuffles to match SIMT convention.
-        ::glass::row_strided_gemv<T, M, N, ROW_STRIDE>(A, x, y, alpha, beta);
+    if constexpr (!should_use_cublasdx_gemv_strided<T, M, N, ROW_STRIDE, SM_VAL>()) {
+        // SIMT path: ::glass::gemv_strided uses the stride directly,
+        // no packing required.
+        ::glass::gemv_strided<T, M, N, ROW_STRIDE>(alpha, A, x, beta, y);
     } else {
         // cuBLASDx path: pack strided A into compact scratch, then delegate
         // to the cuBLASDx-specialized gemv<>.
@@ -429,7 +429,7 @@ __device__ void row_strided_gemv(T alpha, T* A, T* x, T beta, T* y, char* smem)
 }
 
 /**
- * @brief Shared-memory bytes needed by `row_strided_gemv<...>` (host-callable).
+ * @brief Shared-memory bytes needed by `gemv_strided<...>` (host-callable).
  *
  * Returns 0 when the auto-dispatch routes to SIMT (no packing), or the
  * A-packing scratch plus the inner cuBLASDx gemv scratch otherwise. constexpr.
@@ -450,11 +450,11 @@ template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE = M,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           uint32_t SM_VAL = SMS>
-constexpr std::size_t row_strided_gemv_smem_size()
+constexpr std::size_t gemv_strided_scratch_bytes()
 {
-    if constexpr (!should_use_cublasdx_row_strided_gemv<T, M, N, ROW_STRIDE, SM_VAL>())
+    if constexpr (!should_use_cublasdx_gemv_strided<T, M, N, ROW_STRIDE, SM_VAL>())
         return 0;
     else
         return M * N * sizeof(T)
-             + gemv_smem_size<T, M, N, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
+             + gemv_scratch_bytes<T, M, N, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
 }

--- a/src/nvidia/l3.cuh
+++ b/src/nvidia/l3.cuh
@@ -18,7 +18,7 @@
 //
 // Example (basic):
 //   DEFINE_NVIDIA_GEMM(6, 6, 6)
-//   constexpr auto smem    = glass::nvidia::gemm_smem_size<float, 6, 6, 6>();
+//   constexpr auto smem    = glass::nvidia::gemm_scratch_bytes<float, 6, 6, 6>();
 //   constexpr auto threads = glass::nvidia::gemm_threads<float, 6, 6, 6>();
 //   kernel<<<1, threads, smem>>>(...);
 //   glass::nvidia::gemm<float, 6, 6, 6>(1.f, A, B, 0.f, C, smem_ptr);
@@ -118,24 +118,15 @@ template <typename T, uint32_t M, uint32_t N, uint32_t K,
 __device__ void gemm(T alpha, T* A, T* B, T beta, T* C, char* smem)
 {
     if constexpr (!should_use_cublasdx<T, M, N, K, SM_VAL>()) {
-        // Map layout flags onto SIMT (TRANSPOSE_B, ROW_MAJOR). SIMT supports:
-        //   (col, col, col) → (false, false)   standard col-major
-        //   (col, row, col) → (true,  false)   col-major A·Bᵀ      (Gap D, round-2)
-        //   (row, row, row) → (false, true )   standard row-major
-        //   (row, col, row) → (true,  true )   row-major A·Bᵀ
-        // Other combinations are mixed layouts SIMT can't express directly;
-        // those require DEFINE_NVIDIA_GEMM_LAYOUT* to force cuBLASDx routing.
-        constexpr bool LA_ROW = (LA == layout::row_major);
-        constexpr bool LB_ROW = (LB == layout::row_major);
-        constexpr bool LC_ROW = (LC == layout::row_major);
-        static_assert(LA_ROW == LC_ROW,
-            "glass::nvidia::gemm SIMT fallback requires LA == LC (A and C "
-            "share the row/col-major convention). Use "
-            "DEFINE_NVIDIA_GEMM_LAYOUT to specialize cuBLASDx for mixed "
-            "layouts, or call ::glass::gemm_ex directly.");
-        constexpr bool ROW_MAJOR   = LA_ROW;
-        constexpr bool TRANSPOSE_B = (LB_ROW != LA_ROW);
-        ::glass::gemm<T, M, N, K, TRANSPOSE_B, ROW_MAJOR>(
+        // Map per-operand layouts directly onto the standard-BLAS SIMT gemm.
+        // A row-major operand is a transposed column-major operand, so:
+        //   LA=row_major ⇒ TRANSPOSE_A,  LB=row_major ⇒ TRANSPOSE_B,
+        //   LC=row_major ⇒ ROW_MAJOR_C.  All four operand layouts are now
+        //   independently expressible — no mixed-layout restriction.
+        constexpr bool TRANSPOSE_A = (LA == layout::row_major);
+        constexpr bool TRANSPOSE_B = (LB == layout::row_major);
+        constexpr bool ROW_MAJOR_C = (LC == layout::row_major);
+        ::glass::gemm<T, M, N, K, TRANSPOSE_A, TRANSPOSE_B, ROW_MAJOR_C>(
             alpha, A, B, beta, C);
     } else {
         static_assert(sizeof(T) == 0,
@@ -169,7 +160,7 @@ template <typename T, uint32_t M, uint32_t N, uint32_t K,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           uint32_t SM_VAL = SMS>
-constexpr std::size_t gemm_smem_size() { return 0; }
+constexpr std::size_t gemm_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuBLASDx wants for `gemm<...>` (host-callable).
@@ -275,7 +266,7 @@ constexpr uint32_t gemm_threads() { return 256; }
             ::template run<false>(alpha, A, B, beta, C, smem);                                  \
     }                                                                                           \
     template <>                                                                                 \
-    constexpr std::size_t gemm_smem_size<CT, M, N, K, 0,                                     \
+    constexpr std::size_t gemm_scratch_bytes<CT, M, N, K, 0,                                     \
                                           static_cast<layout>(LA),                              \
                                           static_cast<layout>(LB),                              \
                                           static_cast<layout>(LC), ARCH>()                      \
@@ -363,7 +354,7 @@ constexpr uint32_t gemm_threads() { return 256; }
             ::template run<false>(alpha, A, B, beta, C, smem);                                  \
     }                                                                                           \
     template <>                                                                                 \
-    constexpr std::size_t gemm_smem_size<CT, M, N, K, TC,                                    \
+    constexpr std::size_t gemm_scratch_bytes<CT, M, N, K, TC,                                    \
                                           static_cast<layout>(LA),                              \
                                           static_cast<layout>(LB),                              \
                                           static_cast<layout>(LC), ARCH>()                     \
@@ -451,7 +442,7 @@ constexpr uint32_t gemm_threads() { return 256; }
     DEFINE_NVIDIA_GEMM_BLOCKDIM_LAYOUT_SM(M, N, K, TC, 0, 1, 0, SM)
 
 // ---------------------------------------------------------------------------
-// row_strided_gemm: packs strided A and B into compact shared scratch, then
+// gemm_strided: packs strided A and B into compact shared scratch, then
 // delegates to the standard nvidia::gemm<...>. Forwards all template parameters
 // (BLOCK_THREADS, layouts, SM) to the inner call so any DEFINE_NVIDIA_GEMM*
 // variant works underneath.
@@ -492,34 +483,35 @@ constexpr uint32_t gemm_threads() { return 256; }
  * @param  smem          Shared scratch (cuBLASDx route only; unused for SIMT).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          uint32_t A_RS = M, uint32_t B_RS = N,
+          uint32_t A_RS = M, uint32_t B_RS = K,
           uint32_t BLOCK_THREADS = 0,
           layout LA = layout::col_major,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           uint32_t SM_VAL = SMS,
           bool TRAILING_SYNC = true>
-__device__ void row_strided_gemm(T alpha, T* A, T* B, T beta, T* C, char* smem)
+__device__ void gemm_strided(T alpha, T* A, T* B, T beta, T* C, char* smem)
 {
     // Round-2 Gap C: auto-dispatch. On the SIMT route we use the strides
-    // directly (no packing), saving the M*N + N*K scratch and two pack
+    // directly (no packing), saving the M*K + K*N scratch and two pack
     // passes. On the cuBLASDx route we pack into compact scratch and
     // delegate to gemm<> (which will hit the cuBLASDx specialization).
+    // Standard convention: A is M×K (lead A_RS), B is K×N (lead B_RS), C is M×N.
     if constexpr (!should_use_cublasdx<T, M, N, K, SM_VAL>()) {
-        ::glass::row_strided_gemm<T, M, N, K, A_RS, B_RS>(A, B, C, alpha, beta);
+        ::glass::gemm_strided<T, M, N, K, A_RS, B_RS>(alpha, A, B, beta, C);
     } else {
         uint32_t rank = threadIdx.x + threadIdx.y*blockDim.x + threadIdx.z*blockDim.x*blockDim.y;
         uint32_t size = blockDim.x * blockDim.y * blockDim.z;
         T* A_compact = reinterpret_cast<T*>(smem);
-        T* B_compact = reinterpret_cast<T*>(smem + M * N * sizeof(T));
-        char* cublas_smem = smem + (M * N + N * K) * sizeof(T);
-        for (uint32_t i = rank; i < M * N; i += size) {
+        T* B_compact = reinterpret_cast<T*>(smem + M * K * sizeof(T));
+        char* cublas_smem = smem + (M * K + K * N) * sizeof(T);
+        for (uint32_t i = rank; i < M * K; i += size) {   // A is M×K
             uint32_t r = i % M, c = i / M;
             A_compact[r + c*M] = A[r + c*A_RS];
         }
-        for (uint32_t i = rank; i < N * K; i += size) {
-            uint32_t r = i % N, c = i / N;
-            B_compact[r + c*N] = B[r + c*B_RS];
+        for (uint32_t i = rank; i < K * N; i += size) {   // B is K×N
+            uint32_t r = i % K, c = i / K;
+            B_compact[r + c*K] = B[r + c*B_RS];
         }
         __syncthreads();
         gemm<T, M, N, K, BLOCK_THREADS, LA, LB, LC, SM_VAL, TRAILING_SYNC>(
@@ -530,7 +522,7 @@ __device__ void row_strided_gemm(T alpha, T* A, T* B, T beta, T* C, char* smem)
 // Returns the cuBLASDx scratch + packing scratch the cuBLASDx route needs,
 // or 0 when the auto-dispatch would route to SIMT (which skips packing).
 /**
- * @brief Shared-memory bytes needed by `row_strided_gemm<...>` (host-callable).
+ * @brief Shared-memory bytes needed by `gemm_strided<...>` (host-callable).
  *
  * Returns 0 when the auto-dispatch routes to SIMT (no packing), or the A+B
  * packing scratch plus the inner cuBLASDx gemm scratch otherwise. constexpr.
@@ -548,19 +540,19 @@ __device__ void row_strided_gemm(T alpha, T* A, T* B, T beta, T* C, char* smem)
  * @tparam SM_VAL        Target SM architecture.
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
-          uint32_t A_RS = M, uint32_t B_RS = N,
+          uint32_t A_RS = M, uint32_t B_RS = K,
           uint32_t BLOCK_THREADS = 0,
           layout LA = layout::col_major,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           uint32_t SM_VAL = SMS>
-constexpr std::size_t row_strided_gemm_smem_size()
+constexpr std::size_t gemm_strided_scratch_bytes()
 {
     if constexpr (!should_use_cublasdx<T, M, N, K, SM_VAL>())
         return 0;
     else
-        return (M * N + N * K) * sizeof(T)
-             + gemm_smem_size<T, M, N, K, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
+        return (M * K + K * N) * sizeof(T)
+             + gemm_scratch_bytes<T, M, N, K, BLOCK_THREADS, LA, LB, LC, SM_VAL>();
 }
 
 // ---------------------------------------------------------------------------
@@ -574,8 +566,8 @@ constexpr std::size_t row_strided_gemm_smem_size()
 // an arbitrary global address. For contiguous batches, populate the array as
 //   { base + 0*M*N, base + 1*M*N, ..., base + (BATCH-1)*M*N }.
 //
-// Required launch:  kernel<<<grid, dim3(TC, BATCH), gemm_batched_smem_size>>>
-// Required smem:    glass::nvidia::gemm_batched_smem_size<T, M, N, K, BATCH, TC>()
+// Required launch:  kernel<<<grid, dim3(TC, BATCH), gemm_batched_scratch_bytes>>>
+// Required smem:    glass::nvidia::gemm_batched_scratch_bytes<T, M, N, K, BATCH, TC>()
 // ---------------------------------------------------------------------------
 
 /**
@@ -645,7 +637,7 @@ template <typename T, uint32_t M, uint32_t N, uint32_t K, uint32_t BATCH,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           uint32_t SM_VAL = SMS>
-constexpr std::size_t gemm_batched_smem_size() { return 0; }
+constexpr std::size_t gemm_batched_scratch_bytes() { return 0; }
 
 /**
  * @brief Total thread count for `gemm_batched<...>` (host-callable).
@@ -750,7 +742,7 @@ constexpr uint32_t gemm_batched_threads() { return 256; }
             ::template run<false>(alpha, A, B, beta, C, smem);                                  \
     }                                                                                           \
     template <>                                                                                 \
-    constexpr std::size_t gemm_batched_smem_size<float, M, N, K, BATCH, TC,                    \
+    constexpr std::size_t gemm_batched_scratch_bytes<float, M, N, K, BATCH, TC,                    \
                                                   static_cast<layout>(LA),                      \
                                                   static_cast<layout>(LB),                      \
                                                   static_cast<layout>(LC), ARCH>()             \

--- a/src/nvidia/l3_simt.cuh
+++ b/src/nvidia/l3_simt.cuh
@@ -92,7 +92,7 @@ __device__ void gemm_batched_1d(T alpha, T* const* A, T* const* B,
         // Reuse the well-tested compile-time SIMT gemm core from glass::.
         // Inner loop is fully unrolled; no inter-batch synchronization needed
         // because batches use disjoint thread sets and disjoint output buffers.
-        ::glass::gemm_impl_ct<T, M, N, K, /*TRANSPOSE_B=*/false, RM_A, RM_B, RM_C>(
+        ::glass::gemm_impl_ct<T, M, N, K, RM_A, RM_B, RM_C>(
             tx, TC, alpha, A[b], B[b], beta, C[b]);
     }
     if constexpr (TRAILING_SYNC) {
@@ -113,7 +113,7 @@ template <typename T, uint32_t M, uint32_t N, uint32_t K,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           bool TRAILING_SYNC = true>
-constexpr std::size_t gemm_batched_1d_smem_size() { return 0; }
+constexpr std::size_t gemm_batched_1d_scratch_bytes() { return 0; }
 
 /**
  * @brief Total threads required across the 1D block for `gemm_batched_1d<...>`.
@@ -141,8 +141,8 @@ constexpr uint32_t gemm_batched_1d_threads() { return TC * BATCH; }
 //   B element address for batch b:  B + b * B_STRIDE
 //   C element address for batch b:  C + b * C_STRIDE
 //
-// Defaults for B_STRIDE / C_STRIDE assume tightly packed batches (B is N×K,
-// C is M×K). Override for non-contiguous storage.
+// Defaults for B_STRIDE / C_STRIDE assume tightly packed batches (B is K×N,
+// C is M×N). Override for non-contiguous storage.
 //
 // Only B and C are strided — A is always shared. Use gemm_batched_1d if a
 // per-batch A is needed.
@@ -181,7 +181,7 @@ constexpr uint32_t gemm_batched_1d_threads() { return TC * BATCH; }
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
           uint32_t BATCH, uint32_t TC,
           uint32_t B_STRIDE = N * K,
-          uint32_t C_STRIDE = M * K,
+          uint32_t C_STRIDE = M * N,
           layout LA = layout::col_major,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
@@ -204,7 +204,7 @@ __device__ void gemm_strided_batched_1d(T alpha, const T* A_shared, T* B,
         uint32_t tx = rank - b * TC;
         // const_cast: gemm_impl_ct's signature takes T*, but it only reads A.
         // Safe because every batch element only reads — never writes — A_shared.
-        ::glass::gemm_impl_ct<T, M, N, K, /*TRANSPOSE_B=*/false, RM_A, RM_B, RM_C>(
+        ::glass::gemm_impl_ct<T, M, N, K, RM_A, RM_B, RM_C>(
             tx, TC, alpha, const_cast<T*>(A_shared),
                            B + b * B_STRIDE,
             beta,          C + b * C_STRIDE);
@@ -222,12 +222,12 @@ __device__ void gemm_strided_batched_1d(T alpha, const T* A_shared, T* B,
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
           uint32_t BATCH, uint32_t TC,
-          uint32_t B_STRIDE = N * K, uint32_t C_STRIDE = M * K,
+          uint32_t B_STRIDE = N * K, uint32_t C_STRIDE = M * N,
           layout LA = layout::col_major,
           layout LB = layout::col_major,
           layout LC = layout::col_major,
           bool TRAILING_SYNC = true>
-constexpr std::size_t gemm_strided_batched_1d_smem_size() { return 0; }
+constexpr std::size_t gemm_strided_batched_1d_scratch_bytes() { return 0; }
 
 /**
  * @brief Total threads required across the 1D block for `gemm_strided_batched_1d<...>`.
@@ -237,7 +237,7 @@ constexpr std::size_t gemm_strided_batched_1d_smem_size() { return 0; }
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
           uint32_t BATCH, uint32_t TC,
-          uint32_t B_STRIDE = N * K, uint32_t C_STRIDE = M * K,
+          uint32_t B_STRIDE = N * K, uint32_t C_STRIDE = M * N,
           layout LA = layout::col_major,
           layout LB = layout::col_major,
           layout LC = layout::col_major,

--- a/src/nvidia/lapack.cuh
+++ b/src/nvidia/lapack.cuh
@@ -9,7 +9,7 @@
  * least-squares (gels). Each is a static_assert stub by default; instantiate a
  * shape with the matching `DEFINE_NVIDIA_<NAME>` / `_BLOCKDIM` / `_SM` /
  * `_BLOCKDIM_SM` macro in your `.cu` (inside `namespace glass::nvidia`). Each
- * also ships `*_smem_size` / `*_threads` host-callable constexpr queries.
+ * also ships `*_scratch_bytes` / `*_threads` host-callable constexpr queries.
  *
  * Requires cuSOLVERDx / NVIDIA MathDx (MATHDX_ROOT) and linking the precompiled
  * device library (`-rdc=true -dlto -lcusolverdx -lcublas -lcusolver -lcudart`).
@@ -39,7 +39,7 @@
 //
 // Example:
 //   DEFINE_NVIDIA_CHOL_BLOCKDIM(7, 352)
-//   constexpr auto smem    = glass::nvidia::cholDecomp_InPlace_smem_size<float, 7, 352>();
+//   constexpr auto smem    = glass::nvidia::cholDecomp_InPlace_scratch_bytes<float, 7, 352>();
 //   constexpr auto threads = glass::nvidia::cholDecomp_InPlace_threads<float, 7, 352>();
 //   kernel<<<1, threads, smem>>>(d_A);
 //   glass::nvidia::cholDecomp_InPlace<float, 7, 352>(A, smem_ptr);
@@ -66,7 +66,7 @@
  * @tparam SM_VAL        Target SM architecture (default = SMS).
  * @tparam TRAILING_SYNC Emit a trailing __syncthreads() before return (default true).
  * @param  A             Pointer to the N×N column-major SPD matrix; overwritten with L.
- * @param  smem          Shared scratch (>= cholDecomp_InPlace_smem_size<...>()).
+ * @param  smem          Shared scratch (>= cholDecomp_InPlace_scratch_bytes<...>()).
  */
 template <typename T, uint32_t N, uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS,
           bool TRAILING_SYNC = true>
@@ -82,7 +82,7 @@ __device__ void cholDecomp_InPlace(T* A, char* smem)
  * @tparam T T scalar; @tparam N dim; @tparam BLOCK_THREADS pinned BlockDim; @tparam SM_VAL SM arch.
  */
 template <typename T, uint32_t N, uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t cholDecomp_InPlace_smem_size() { return 0; }
+constexpr std::size_t cholDecomp_InPlace_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `cholDecomp_InPlace<...>` (host-callable, constexpr).
@@ -109,7 +109,7 @@ constexpr uint32_t cholDecomp_InPlace_threads() { return 256; }
  * @param  alpha         Scaling factor applied to B before the solve.
  * @param  L             Pointer to the M×M lower-triangular matrix.
  * @param  B             Pointer to the M×N right-hand sides; overwritten with X.
- * @param  smem          Shared scratch (>= trsm_smem_size<...>()).
+ * @param  smem          Shared scratch (>= trsm_scratch_bytes<...>()).
  */
 template <typename T, uint32_t M, uint32_t N,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS,
@@ -127,7 +127,7 @@ __device__ void trsm(T alpha, T* L, T* B, char* smem)
  */
 template <typename T, uint32_t M, uint32_t N,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t trsm_smem_size() { return 0; }
+constexpr std::size_t trsm_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `trsm<...>` (host-callable, constexpr).
@@ -184,7 +184,7 @@ constexpr uint32_t trsm_threads() { return 256; }
         _nvidia_chol_impl_##N##_##CT##_bd0_sm##ARCH::template run<false>(A, smem);                   \
     }                                                                                         \
     template <>                                                                               \
-    constexpr std::size_t cholDecomp_InPlace_smem_size<CT, N, 0, ARCH>()                         \
+    constexpr std::size_t cholDecomp_InPlace_scratch_bytes<CT, N, 0, ARCH>()                         \
     {                                                                                         \
         return _nvidia_chol_impl_##N##_##CT##_bd0_sm##ARCH::smem_bytes;                              \
     }                                                                                         \
@@ -237,7 +237,7 @@ constexpr uint32_t trsm_threads() { return 256; }
         _nvidia_chol_impl_##N##_##CT##_bd##TC##_sm##ARCH::template run<false>(A, smem);              \
     }                                                                                         \
     template <>                                                                               \
-    constexpr std::size_t cholDecomp_InPlace_smem_size<CT, N, TC, ARCH>()                        \
+    constexpr std::size_t cholDecomp_InPlace_scratch_bytes<CT, N, TC, ARCH>()                        \
     {                                                                                         \
         return _nvidia_chol_impl_##N##_##CT##_bd##TC##_sm##ARCH::smem_bytes;                         \
     }                                                                                         \
@@ -311,7 +311,7 @@ constexpr uint32_t trsm_threads() { return 256; }
         _nvidia_trsm_impl_##M##x##N##_##CT##_bd0_sm##ARCH::template run<false>(alpha, L, B, smem);   \
     }                                                                                         \
     template <>                                                                               \
-    constexpr std::size_t trsm_smem_size<CT, M, N, 0, ARCH>()                              \
+    constexpr std::size_t trsm_scratch_bytes<CT, M, N, 0, ARCH>()                              \
     {                                                                                         \
         return _nvidia_trsm_impl_##M##x##N##_##CT##_bd0_sm##ARCH::smem_bytes;                        \
     }                                                                                         \
@@ -379,7 +379,7 @@ constexpr uint32_t trsm_threads() { return 256; }
         _nvidia_trsm_impl_##M##x##N##_##CT##_bd##TC##_sm##ARCH::template run<false>(alpha, L, B, smem);\
     }                                                                                         \
     template <>                                                                               \
-    constexpr std::size_t trsm_smem_size<CT, M, N, TC, ARCH>()                             \
+    constexpr std::size_t trsm_scratch_bytes<CT, M, N, TC, ARCH>()                             \
     {                                                                                         \
         return _nvidia_trsm_impl_##M##x##N##_##CT##_bd##TC##_sm##ARCH::smem_bytes;                   \
     }                                                                                         \
@@ -431,7 +431,7 @@ constexpr uint32_t trsm_threads() { return 256; }
 //
 // All seven follow the same primary-template + private-core-macro + _E
 // indirection + public DEFINE convenience-macro pattern as cholDecomp_InPlace/trsm.
-// Each provides _smem_size and _threads constexpr queries.
+// Each provides _scratch_bytes and _threads constexpr queries.
 // =============================================================================
 
 // --- posv (SPD factor + solve) ----------------------------------------------
@@ -454,7 +454,7 @@ constexpr uint32_t trsm_threads() { return 256; }
  * @tparam TRAILING_SYNC Emit a trailing __syncthreads() before return (default true).
  * @param  A             Pointer to the N×N SPD matrix; overwritten with L.
  * @param  B             Pointer to the N×NRHS right-hand sides; overwritten with X.
- * @param  smem          Shared scratch (>= posv_smem_size<...>()).
+ * @param  smem          Shared scratch (>= posv_scratch_bytes<...>()).
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS,
@@ -472,7 +472,7 @@ __device__ void posv(T* A, T* B, char* smem)
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t posv_smem_size() { return 0; }
+constexpr std::size_t posv_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `posv<...>` (host-callable, constexpr).
@@ -523,7 +523,7 @@ constexpr uint32_t posv_threads() { return 256; }
     __device__ inline void posv<CT, N, NRHS, 0, ARCH, false>(CT* A, CT* B, char* smem) \
     { _nvidia_posv_impl_##N##x##NRHS##_##CT##_bd0_sm##ARCH::template run<false>(A, B, smem); }          \
     template <>                                                                                  \
-    constexpr std::size_t posv_smem_size<CT, N, NRHS, 0, ARCH>()                             \
+    constexpr std::size_t posv_scratch_bytes<CT, N, NRHS, 0, ARCH>()                             \
     { return _nvidia_posv_impl_##N##x##NRHS##_##CT##_bd0_sm##ARCH::smem_bytes; }                        \
     template <>                                                                                  \
     constexpr uint32_t posv_threads<CT, N, NRHS, 0, ARCH>()                                  \
@@ -571,7 +571,7 @@ constexpr uint32_t posv_threads() { return 256; }
     __device__ inline void posv<CT, N, NRHS, TC, ARCH, false>(CT* A, CT* B, char* smem)\
     { _nvidia_posv_impl_##N##x##NRHS##_##CT##_bd##TC##_sm##ARCH::template run<false>(A, B, smem); }     \
     template <>                                                                                  \
-    constexpr std::size_t posv_smem_size<CT, N, NRHS, TC, ARCH>()                            \
+    constexpr std::size_t posv_scratch_bytes<CT, N, NRHS, TC, ARCH>()                            \
     { return _nvidia_posv_impl_##N##x##NRHS##_##CT##_bd##TC##_sm##ARCH::smem_bytes; }                   \
     template <>                                                                                  \
     constexpr uint32_t posv_threads<CT, N, NRHS, TC, ARCH>()                                 \
@@ -609,7 +609,7 @@ constexpr uint32_t posv_threads() { return 256; }
  * @tparam SM_VAL        Target SM architecture (default = SMS).
  * @param  L             Pointer to the N×N lower Cholesky factor (read-only).
  * @param  B             Pointer to the N×NRHS right-hand sides; overwritten with X.
- * @param  smem          Shared scratch (>= potrs_smem_size<...>()).
+ * @param  smem          Shared scratch (>= potrs_scratch_bytes<...>()).
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
@@ -626,7 +626,7 @@ __device__ void potrs(const T* L, T* B, char* smem)
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t potrs_smem_size() { return 0; }
+constexpr std::size_t potrs_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `potrs<...>` (host-callable, constexpr).
@@ -669,7 +669,7 @@ constexpr uint32_t potrs_threads() { return 256; }
     __device__ inline void potrs<float, N, NRHS, 0, ARCH>(const float* L, float* B, char* smem) \
     { _nvidia_potrs_impl_##N##x##NRHS##_bd0_sm##ARCH::run(L, B, smem); }                         \
     template <>                                                                                  \
-    constexpr std::size_t potrs_smem_size<float, N, NRHS, 0, ARCH>()                            \
+    constexpr std::size_t potrs_scratch_bytes<float, N, NRHS, 0, ARCH>()                            \
     { return _nvidia_potrs_impl_##N##x##NRHS##_bd0_sm##ARCH::smem_bytes; }                       \
     template <>                                                                                  \
     constexpr uint32_t potrs_threads<float, N, NRHS, 0, ARCH>()                                 \
@@ -709,7 +709,7 @@ constexpr uint32_t potrs_threads() { return 256; }
     __device__ inline void potrs<float, N, NRHS, TC, ARCH>(const float* L, float* B, char* smem)\
     { _nvidia_potrs_impl_##N##x##NRHS##_bd##TC##_sm##ARCH::run(L, B, smem); }                    \
     template <>                                                                                  \
-    constexpr std::size_t potrs_smem_size<float, N, NRHS, TC, ARCH>()                           \
+    constexpr std::size_t potrs_scratch_bytes<float, N, NRHS, TC, ARCH>()                           \
     { return _nvidia_potrs_impl_##N##x##NRHS##_bd##TC##_sm##ARCH::smem_bytes; }                  \
     template <>                                                                                  \
     constexpr uint32_t potrs_threads<float, N, NRHS, TC, ARCH>()                                \
@@ -740,7 +740,7 @@ constexpr uint32_t potrs_threads() { return 256; }
  * @tparam BLOCK_THREADS Pinned cuSOLVERDx BlockDim (0 = vendor picks).
  * @tparam SM_VAL        Target SM architecture (default = SMS).
  * @param  A             Pointer to the N×N matrix; overwritten with the LU factors.
- * @param  smem          Shared scratch (>= getrf_no_pivot_smem_size<...>()).
+ * @param  smem          Shared scratch (>= getrf_no_pivot_scratch_bytes<...>()).
  */
 template <typename T, uint32_t N,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
@@ -756,7 +756,7 @@ __device__ void getrf_no_pivot(T* A, char* smem)
  * @tparam T scalar; @tparam N dim; @tparam BLOCK_THREADS pinned BlockDim; @tparam SM_VAL SM arch.
  */
 template <typename T, uint32_t N, uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t getrf_no_pivot_smem_size() { return 0; }
+constexpr std::size_t getrf_no_pivot_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `getrf_no_pivot<...>` (host-callable, constexpr).
@@ -796,7 +796,7 @@ constexpr uint32_t getrf_no_pivot_threads() { return 256; }
     __device__ inline void getrf_no_pivot<float, N, 0, ARCH>(float* A, char* smem)              \
     { _nvidia_getrf_impl_##N##_bd0_sm##ARCH::run(A, smem); }                                     \
     template <>                                                                                  \
-    constexpr std::size_t getrf_no_pivot_smem_size<float, N, 0, ARCH>()                         \
+    constexpr std::size_t getrf_no_pivot_scratch_bytes<float, N, 0, ARCH>()                         \
     { return _nvidia_getrf_impl_##N##_bd0_sm##ARCH::smem_bytes; }                                \
     template <>                                                                                  \
     constexpr uint32_t getrf_no_pivot_threads<float, N, 0, ARCH>()                              \
@@ -834,7 +834,7 @@ constexpr uint32_t getrf_no_pivot_threads() { return 256; }
     __device__ inline void getrf_no_pivot<float, N, TC, ARCH>(float* A, char* smem)             \
     { _nvidia_getrf_impl_##N##_bd##TC##_sm##ARCH::run(A, smem); }                                \
     template <>                                                                                  \
-    constexpr std::size_t getrf_no_pivot_smem_size<float, N, TC, ARCH>()                        \
+    constexpr std::size_t getrf_no_pivot_scratch_bytes<float, N, TC, ARCH>()                        \
     { return _nvidia_getrf_impl_##N##_bd##TC##_sm##ARCH::smem_bytes; }                           \
     template <>                                                                                  \
     constexpr uint32_t getrf_no_pivot_threads<float, N, TC, ARCH>()                             \
@@ -867,7 +867,7 @@ constexpr uint32_t getrf_no_pivot_threads() { return 256; }
  * @tparam SM_VAL        Target SM architecture (default = SMS).
  * @param  LU            Pointer to the N×N LU factor (read-only).
  * @param  B             Pointer to the N×NRHS right-hand sides; overwritten with X.
- * @param  smem          Shared scratch (>= getrs_no_pivot_smem_size<...>()).
+ * @param  smem          Shared scratch (>= getrs_no_pivot_scratch_bytes<...>()).
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
@@ -884,7 +884,7 @@ __device__ void getrs_no_pivot(const T* LU, T* B, char* smem)
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t getrs_no_pivot_smem_size() { return 0; }
+constexpr std::size_t getrs_no_pivot_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `getrs_no_pivot<...>` (host-callable, constexpr).
@@ -926,7 +926,7 @@ constexpr uint32_t getrs_no_pivot_threads() { return 256; }
     __device__ inline void getrs_no_pivot<float, N, NRHS, 0, ARCH>(const float* LU, float* B, char* smem) \
     { _nvidia_getrs_impl_##N##x##NRHS##_bd0_sm##ARCH::run(LU, B, smem); }                        \
     template <>                                                                                  \
-    constexpr std::size_t getrs_no_pivot_smem_size<float, N, NRHS, 0, ARCH>()                   \
+    constexpr std::size_t getrs_no_pivot_scratch_bytes<float, N, NRHS, 0, ARCH>()                   \
     { return _nvidia_getrs_impl_##N##x##NRHS##_bd0_sm##ARCH::smem_bytes; }                       \
     template <>                                                                                  \
     constexpr uint32_t getrs_no_pivot_threads<float, N, NRHS, 0, ARCH>()                        \
@@ -965,7 +965,7 @@ constexpr uint32_t getrs_no_pivot_threads() { return 256; }
     __device__ inline void getrs_no_pivot<float, N, NRHS, TC, ARCH>(const float* LU, float* B, char* smem) \
     { _nvidia_getrs_impl_##N##x##NRHS##_bd##TC##_sm##ARCH::run(LU, B, smem); }                   \
     template <>                                                                                  \
-    constexpr std::size_t getrs_no_pivot_smem_size<float, N, NRHS, TC, ARCH>()                  \
+    constexpr std::size_t getrs_no_pivot_scratch_bytes<float, N, NRHS, TC, ARCH>()                  \
     { return _nvidia_getrs_impl_##N##x##NRHS##_bd##TC##_sm##ARCH::smem_bytes; }                  \
     template <>                                                                                  \
     constexpr uint32_t getrs_no_pivot_threads<float, N, NRHS, TC, ARCH>()                       \
@@ -999,7 +999,7 @@ constexpr uint32_t getrs_no_pivot_threads() { return 256; }
  * @tparam TRAILING_SYNC Emit a trailing __syncthreads() before return (default true).
  * @param  A             Pointer to the N×N matrix; destroyed (holds LU on exit).
  * @param  B             Pointer to the N×NRHS right-hand sides; overwritten with X.
- * @param  smem          Shared scratch (>= gesv_no_pivot_smem_size<...>()).
+ * @param  smem          Shared scratch (>= gesv_no_pivot_scratch_bytes<...>()).
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS,
@@ -1017,7 +1017,7 @@ __device__ void gesv_no_pivot(T* A, T* B, char* smem)
  */
 template <typename T, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t gesv_no_pivot_smem_size() { return 0; }
+constexpr std::size_t gesv_no_pivot_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `gesv_no_pivot<...>` (host-callable, constexpr).
@@ -1067,7 +1067,7 @@ constexpr uint32_t gesv_no_pivot_threads() { return 256; }
     __device__ inline void gesv_no_pivot<float, N, NRHS, 0, ARCH, false>(float* A, float* B, char* smem) \
     { _nvidia_gesv_impl_##N##x##NRHS##_bd0_sm##ARCH::template run<false>(A, B, smem); }          \
     template <>                                                                                  \
-    constexpr std::size_t gesv_no_pivot_smem_size<float, N, NRHS, 0, ARCH>()                    \
+    constexpr std::size_t gesv_no_pivot_scratch_bytes<float, N, NRHS, 0, ARCH>()                    \
     { return _nvidia_gesv_impl_##N##x##NRHS##_bd0_sm##ARCH::smem_bytes; }                        \
     template <>                                                                                  \
     constexpr uint32_t gesv_no_pivot_threads<float, N, NRHS, 0, ARCH>()                         \
@@ -1114,7 +1114,7 @@ constexpr uint32_t gesv_no_pivot_threads() { return 256; }
     __device__ inline void gesv_no_pivot<float, N, NRHS, TC, ARCH, false>(float* A, float* B, char* smem) \
     { _nvidia_gesv_impl_##N##x##NRHS##_bd##TC##_sm##ARCH::template run<false>(A, B, smem); }     \
     template <>                                                                                  \
-    constexpr std::size_t gesv_no_pivot_smem_size<float, N, NRHS, TC, ARCH>()                   \
+    constexpr std::size_t gesv_no_pivot_scratch_bytes<float, N, NRHS, TC, ARCH>()                   \
     { return _nvidia_gesv_impl_##N##x##NRHS##_bd##TC##_sm##ARCH::smem_bytes; }                   \
     template <>                                                                                  \
     constexpr uint32_t gesv_no_pivot_threads<float, N, NRHS, TC, ARCH>()                        \
@@ -1150,7 +1150,7 @@ constexpr uint32_t gesv_no_pivot_threads() { return 256; }
  * @tparam SM_VAL        Target SM architecture (default = SMS).
  * @param  A             Pointer to the M×N matrix; overwritten with R + reflectors.
  * @param  tau           Caller-provided output array of min(M,N) scalars.
- * @param  smem          Shared scratch (>= geqrf_smem_size<...>()).
+ * @param  smem          Shared scratch (>= geqrf_scratch_bytes<...>()).
  */
 template <typename T, uint32_t M, uint32_t N,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
@@ -1167,7 +1167,7 @@ __device__ void geqrf(T* A, T* tau, char* smem)
  */
 template <typename T, uint32_t M, uint32_t N,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t geqrf_smem_size() { return 0; }
+constexpr std::size_t geqrf_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `geqrf<...>` (host-callable, constexpr).
@@ -1207,7 +1207,7 @@ constexpr uint32_t geqrf_threads() { return 256; }
     __device__ inline void geqrf<float, M, N, 0, ARCH>(float* A, float* tau, char* smem)        \
     { _nvidia_geqrf_impl_##M##x##N##_bd0_sm##ARCH::run(A, tau, smem); }                          \
     template <>                                                                                  \
-    constexpr std::size_t geqrf_smem_size<float, M, N, 0, ARCH>()                               \
+    constexpr std::size_t geqrf_scratch_bytes<float, M, N, 0, ARCH>()                               \
     { return _nvidia_geqrf_impl_##M##x##N##_bd0_sm##ARCH::smem_bytes; }                          \
     template <>                                                                                  \
     constexpr uint32_t geqrf_threads<float, M, N, 0, ARCH>()                                    \
@@ -1244,7 +1244,7 @@ constexpr uint32_t geqrf_threads() { return 256; }
     __device__ inline void geqrf<float, M, N, TC, ARCH>(float* A, float* tau, char* smem)       \
     { _nvidia_geqrf_impl_##M##x##N##_bd##TC##_sm##ARCH::run(A, tau, smem); }                     \
     template <>                                                                                  \
-    constexpr std::size_t geqrf_smem_size<float, M, N, TC, ARCH>()                              \
+    constexpr std::size_t geqrf_scratch_bytes<float, M, N, TC, ARCH>()                              \
     { return _nvidia_geqrf_impl_##M##x##N##_bd##TC##_sm##ARCH::smem_bytes; }                     \
     template <>                                                                                  \
     constexpr uint32_t geqrf_threads<float, M, N, TC, ARCH>()                                   \
@@ -1283,7 +1283,7 @@ constexpr uint32_t geqrf_threads() { return 256; }
  * @param  A             Pointer to the M×N matrix; destroyed during the solve.
  * @param  tau           Caller-provided workspace of min(M,N) scalars.
  * @param  B             Right-hand sides (max(M,N)×NRHS storage); overwritten with X.
- * @param  smem          Shared scratch (>= gels_smem_size<...>()).
+ * @param  smem          Shared scratch (>= gels_scratch_bytes<...>()).
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS,
@@ -1301,7 +1301,7 @@ __device__ void gels(T* A, T* tau, T* B, char* smem)
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t NRHS,
           uint32_t BLOCK_THREADS = 0, uint32_t SM_VAL = SMS>
-constexpr std::size_t gels_smem_size() { return 0; }
+constexpr std::size_t gels_scratch_bytes() { return 0; }
 
 /**
  * @brief Thread count cuSOLVERDx wants for `gels<...>` (host-callable, constexpr).
@@ -1352,7 +1352,7 @@ constexpr uint32_t gels_threads() { return 256; }
     __device__ inline void gels<float, M, N, NRHS, 0, ARCH, false>(float* A, float* tau, float* B, char* smem) \
     { _nvidia_gels_impl_##M##x##N##x##NRHS##_bd0_sm##ARCH::template run<false>(A, tau, B, smem); }\
     template <>                                                                                  \
-    constexpr std::size_t gels_smem_size<float, M, N, NRHS, 0, ARCH>()                          \
+    constexpr std::size_t gels_scratch_bytes<float, M, N, NRHS, 0, ARCH>()                          \
     { return _nvidia_gels_impl_##M##x##N##x##NRHS##_bd0_sm##ARCH::smem_bytes; }                  \
     template <>                                                                                  \
     constexpr uint32_t gels_threads<float, M, N, NRHS, 0, ARCH>()                               \
@@ -1398,7 +1398,7 @@ constexpr uint32_t gels_threads() { return 256; }
     __device__ inline void gels<float, M, N, NRHS, TC, ARCH, false>(float* A, float* tau, float* B, char* smem) \
     { _nvidia_gels_impl_##M##x##N##x##NRHS##_bd##TC##_sm##ARCH::template run<false>(A, tau, B, smem); }\
     template <>                                                                                  \
-    constexpr std::size_t gels_smem_size<float, M, N, NRHS, TC, ARCH>()                         \
+    constexpr std::size_t gels_scratch_bytes<float, M, N, NRHS, TC, ARCH>()                         \
     { return _nvidia_gels_impl_##M##x##N##x##NRHS##_bd##TC##_sm##ARCH::smem_bytes; }             \
     template <>                                                                                  \
     constexpr uint32_t gels_threads<float, M, N, NRHS, TC, ARCH>()                              \

--- a/src/nvidia/query_simt.cuh
+++ b/src/nvidia/query_simt.cuh
@@ -120,8 +120,8 @@ constexpr bool gemm_batched_1d_block_threads_valid()
 //
 // These mirror should_use_cublasdx<> for the round-2 APIs:
 //   * gemv<>             (Gap A)  → cublasdx_wins_gemv
-//   * row_strided_gemv<> (Gap B)  → cublasdx_wins_row_strided_gemv
-//   * row_strided_gemm<> (Gap C)  → cublasdx_wins_row_strided_gemm
+//   * gemv_strided<> (Gap B)  → cublasdx_wins_gemv_strided
+//   * gemm_strided<> (Gap C)  → cublasdx_wins_gemm_strided
 //   * gemm_batched_1d    (NEW-1)  → cublasdx_wins_batched
 //
 // Each routes through a per-API primary template in tuning_table.cuh
@@ -149,7 +149,7 @@ constexpr bool should_use_cublasdx_gemv() {
 }
 
 /**
- * @brief Compile-time backend decision for `row_strided_gemv` (host-callable).
+ * @brief Compile-time backend decision for `gemv_strided` (host-callable).
  *
  * Sibling of should_use_cublasdx<> for the strided-GEMV API. Only T==float is
  * tuned; other types return false. constexpr.
@@ -163,13 +163,13 @@ constexpr bool should_use_cublasdx_gemv() {
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE,
           uint32_t SM_VAL = SMS>
-constexpr bool should_use_cublasdx_row_strided_gemv() {
+constexpr bool should_use_cublasdx_gemv_strided() {
     if constexpr (!std::is_same<T, float>::value) return false;
-    else return _glass_tuning::cublasdx_wins_row_strided_gemv<M, N, ROW_STRIDE, SM_VAL>();
+    else return _glass_tuning::cublasdx_wins_gemv_strided<M, N, ROW_STRIDE, SM_VAL>();
 }
 
 /**
- * @brief Compile-time backend decision for `row_strided_gemm` (host-callable).
+ * @brief Compile-time backend decision for `gemm_strided` (host-callable).
  *
  * Sibling of should_use_cublasdx<> for the strided-GEMM API. Only T==float is
  * tuned; other types return false. constexpr.
@@ -185,9 +185,9 @@ constexpr bool should_use_cublasdx_row_strided_gemv() {
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
           uint32_t A_RS, uint32_t B_RS, uint32_t SM_VAL = SMS>
-constexpr bool should_use_cublasdx_row_strided_gemm() {
+constexpr bool should_use_cublasdx_gemm_strided() {
     if constexpr (!std::is_same<T, float>::value) return false;
-    else return _glass_tuning::cublasdx_wins_row_strided_gemm<M, N, K, A_RS, B_RS, SM_VAL>();
+    else return _glass_tuning::cublasdx_wins_gemm_strided<M, N, K, A_RS, B_RS, SM_VAL>();
 }
 
 /**
@@ -237,7 +237,7 @@ __host__ __device__ inline void print_dispatch_gemv() {
 }
 
 /**
- * @brief Print which backend `row_strided_gemm<...>` dispatches to (host/device).
+ * @brief Print which backend `gemm_strided<...>` dispatches to (host/device).
  *
  * Diagnostic sibling of print_dispatch<> for the strided-GEMM API.
  *
@@ -251,16 +251,16 @@ __host__ __device__ inline void print_dispatch_gemv() {
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t K,
           uint32_t A_RS = M, uint32_t B_RS = N, uint32_t SM_VAL = SMS>
-__host__ __device__ inline void print_dispatch_row_strided_gemm() {
-    printf("glass::nvidia::row_strided_gemm<T,%u,%u,%u,A_RS=%u,B_RS=%u,SM=%u>: %s\n",
+__host__ __device__ inline void print_dispatch_gemm_strided() {
+    printf("glass::nvidia::gemm_strided<T,%u,%u,%u,A_RS=%u,B_RS=%u,SM=%u>: %s\n",
            M, N, K, A_RS, B_RS, SM_VAL,
-           should_use_cublasdx_row_strided_gemm<T, M, N, K, A_RS, B_RS, SM_VAL>()
+           should_use_cublasdx_gemm_strided<T, M, N, K, A_RS, B_RS, SM_VAL>()
                ? "cuBLASDx (needs DEFINE_NVIDIA_GEMM*)"
                : "SIMT fallback");
 }
 
 /**
- * @brief Print which backend `row_strided_gemv<...>` dispatches to (host/device).
+ * @brief Print which backend `gemv_strided<...>` dispatches to (host/device).
  *
  * Diagnostic sibling of print_dispatch<> for the strided-GEMV API.
  *
@@ -272,10 +272,10 @@ __host__ __device__ inline void print_dispatch_row_strided_gemm() {
  */
 template <typename T, uint32_t M, uint32_t N, uint32_t ROW_STRIDE = M,
           uint32_t SM_VAL = SMS>
-__host__ __device__ inline void print_dispatch_row_strided_gemv() {
-    printf("glass::nvidia::row_strided_gemv<T,%u,%u,RS=%u,SM=%u>: %s\n",
+__host__ __device__ inline void print_dispatch_gemv_strided() {
+    printf("glass::nvidia::gemv_strided<T,%u,%u,RS=%u,SM=%u>: %s\n",
            M, N, ROW_STRIDE, SM_VAL,
-           should_use_cublasdx_row_strided_gemv<T, M, N, ROW_STRIDE, SM_VAL>()
+           should_use_cublasdx_gemv_strided<T, M, N, ROW_STRIDE, SM_VAL>()
                ? "cuBLASDx (needs DEFINE_NVIDIA_GEMV*)"
                : "SIMT fallback");
 }

--- a/src/nvidia/sizes.cuh
+++ b/src/nvidia/sizes.cuh
@@ -12,7 +12,7 @@
 // Sizes below match the benchmark suite. To add a new size:
 //   1. Call DEFINE_NVIDIA_GEMM(M, N, K) or DEFINE_NVIDIA_GEMV(M, N) in your .cu file.
 //   2. Launch with the thread count and smem from GEMM::block_dim and
-//      glass::nvidia::gemm_smem_size<T,M,N,K>().
+//      glass::nvidia::gemm_scratch_bytes<T,M,N,K>().
 //
 // All functions are __device__-only and require compile-time sizes.
 

--- a/src/nvidia/tuning_table.cuh
+++ b/src/nvidia/tuning_table.cuh
@@ -74,12 +74,12 @@ constexpr bool cublasdx_wins_batched() {
 // strided cases skew differently.
 template <uint32_t M, uint32_t N, uint32_t K,
           uint32_t A_RS, uint32_t B_RS, uint32_t SM_VAL>
-constexpr bool cublasdx_wins_row_strided_gemm() {
+constexpr bool cublasdx_wins_gemm_strided() {
     return cublasdx_wins<M, N, K, SM_VAL>();
 }
 
 template <uint32_t M, uint32_t N, uint32_t ROW_STRIDE, uint32_t SM_VAL>
-constexpr bool cublasdx_wins_row_strided_gemv() {
+constexpr bool cublasdx_wins_gemv_strided() {
     return cublasdx_wins_gemv<M, N, SM_VAL>();
 }
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -40,6 +40,104 @@ def detect_arch() -> str:
 CUDA_ARCH = detect_arch()
 
 
+# ─── thread-count sweeps (single source of truth) ─────────────────────────────
+#
+# GLASS's #1 invariant is thread-count invariance: every single-block op must
+# produce BIT-IDENTICAL output at any block size. The bugs this catches hide at
+# the counts most tests historically used (a full warp / 256), so the canonical
+# sweep deliberately spans four regimes:
+#
+#   • 1            — single thread (serializes every grid-stride loop; exposes
+#                    "loop wrote to the wrong place because size==1" bugs).
+#   • 7            — low partial warp, ODD (fewer threads than most problem dims;
+#                    exposes missing tail handling).
+#   • 31           — one BELOW a warp boundary, odd (off-by-one at the warp edge).
+#   • 32, 64       — exact warp boundaries. NOTE: races between same-value writers
+#                    are INVISIBLE here (a warp runs lockstep) — these are the
+#                    counts that let the inv.cuh `ind++` race pass for months.
+#                    Kept so a real *value* divergence at the boundary still shows.
+#   • 33, 57       — just ABOVE a warp / mid, both ODD and NON-warp-boundary
+#                    (partial trailing warp + a full warp; the load-bearing cases).
+#   • 96, 128, 256 — multi-warp (3,4,8 warps); exercises cross-warp reductions.
+#
+# Use THREAD_SWEEP for an op's dedicated thread-invariance test (one representative
+# input). For tests that already fan out over a large parameter matrix, use
+# THREAD_SWEEP_CORE — a cheap 4-count subset that still includes a low partial (7),
+# an odd non-boundary count (33), and a multi-warp count (256). Runtime cost of a
+# binary invocation is ~ms; the only real cost is the one-time nvcc recompile, so
+# prefer the full sweep wherever a single input suffices.
+THREAD_SWEEP      = [1, 7, 31, 32, 33, 57, 64, 96, 128, 256]
+THREAD_SWEEP_CORE = [1, 7, 33, 256]
+
+
+# ─── input variety (single source of truth) ───────────────────────────────────
+#
+# A correctness test that only ever sees one well-conditioned random matrix can
+# miss sign-handling, conditioning, and pivot bugs. These makers give every test
+# the same vocabulary of "kinds of input". All return float32, seedable so a
+# failure reproduces. Pass distinct `seed`s to vary the draw within a sweep.
+
+def make_spd(n, seed=0, cond=None, rng=None):
+    """Random n x n symmetric positive-definite matrix (float32).
+
+    cond=None: well-conditioned (A Aᵀ + n·I). Pass a float `cond` to force an
+    approximate 2-norm condition number (eigenvalues geometrically spaced in
+    [1, cond]) for ill-conditioned / near-singular factorization tests.
+
+    Pass an existing `rng` (np.random.Generator) to draw from a caller-owned
+    stream — lets a test module advance one RNG across calls for varied draws;
+    otherwise a fresh `default_rng(seed)` is used (deterministic per seed)."""
+    import numpy as np
+    if rng is None:
+        rng = np.random.default_rng(seed)
+    if cond is None:
+        A = rng.standard_normal((n, n)).astype(np.float32)
+        return (A @ A.T + n * np.eye(n, dtype=np.float32)).astype(np.float32)
+    # Q Λ Qᵀ with a controlled spectrum.
+    Q, _ = np.linalg.qr(rng.standard_normal((n, n)))
+    eig = np.geomspace(1.0, float(cond), n)
+    return (Q @ np.diag(eig) @ Q.T).astype(np.float32)
+
+
+def make_general(m, n=None, seed=0, scale=1.0, rng=None):
+    """Random m x n general matrix (float32), mean-zero so signs are mixed.
+
+    Pass an existing `rng` to draw from a caller-owned stream (see make_spd)."""
+    import numpy as np
+    n = m if n is None else n
+    if rng is None:
+        rng = np.random.default_rng(seed)
+    return (scale * rng.standard_normal((m, n))).astype(np.float32)
+
+
+def make_lower_triangular(n, seed=0, rng=None):
+    """Random n x n lower-triangular matrix with a positive diagonal (float32).
+
+    Pass an existing `rng` to draw from a caller-owned stream (see make_spd)."""
+    import numpy as np
+    if rng is None:
+        rng = np.random.default_rng(seed)
+    L = np.tril(rng.standard_normal((n, n)).astype(np.float32))
+    np.fill_diagonal(L, np.abs(L.diagonal()) + 0.5)
+    return L.astype(np.float32)
+
+
+def make_vec(n, seed=0, kind="normal"):
+    """Random length-n vector (float32). kind: 'normal' (mixed sign), 'pos'
+    (strictly positive), 'mixed' (alternating large/small magnitudes to stress
+    reductions and 1-norms)."""
+    import numpy as np
+    rng = np.random.default_rng(seed)
+    if kind == "pos":
+        return (np.abs(rng.standard_normal(n)) + 0.1).astype(np.float32)
+    if kind == "mixed":
+        v = rng.standard_normal(n).astype(np.float32)
+        v[::2] *= 1e3
+        v[1::2] *= 1e-3
+        return v
+    return rng.standard_normal(n).astype(np.float32)
+
+
 # ─── source hashing ───────────────────────────────────────────────────────────
 
 def _hash_sources(cu_path: pathlib.Path) -> str:
@@ -57,12 +155,20 @@ def _hash_sources(cu_path: pathlib.Path) -> str:
               GLASS_DIR / "src" / "base" / "L1" / "axpy.cuh",
               GLASS_DIR / "src" / "base" / "L1" / "copy.cuh",
               GLASS_DIR / "src" / "base" / "L1" / "scal.cuh",
+              GLASS_DIR / "src" / "base" / "L1" / "asum.cuh",
+              GLASS_DIR / "src" / "base" / "L1" / "nrm2.cuh",
+              GLASS_DIR / "src" / "base" / "L1" / "nrm1_diff.cuh",
+              GLASS_DIR / "src" / "base" / "L1" / "axpy_strided.cuh",
+              GLASS_DIR / "src" / "base" / "L1" / "copy_strided.cuh",
+              GLASS_DIR / "test" / "cuda" / "test_l1_round2.cu",
               GLASS_DIR / "src" / "base" / "L2" / "gemv.cuh",
+              GLASS_DIR / "src" / "base" / "L2" / "gemv_strided.cuh",
               GLASS_DIR / "src" / "base" / "L2" / "gemv_reduced.cuh",
               GLASS_DIR / "src" / "base" / "L3" / "syrk_reduced.cuh",
               GLASS_DIR / "test" / "cuda" / "test_reduced_blas.cu",
               GLASS_DIR / "test" / "cuda" / "test_warp.cu",
               GLASS_DIR / "src" / "base" / "L3" / "gemm.cuh",
+              GLASS_DIR / "src" / "base" / "L3" / "gemm_strided.cuh",
               GLASS_DIR / "src" / "base" / "L3" / "gemm_reduced.cuh",
               GLASS_DIR / "test" / "cuda" / "test_reduced.cu",
               GLASS_DIR / "src" / "base" / "L3" / "tensor_contract.cuh",
@@ -88,6 +194,8 @@ def _hash_sources(cu_path: pathlib.Path) -> str:
               GLASS_DIR / "test" / "cuda" / "test_solve.cu",
               GLASS_DIR / "src" / "base" / "L3" / "gemm_batched_indexed.cuh",
               GLASS_DIR / "src" / "base" / "banded" / "bdmv.cuh",
+              GLASS_DIR / "src" / "base" / "banded" / "block_access.cuh",
+              GLASS_DIR / "test" / "cuda" / "test_block_access.cu",
               GLASS_DIR / "src" / "base" / "pcg" / "solve.cuh",
               GLASS_DIR / "glass-defaults.cuh",
               GLASS_DIR / "glass-nvidia.cuh",
@@ -167,6 +275,8 @@ def bins(tmp_path_factory):
         "reduced_blas": compile_binary("test_reduced_blas", build_dir, CUDA_ARCH),
         "base_f64": compile_binary("test_base_f64", build_dir, CUDA_ARCH),
         "defaults": compile_binary("test_defaults", build_dir, CUDA_ARCH),
+        "l1_round2": compile_binary("test_l1_round2", build_dir, CUDA_ARCH),
+        "block_access": compile_binary("test_block_access", build_dir, CUDA_ARCH),
     }
     # test_l3_nvidia.cu includes glass-nvidia.cuh and exercises the SIMT-only
     # batched APIs (gemm_batched_1d, gemm_strided_batched_1d). It does NOT

--- a/test/cuda/test_block_access.cu
+++ b/test/cuda/test_block_access.cu
@@ -1,0 +1,70 @@
+// test_block_access.cu — dense d×d block ↔ [L|D|R] strip movers
+// (glass::store_block / load_block, block + warp).
+//
+//   store <threads> <d> <slot> <transpose> <scale> <src.bin>   (src = dense d*d)
+//         → prints the full strip (d * 3d, row-major), pre-zeroed.
+//   load  <threads> <d> <slot> <transpose> <scale> <strip.bin> (strip = d*3d)
+//         → prints the dense d*d block.
+//   _warp variants run on one 32-lane warp.
+// d ∈ {3,6,7}; slot 0=LEFT 1=MAIN 2=RIGHT; transpose 0/1.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+
+#include "helpers.cuh"
+#include "../../glass.cuh"
+
+template <uint32_t d, bool TRANSPOSE, bool WARP, bool LOAD>
+__global__ void k_blk(uint32_t slot_i, float scale, const float* in, float* out) {
+    glass::BandSlot slot = static_cast<glass::BandSlot>(slot_i);
+    if constexpr (LOAD) {
+        if constexpr (WARP) glass::warp::load_block<float, d, 3 * d, TRANSPOSE>(out, in, slot, scale);
+        else                glass::load_block<float, d, 3 * d, TRANSPOSE>(out, in, slot, scale);
+    } else {
+        if constexpr (WARP) glass::warp::store_block<float, d, 3 * d, TRANSPOSE>(out, slot, in, scale);
+        else                glass::store_block<float, d, 3 * d, TRANSPOSE>(out, slot, in, scale);
+    }
+}
+
+template <uint32_t d>
+int run_d(int THREADS, int slot, bool tr, bool warp, bool load, float scale,
+          const float* in, float* out, int out_n) {
+#define K(TR, WP, LD) k_blk<d, TR, WP, LD><<<1, THREADS>>>(slot, scale, in, out)
+    if (load) {
+        if (warp) { tr ? K(true, true, true)   : K(false, true, true); }
+        else      { tr ? K(true, false, true)  : K(false, false, true); }
+    } else {
+        if (warp) { tr ? K(true, true, false)  : K(false, true, false); }
+        else      { tr ? K(true, false, false) : K(false, false, false); }
+    }
+#undef K
+    cudaDeviceSynchronize();
+    print_device_vec(out, out_n);
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 8) { fprintf(stderr, "usage: %s <store|load[_warp]> <threads> <d> <slot> <transpose> <scale> <in.bin>\n", argv[0]); return 1; }
+    const char* op = argv[1];
+    int THREADS = atoi(argv[2]);
+    int d       = atoi(argv[3]);
+    int slot    = atoi(argv[4]);
+    bool tr     = atoi(argv[5]) != 0;
+    float scale = (float)atof(argv[6]);
+    bool warp   = (strstr(op, "_warp") != nullptr);
+    bool load   = (strncmp(op, "load", 4) == 0);
+
+    int dd = d * d, strip = d * 3 * d;
+    int in_n  = load ? strip : dd;
+    int out_n = load ? dd    : strip;
+    float* d_in = read_device_vec(argv[7], in_n);
+    float* d_out = alloc_device_vec(out_n);   // zeroed: store leaves non-slot strip cols at 0
+
+    if      (d == 3) return run_d<3>(THREADS, slot, tr, warp, load, scale, d_in, d_out, out_n);
+    else if (d == 6) return run_d<6>(THREADS, slot, tr, warp, load, scale, d_in, d_out, out_n);
+    else if (d == 7) return run_d<7>(THREADS, slot, tr, warp, load, scale, d_in, d_out, out_n);
+    fprintf(stderr, "unsupported d=%d (use 3,6,7)\n", d);
+    return 1;
+}

--- a/test/cuda/test_congruence.cu
+++ b/test/cuda/test_congruence.cu
@@ -46,6 +46,25 @@ static void launch_cong(int surf, int th, bool acc, float al, const float* dX, c
     }
 }
 
+template <int SURF, uint32_t P, uint32_t Q, bool ACC>
+__global__ void k_cacc(float alpha, const float* G, const float* M, float beta, float* C) {
+    extern __shared__ float st[];
+    if (SURF == SURF_WARP) glass::warp::congruence_accum<float, P, Q, ACC>(alpha, G, M, beta, C, st);
+    else                   glass::congruence_accum<float, P, Q, ACC>(alpha, G, M, beta, C, st);
+}
+
+template <uint32_t P, uint32_t Q>
+static void launch_cacc(int surf, int th, bool acc, float al, const float* dG, const float* dM, float be, float* dC) {
+    int sm = glass::congruence_accum_smem_count<float,P,Q>() * sizeof(float);
+    if (acc) {
+        if (surf==SURF_WARP) k_cacc<SURF_WARP,P,Q,true><<<1,th,sm>>>(al,dG,dM,be,dC);
+        else                 k_cacc<SURF_BLOCK,P,Q,true><<<1,th,sm>>>(al,dG,dM,be,dC);
+    } else {
+        if (surf==SURF_WARP) k_cacc<SURF_WARP,P,Q,false><<<1,th,sm>>>(al,dG,dM,be,dC);
+        else                 k_cacc<SURF_BLOCK,P,Q,false><<<1,th,sm>>>(al,dG,dM,be,dC);
+    }
+}
+
 template <uint32_t N, uint32_t P, uint32_t Qd>
 static void launch_bil(int surf, int th, bool acc, float al, const float* dX, const float* dM, const float* dY, float be, float* dR) {
     int sm = N * Qd * sizeof(float);
@@ -62,6 +81,8 @@ static void launch_bil(int surf, int th, bool acc, float al, const float* dX, co
 
 #define CONG_SHAPES(_) _(14,21) _(8,8) _(5,3) _(7,14) _(33,5) _(64,3) _(14,14) _(3,4)
 #define BIL_SHAPES(_)  _(14,7,21) _(8,5,3) _(5,5,5) _(33,4,6) _(7,14,7)
+// congruence_accum: G is P×Q, M is Q×Q, C is P×P (GATO B·R⁻¹·Bᵀ shapes).
+#define CACC_SHAPES(_) _(5,3) _(14,7) _(7,7) _(8,4) _(6,5) _(3,3)
 
 int main(int argc, char** argv) {
     if (argc < 2) { fprintf(stderr, "need op\n"); return 1; }
@@ -98,6 +119,20 @@ int main(int argc, char** argv) {
         cudaError_t e=cudaDeviceSynchronize();
         if(e!=cudaSuccess){fprintf(stderr,"err %s\n",cudaGetErrorString(e));return 1;}
         print_device_vec(dR, P*Qd);
+    } else if (strcmp(op,"cacc")==0) {
+        uint32_t P=atoi(argv[4]), Q=atoi(argv[5]); bool acc=atoi(argv[6])!=0;
+        float al=atof(argv[7]), be=atof(argv[8]);
+        float* dG=read_device_vec(argv[9], P*Q);
+        float* dM=read_device_vec(argv[10], Q*Q);
+        float* dC=read_device_vec(argv[11], P*P);
+        bool ok=false;
+        #define DA(PP,QQ) if(!ok&&P==PP&&Q==QQ){launch_cacc<PP,QQ>(surf,th,acc,al,dG,dM,be,dC);ok=true;}
+        CACC_SHAPES(DA)
+        #undef DA
+        if(!ok){fprintf(stderr,"bad cacc shape\n");return 1;}
+        cudaError_t e=cudaDeviceSynchronize();
+        if(e!=cudaSuccess){fprintf(stderr,"err %s\n",cudaGetErrorString(e));return 1;}
+        print_device_vec(dC, P*P);
     } else { fprintf(stderr,"bad op\n"); return 1; }
     return 0;
 }

--- a/test/cuda/test_l1.cu
+++ b/test/cuda/test_l1.cu
@@ -84,10 +84,10 @@ __global__ void k_reduce_partial_hs(int n, float* x, float* out, float* scratch)
     out[0] = total;   // broadcast check: every thread holds the same `total`
 }
 
-__global__ void k_l2norm_cg(int n, float* x) { glass::cgrps::l2norm(n, x); }
-__global__ void k_l2norm_simple_lm(int n, float* x) { glass::low_memory::l2norm(n, x); }
-__global__ void k_l2norm_simple_hs(int n, float* x, float* scratch) {
-    glass::high_speed::l2norm(n, x, scratch);
+__global__ void k_nrm2_cg(int n, float* x) { glass::cgrps::nrm2(n, x); }
+__global__ void k_nrm2_simple_lm(int n, float* x) { glass::low_memory::nrm2(n, x); }
+__global__ void k_nrm2_simple_hs(int n, float* x, float* scratch) {
+    glass::high_speed::nrm2(n, x, scratch);
 }
 
 __global__ void k_infnorm_cg(int n, float* x) { glass::cgrps::infnorm(n, x); }
@@ -339,14 +339,14 @@ int main(int argc, char** argv) {
         cudaDeviceSynchronize();
         print_device_vec(dout, 1);
 
-    } else if (strcmp(op, "l2norm") == 0) {
+    } else if (strcmp(op, "nrm2") == 0) {
         float* dx = read_device_vec(argv[4], n);
         if (is_cg(ver)) {
-            k_l2norm_cg<<<1, THREADS>>>(n, dx);
+            k_nrm2_cg<<<1, THREADS>>>(n, dx);
         } else if (is_lm(ver)) {
-            k_l2norm_simple_lm<<<1, THREADS>>>(n, dx);
+            k_nrm2_simple_lm<<<1, THREADS>>>(n, dx);
         } else {
-            k_l2norm_simple_hs<<<1, THREADS>>>(n, dx, d_scratch);
+            k_nrm2_simple_hs<<<1, THREADS>>>(n, dx, d_scratch);
         }
         cudaDeviceSynchronize();
         print_device_vec(dx, 1);

--- a/test/cuda/test_l1_round2.cu
+++ b/test/cuda/test_l1_round2.cu
@@ -1,0 +1,112 @@
+// test_l1_round2.cu — round-2 L1 ops: nrm1_diff (‖x−y‖₁), warp norms (asum/nrm2),
+// and the row-strided AXPY/COPY block movers. All take a runtime <threads> arg so
+// the Python side can sweep block sizes (incl. partial/odd/non-warp-boundary).
+//
+// Scalar-reduction ops print the single result on one line.
+// Strided ops print the FULL Y buffer (Y_RS*N elements, column-major) on one line.
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cstdint>
+
+#include "helpers.cuh"
+#include "../../glass.cuh"
+
+// ─── nrm1_diff ────────────────────────────────────────────────────────────────
+__global__ void k_nrm1_lm(uint32_t n, const float* x, const float* y, float* out) {
+    glass::low_memory::nrm1_diff<float>(n, x, y, out);            // result in out[0]
+}
+__global__ void k_nrm1_hs(uint32_t n, const float* x, const float* y, float* out, float* scr) {
+    glass::high_speed::nrm1_diff<float>(n, x, y, out, scr);        // result in out[0]
+}
+__global__ void k_nrm1_warp(uint32_t n, const float* x, const float* y, float* out) {
+    float r = glass::warp::nrm1_diff<float>(n, x, y);
+    if (((threadIdx.x) & 31) == 0) out[0] = r;                     // every lane has r; lane 0 writes
+}
+
+// ─── warp norms ───────────────────────────────────────────────────────────────
+__global__ void k_warp_asum(uint32_t n, const float* x, float* out) {
+    float r = glass::warp::asum<float>(n, x);
+    if (((threadIdx.x) & 31) == 0) out[0] = r;
+}
+__global__ void k_warp_nrm2(uint32_t n, const float* x, float* out) {
+    float r = glass::warp::nrm2<float>(n, x);
+    if (((threadIdx.x) & 31) == 0) out[0] = r;
+}
+
+// ─── row-strided AXPY / COPY (compile-time shapes) ────────────────────────────
+template <uint32_t M, uint32_t N, uint32_t YRS, uint32_t XRS, bool WARP, bool COPY>
+__global__ void k_rs(float alpha, const float* X, float* Y) {
+    if constexpr (WARP) {
+        if constexpr (COPY) glass::warp::copy_strided<float, M, N, YRS, XRS>(alpha, X, Y);
+        else                glass::warp::axpy_strided<float, M, N, YRS, XRS>(alpha, X, Y);
+    } else {
+        if constexpr (COPY) glass::copy_strided<float, M, N, YRS, XRS>(alpha, X, Y);
+        else                glass::axpy_strided<float, M, N, YRS, XRS>(alpha, X, Y);
+    }
+}
+
+// Shape table (id : M, N, Y_RS, X_RS). id 0 = PDDP acceptance (14×14 into 21-lead).
+#define DISPATCH_SHAPE(id, WARP, COPY, alpha, dX, dY)                                  \
+    do {                                                                               \
+        if      (id == 0) k_rs<14,14,21,14,WARP,COPY><<<1,THREADS>>>(alpha,dX,dY);      \
+        else if (id == 1) k_rs< 6, 5, 8, 6,WARP,COPY><<<1,THREADS>>>(alpha,dX,dY);      \
+        else if (id == 2) k_rs< 4, 4, 4, 4,WARP,COPY><<<1,THREADS>>>(alpha,dX,dY);      \
+        else { fprintf(stderr, "bad shape id %d\n", id); return 1; }                    \
+    } while (0)
+
+static void shape_dims(int id, int* M, int* N, int* YRS, int* XRS) {
+    if (id == 0) { *M=14; *N=14; *YRS=21; *XRS=14; }
+    else if (id == 1) { *M=6; *N=5; *YRS=8; *XRS=6; }
+    else { *M=4; *N=4; *YRS=4; *XRS=4; }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s <op> <threads> ...\n", argv[0]); return 1; }
+    const char* op = argv[1];
+    int THREADS = atoi(argv[2]);
+
+    // Scalar reductions: <op> <threads> <n> <x.bin> [<y.bin>]
+    if (strncmp(op, "nrm1_", 5) == 0 || strncmp(op, "warp_", 5) == 0) {
+        int n = atoi(argv[3]);
+        bool needs_y = (strncmp(op, "nrm1_", 5) == 0);
+        float* dx = read_device_vec(argv[4], n);
+        float* dy = needs_y ? read_device_vec(argv[5], n) : nullptr;
+        float* out = alloc_device_vec(n);  // low_memory needs n; others use out[0]
+        if      (strcmp(op, "nrm1_lm")   == 0) k_nrm1_lm<<<1,THREADS>>>(n, dx, dy, out);
+        else if (strcmp(op, "nrm1_hs")   == 0) {
+            float* scr; cudaMalloc(&scr, ((THREADS+31)/32)*sizeof(float));
+            k_nrm1_hs<<<1,THREADS>>>(n, dx, dy, out, scr);
+        }
+        else if (strcmp(op, "nrm1_warp") == 0) k_nrm1_warp<<<1,THREADS>>>(n, dx, dy, out);
+        else if (strcmp(op, "warp_asum") == 0) k_warp_asum<<<1,THREADS>>>(n, dx, out);
+        else if (strcmp(op, "warp_nrm2")==0) k_warp_nrm2<<<1,THREADS>>>(n, dx, out);
+        else { fprintf(stderr, "bad op %s\n", op); return 1; }
+        cudaDeviceSynchronize();
+        print_device_vec(out, 1);
+        return 0;
+    }
+
+    // Strided movers: <op> <threads> <shape_id> <alpha> <X.bin> <Y.bin>
+    // op ∈ {rsaxpy, rscopy, rsaxpy_warp, rscopy_warp}. Prints full Y (Y_RS*N).
+    if (strncmp(op, "rs", 2) == 0) {
+        int id = atoi(argv[3]);
+        float alpha = (float)atof(argv[4]);
+        int M,N,YRS,XRS; shape_dims(id, &M, &N, &YRS, &XRS);
+        float* dX = read_device_vec(argv[5], XRS * N);
+        float* dY = read_device_vec(argv[6], YRS * N);
+        bool warp = (strstr(op, "_warp") != nullptr);
+        bool copy = (strncmp(op, "rscopy", 6) == 0);
+        if      (!warp && !copy) DISPATCH_SHAPE(id, false, false, alpha, dX, dY);
+        else if (!warp &&  copy) DISPATCH_SHAPE(id, false, true,  alpha, dX, dY);
+        else if ( warp && !copy) DISPATCH_SHAPE(id, true,  false, alpha, dX, dY);
+        else                     DISPATCH_SHAPE(id, true,  true,  alpha, dX, dY);
+        cudaDeviceSynchronize();
+        print_device_vec(dY, YRS * N);
+        return 0;
+    }
+
+    fprintf(stderr, "bad op %s\n", op);
+    return 1;
+}

--- a/test/cuda/test_l2.cu
+++ b/test/cuda/test_l2.cu
@@ -43,45 +43,42 @@ __global__ void k_gemv_t_simple(int m, int n, float alpha, float* A, float* x, f
 __global__ void k_gemv_rowmajor(int m, int n, float alpha, float* A, float* x, float beta, float* y) {
     glass::gemv<float, false, true>(m, n, alpha, A, x, beta, y);
 }
-__global__ void k_gemv_ex_rowA(int m, int n, float alpha, float* A, float* x, float beta, float* y) {
-    glass::gemv_ex<float, false, true>(m, n, alpha, A, x, beta, y);
-}
 
-// ─── row_strided_gemv kernels (compile-time M, N, ROW_STRIDE) ────────────────
+// ─── gemv_strided kernels (compile-time M, N, ROW_STRIDE) ────────────────
 // A has M*ROW_STRIDE elements; A[i][j] = A[i + j*ROW_STRIDE] (col-major, LDA=ROW_STRIDE)
 __global__ void k_gemv_strided_6x6_6(float alpha, float* A, float* x, float beta, float* y) {
-    glass::row_strided_gemv<float, 6, 6, 6>(A, x, y, alpha, beta);
+    glass::gemv_strided<float, 6, 6, 6>(alpha, A, x, beta, y);
 }
 __global__ void k_gemv_strided_6x6_8(float alpha, float* A, float* x, float beta, float* y) {
-    glass::row_strided_gemv<float, 6, 6, 8>(A, x, y, alpha, beta);
+    glass::gemv_strided<float, 6, 6, 8>(alpha, A, x, beta, y);
 }
 __global__ void k_gemv_strided_4x4_4(float alpha, float* A, float* x, float beta, float* y) {
-    glass::row_strided_gemv<float, 4, 4, 4>(A, x, y, alpha, beta);
+    glass::gemv_strided<float, 4, 4, 4>(alpha, A, x, beta, y);
 }
 __global__ void k_gemv_strided_4x4_6(float alpha, float* A, float* x, float beta, float* y) {
-    glass::row_strided_gemv<float, 4, 4, 6>(A, x, y, alpha, beta);
+    glass::gemv_strided<float, 4, 4, 6>(alpha, A, x, beta, y);
 }
 
-// ─── segmented_row_strided_gemv kernels ──────────────────────────────────────
+// ─── gemv_segmented kernels ──────────────────────────────────────
 // Descriptor arrays arrive as float32 .bin; cast to int on host then upload.
 __global__ void k_seg_gemv_6x6_nofuse(uint32_t segs, int* a_off, int* x_off, int* y_off,
                                       float* A, float* x, float* y, float alpha, float beta) {
-    glass::segmented_row_strided_gemv<float, 6, 6, 6, false>(
+    glass::gemv_segmented<float, 6, 6, 6, false>(
         segs, a_off, x_off, y_off, A, x, y, alpha, beta);
 }
 __global__ void k_seg_gemv_6x6_fuse(uint32_t segs, int* a_off, int* x_off, int* y_off,
                                      float* A, float* x, float* y, float alpha, float beta,
                                      int* s_off, float* S, float* scalar) {
-    glass::segmented_row_strided_gemv<float, 6, 6, 6, true>(
+    glass::gemv_segmented<float, 6, 6, 6, true>(
         segs, a_off, x_off, y_off, A, x, y, alpha, beta, s_off, S, scalar);
 }
 
-// ─── segmented_row_strided_gemv: TRANSPOSE / ATOMIC_Y variants ───────────────
+// ─── gemv_segmented: TRANSPOSE / ATOMIC_Y variants ───────────────
 // TRANSPOSE: per segment y_seg(N) = alpha * Aᵀ_seg(N×M) * x_seg(M) + beta*y_seg.
 // A_seg is M×N col-major LDA=ROW_STRIDE; here M=6,N=4,ROW_STRIDE=6.
 __global__ void k_seg_gemv_transpose(uint32_t segs, int* a_off, int* x_off, int* y_off,
                                      float* A, float* x, float* y, float alpha, float beta) {
-    glass::segmented_row_strided_gemv<float, 6, 4, 6,
+    glass::gemv_segmented<float, 6, 4, 6,
         /*FUSE*/false, /*TRANSPOSE*/true, /*ATOMIC_Y*/false>(
         segs, a_off, x_off, y_off, A, x, y, alpha, beta);
 }
@@ -89,7 +86,7 @@ __global__ void k_seg_gemv_transpose(uint32_t segs, int* a_off, int* x_off, int*
 // Overlapping y ranges are summed atomically; caller pre-zeros/pre-scales y.
 __global__ void k_seg_gemv_atomic(uint32_t segs, int* a_off, int* x_off, int* y_off,
                                   float* A, float* x, float* y, float alpha) {
-    glass::segmented_row_strided_gemv<float, 6, 6, 6,
+    glass::gemv_segmented<float, 6, 6, 6,
         /*FUSE*/false, /*TRANSPOSE*/false, /*ATOMIC_Y*/true>(
         segs, a_off, x_off, y_off, A, x, y, alpha);
 }
@@ -97,7 +94,7 @@ __global__ void k_seg_gemv_atomic(uint32_t segs, int* a_off, int* x_off, int* y_
 // atomically accumulate into shared parent y ranges. M=6,N=6,ROW_STRIDE=6.
 __global__ void k_seg_gemv_transpose_atomic(uint32_t segs, int* a_off, int* x_off, int* y_off,
                                             float* A, float* x, float* y, float alpha) {
-    glass::segmented_row_strided_gemv<float, 6, 6, 6,
+    glass::gemv_segmented<float, 6, 6, 6,
         /*FUSE*/false, /*TRANSPOSE*/true, /*ATOMIC_Y*/true>(
         segs, a_off, x_off, y_off, A, x, y, alpha);
 }
@@ -163,16 +160,6 @@ int main(int argc, char** argv) {
         float* dx = read_device_vec(argv[8], n);
         float* dy = read_device_vec(argv[9], m);
         k_gemv_rowmajor<<<1, THREADS>>>(m, n, alpha, dA, dx, beta, dy);
-        cudaDeviceSynchronize();
-        print_device_vec(dy, m);
-
-    } else if (strcmp(op, "gemv_ex") == 0) {
-        float alpha = atof(argv[5]);
-        float beta  = atof(argv[6]);
-        float* dA = read_device_vec(argv[7], m * n);
-        float* dx = read_device_vec(argv[8], n);
-        float* dy = read_device_vec(argv[9], m);
-        k_gemv_ex_rowA<<<1, THREADS>>>(m, n, alpha, dA, dx, beta, dy);
         cudaDeviceSynchronize();
         print_device_vec(dy, m);
 

--- a/test/cuda/test_l3.cu
+++ b/test/cuda/test_l3.cu
@@ -4,6 +4,11 @@
 // Versions:
 //   cg     — glass::cgrps:: (cooperative groups)
 //   simple — glass::        (threadIdx, default)
+//
+// GEMM uses the standard BLAS convention: C is M×N, contraction K;
+// op(A) is M×K (TRANSPOSE_A ⇒ A is K×M), op(B) is K×N (TRANSPOSE_B ⇒ B is N×K),
+// ROW_MAJOR_C selects row-major output. The gemm_rt / gemm_ct ops below take the
+// three layout flags as 0/1 ints so the Python side can sweep the full matrix.
 
 #include <cstdio>
 #include <cstdlib>
@@ -25,51 +30,110 @@ static int* read_device_ivec(const char* path, int n) {
     return d;
 }
 
-// ─── indexed_batched_gemm kernel (DIM=4) ─────────────────────────────────────
+// ─── gemm_batched_indexed kernel (DIM=4) ─────────────────────────────────────
 __global__ void k_indexed_bgemm_4(uint32_t pairs, int* a_idx, int* b_idx, int* c_idx,
                                    float* A, float* B, float* C) {
-    glass::indexed_batched_gemm<float, 4>(pairs, a_idx, b_idx, c_idx, A, B, C);
+    glass::gemm_batched_indexed<float, 4>(pairs, a_idx, b_idx, c_idx, A, B, C);
 }
 
-// ─── indexed_batched_gemm: TRANSPOSE_A / TRANSPOSE_B / ATOMIC_C variants ──────
-// TRANSPOSE_A: C_p = A_pᵀ · B_p (distinct c_idx, plain overwrite).
+// ─── gemm_batched_indexed: TRANSPOSE_A / TRANSPOSE_B / ATOMIC_C variants ──────
 __global__ void k_indexed_bgemm_4_ta(uint32_t pairs, int* a_idx, int* b_idx, int* c_idx,
                                       float* A, float* B, float* C) {
-    glass::indexed_batched_gemm<float, 4, /*TA*/true, /*TB*/false, /*ATOMIC*/false>(
+    glass::gemm_batched_indexed<float, 4, /*TA*/true, /*TB*/false, /*ATOMIC*/false>(
         pairs, a_idx, b_idx, c_idx, A, B, C);
 }
-// TRANSPOSE_B: C_p = A_p · B_pᵀ.
 __global__ void k_indexed_bgemm_4_tb(uint32_t pairs, int* a_idx, int* b_idx, int* c_idx,
                                       float* A, float* B, float* C) {
-    glass::indexed_batched_gemm<float, 4, /*TA*/false, /*TB*/true, /*ATOMIC*/false>(
+    glass::gemm_batched_indexed<float, 4, /*TA*/false, /*TB*/true, /*ATOMIC*/false>(
         pairs, a_idx, b_idx, c_idx, A, B, C);
 }
-// ATOMIC_C: pairs may share c_idx; products are scatter-summed into pre-zeroed C.
 __global__ void k_indexed_bgemm_4_atomic(uint32_t pairs, int* a_idx, int* b_idx, int* c_idx,
                                          float* A, float* B, float* C) {
-    glass::indexed_batched_gemm<float, 4, /*TA*/false, /*TB*/false, /*ATOMIC*/true>(
+    glass::gemm_batched_indexed<float, 4, /*TA*/false, /*TB*/false, /*ATOMIC*/true>(
         pairs, a_idx, b_idx, c_idx, A, B, C);
 }
-// TRANSPOSE_A + ATOMIC_C (the backward-pass case Xᵀ·M·X → shared parent): each
-// child computes A_pᵀ·B_p and atomically accumulates into a SHARED parent C slot.
 __global__ void k_indexed_bgemm_4_ta_atomic(uint32_t pairs, int* a_idx, int* b_idx, int* c_idx,
                                             float* A, float* B, float* C) {
-    glass::indexed_batched_gemm<float, 4, /*TA*/true, /*TB*/false, /*ATOMIC*/true>(
+    glass::gemm_batched_indexed<float, 4, /*TA*/true, /*TB*/false, /*ATOMIC*/true>(
         pairs, a_idx, b_idx, c_idx, A, B, C);
 }
 
-// ─── gemm kernels ─────────────────────────────────────────────────────────────
-__global__ void k_gemm_cg(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
-    glass::cgrps::gemm<float, false>(m, n, k, alpha, A, B, beta, C);
+// ─── GEMM kernels (standard convention) ──────────────────────────────────────
+// `nb` (no-beta): when 1, call the overload that overwrites C and never reads it
+// (so a NaN-poisoned C must survive); when 0, the beta overload.
+template <bool TA, bool TB, bool RMC>
+__global__ void k_gemm_rt(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C, int nb) {
+    if (nb) glass::gemm<float, TA, TB, RMC>(m, n, k, alpha, A, B, C);
+    else    glass::gemm<float, TA, TB, RMC>(m, n, k, alpha, A, B, beta, C);
 }
-__global__ void k_gemm_simple(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
-    glass::gemm<float, false>(m, n, k, alpha, A, B, beta, C);
+template <bool TA, bool TB, bool RMC>
+__global__ void k_gemm_rt_cg(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C, int nb) {
+    if (nb) glass::cgrps::gemm<float, TA, TB, RMC>(m, n, k, alpha, A, B, C);
+    else    glass::cgrps::gemm<float, TA, TB, RMC>(m, n, k, alpha, A, B, beta, C);
 }
-__global__ void k_gemm_t_cg(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
-    glass::cgrps::gemm<float, true>(m, n, k, alpha, A, B, beta, C);
+// Compile-time-size (magic-multiply path).
+template <int M, int N, int K, bool TA, bool TB, bool RMC>
+__global__ void k_gemm_ct(float alpha, float* A, float* B, float beta, float* C, int nb) {
+    if (nb) glass::gemm<float, M, N, K, TA, TB, RMC>(alpha, A, B, C);
+    else    glass::gemm<float, M, N, K, TA, TB, RMC>(alpha, A, B, beta, C);
 }
-__global__ void k_gemm_t_simple(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
-    glass::gemm<float, true>(m, n, k, alpha, A, B, beta, C);
+// Single-warp compile-time (run <<<1,32>>>).
+template <int M, int N, int K, bool TA, bool TB, bool RMC>
+__global__ void k_gemm_warp(float alpha, float* A, float* B, float beta, float* C, int nb) {
+    if (nb) glass::warp::gemm<float, M, N, K, TA, TB, RMC>(alpha, A, B, C);
+    else    glass::warp::gemm<float, M, N, K, TA, TB, RMC>(alpha, A, B, beta, C);
+}
+
+// Runtime flag dispatch (8 combos) for a launcher LAUNCH(TA,TB,RMC).
+#define GEMM_FLAG_DISPATCH(ta, tb, rmc, LAUNCH)         \
+    do {                                                \
+        int _f = ((ta) << 2) | ((tb) << 1) | (rmc);     \
+        switch (_f) {                                   \
+            case 0: LAUNCH(false,false,false); break;   \
+            case 1: LAUNCH(false,false,true ); break;   \
+            case 2: LAUNCH(false,true ,false); break;   \
+            case 3: LAUNCH(false,true ,true ); break;   \
+            case 4: LAUNCH(true ,false,false); break;   \
+            case 5: LAUNCH(true ,false,true ); break;   \
+            case 6: LAUNCH(true ,true ,false); break;   \
+            case 7: LAUNCH(true ,true ,true ); break;   \
+        }                                               \
+    } while (0)
+
+// Compile-time shape table for gemm_ct / gemm_warp, selected by shape_id
+// (deliberately includes non-square + all-distinct dims, plus M=1/N=1 edges).
+static void ct_shape_dims(int id, int* M, int* N, int* K) {
+    switch (id) {
+        case 0: *M=1; *N=1; *K=1; break;
+        case 1: *M=2; *N=3; *K=4; break;
+        case 2: *M=4; *N=2; *K=3; break;
+        case 3: *M=5; *N=7; *K=3; break;
+        case 4: *M=8; *N=1; *K=5; break;
+        case 5: *M=9; *N=4; *K=7; break;
+        case 6: *M=7; *N=5; *K=6; break;
+        default: *M=16; *N=16; *K=16; break;
+    }
+}
+
+// Compile-time-size launcher: 8-way flag switch for a fixed (M,N,K).
+template <int M, int N, int K>
+static void launch_gemm_ct(bool warp, int th, int ta, int tb, int rmc, int nb,
+                           float alpha, float* dA, float* dB, float beta, float* dC) {
+    int f = (ta << 2) | (tb << 1) | rmc;
+    #define _CT_DOIT(TA,TB,RMC)                                                          \
+        do { if (warp) k_gemm_warp<M,N,K,TA,TB,RMC><<<1,32>>>(alpha,dA,dB,beta,dC,nb);   \
+             else      k_gemm_ct  <M,N,K,TA,TB,RMC><<<1,th>>>(alpha,dA,dB,beta,dC,nb); } while (0)
+    switch (f) {
+        case 0: _CT_DOIT(false,false,false); break;
+        case 1: _CT_DOIT(false,false,true ); break;
+        case 2: _CT_DOIT(false,true ,false); break;
+        case 3: _CT_DOIT(false,true ,true ); break;
+        case 4: _CT_DOIT(true ,false,false); break;
+        case 5: _CT_DOIT(true ,false,true ); break;
+        case 6: _CT_DOIT(true ,true ,false); break;
+        case 7: _CT_DOIT(true ,true ,true ); break;
+    }
+    #undef _CT_DOIT
 }
 
 // ─── inv kernels ──────────────────────────────────────────────────────────────
@@ -105,41 +169,29 @@ __global__ void k_trsm_simple(int n, float* L, float* b) {
     glass::trsm(n, L, b);
 }
 
-// ─── warp:: kernels (launch <<<1,32>>>) ──────────────────────────────────────
-// Single-warp 4×4×4 GEMM (the mat4-style transform-multiply replacement).
-__global__ void k_gemm_warp_4x4x4(float alpha, float* A, float* B, float beta, float* C) {
-    glass::warp::gemm<float, 4, 4, 4>(alpha, A, B, beta, C);
-}
-// Single-warp SPD solve A x = b (N=7): factor A=LLᵀ, then forward + transpose solves.
-// Exercises warp::cholDecomp_InPlace + warp::trsm + warp::trsm_transpose together
-// (the HJCD normal-equations pattern). b is overwritten with the solution.
+// ─── warp SPD solve (N=7) ─────────────────────────────────────────────────────
 __global__ void k_posv_warp_7(float* A, float* b) {
     glass::warp::cholDecomp_InPlace<float, 7>(A);
     glass::warp::trsm<float, 7>(A, b);
     glass::warp::trsm_transpose<float, 7>(A, b);
 }
 
-// ─── gemm row-major kernels ───────────────────────────────────────────────────
-__global__ void k_gemm_rowmajor(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
-    glass::gemm<float, false, true>(m, n, k, alpha, A, B, beta, C);
+// ─── gemm_strided kernels (standard convention: A M×K lead A_RS, B K×N lead B_RS) ──
+__global__ void k_rsgemm_6x6x6_6_6(float alpha, float* A, float* B, float beta, float* C) {
+    glass::gemm_strided<float, 6, 6, 6, 6, 6>(alpha, A, B, beta, C);
 }
-__global__ void k_gemm_ex_mixed(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
-    glass::gemm_ex<float, false, true, false, true>(m, n, k, alpha, A, B, beta, C);
+__global__ void k_rsgemm_6x6x6_8_8(float alpha, float* A, float* B, float beta, float* C) {
+    glass::gemm_strided<float, 6, 6, 6, 8, 8>(alpha, A, B, beta, C);
 }
-
-// ─── row_strided_gemm kernels (compile-time M, N, K, A_RS, B_RS) ─────────────
-// A[i][j] = A[i + j*A_RS] (col-major), B[j][l] = B[j + l*B_RS] (col-major), C standard.
-__global__ void k_gemm_strided_6x6x6_6_6(float alpha, float* A, float* B, float beta, float* C) {
-    glass::row_strided_gemm<float, 6, 6, 6, 6, 6>(A, B, C, alpha, beta);
+__global__ void k_rsgemm_4x4x4_4_4(float alpha, float* A, float* B, float beta, float* C) {
+    glass::gemm_strided<float, 4, 4, 4, 4, 4>(alpha, A, B, beta, C);
 }
-__global__ void k_gemm_strided_6x6x6_8_8(float alpha, float* A, float* B, float beta, float* C) {
-    glass::row_strided_gemm<float, 6, 6, 6, 8, 8>(A, B, C, alpha, beta);
+__global__ void k_rsgemm_4x4x4_6_6(float alpha, float* A, float* B, float beta, float* C) {
+    glass::gemm_strided<float, 4, 4, 4, 6, 6>(alpha, A, B, beta, C);
 }
-__global__ void k_gemm_strided_4x4x4_4_4(float alpha, float* A, float* B, float beta, float* C) {
-    glass::row_strided_gemm<float, 4, 4, 4, 4, 4>(A, B, C, alpha, beta);
-}
-__global__ void k_gemm_strided_4x4x4_6_6(float alpha, float* A, float* B, float beta, float* C) {
-    glass::row_strided_gemm<float, 4, 4, 4, 6, 6>(A, B, C, alpha, beta);
+// Non-square strided: C 5×7, contract 3; A 5×3 lead 8, B 3×7 lead 6.
+__global__ void k_rsgemm_5x7x3_8_6(float alpha, float* A, float* B, float beta, float* C) {
+    glass::gemm_strided<float, 5, 7, 3, 8, 6>(alpha, A, B, beta, C);
 }
 
 // ─── packed GEMM CT kernels (4×4×{16,32,48,64}) ──────────────────────────────
@@ -153,7 +205,7 @@ DEFINE_PACKED_GEMM_KERNEL(4, 4, 32)
 DEFINE_PACKED_GEMM_KERNEL(4, 4, 48)
 DEFINE_PACKED_GEMM_KERNEL(4, 4, 64)
 
-// ─── gemm_tiled kernels ───────────────────────────────────────────────────────
+// ─── gemm_tiled kernel (no transpose; A m×k, B k×n, C m×n) ───────────────────
 __global__ void k_gemm_tiled(int m, int n, int k, float alpha, float* A, float* B, float beta, float* C) {
     extern __shared__ float smem[];
     float* s_A = smem;
@@ -172,46 +224,61 @@ int main(int argc, char** argv) {
     const char* ver = argv[2];
     bool cg = (strcmp(ver, "cg") == 0);
 
-    if (strcmp(op, "gemm") == 0) {
-        int m = atoi(argv[3]);
-        int n = atoi(argv[4]);
-        int k = atoi(argv[5]);
-        float alpha = atof(argv[6]);
-        float beta  = atof(argv[7]);
-        float* dA = read_device_vec(argv[8], m * n);
-        float* dB = read_device_vec(argv[9], n * k);
-        float* dC = read_device_vec(argv[10], m * k);
-        if (cg) k_gemm_cg<<<1, THREADS>>>(m, n, k, alpha, dA, dB, beta, dC);
-        else    k_gemm_simple<<<1, THREADS>>>(m, n, k, alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, m * k);
-
-    } else if (strcmp(op, "gemm_t") == 0) {
-        int m = atoi(argv[3]);
-        int n = atoi(argv[4]);
-        int k = n;
-        float alpha = atof(argv[6]);
-        float beta  = atof(argv[7]);
-        float* dA = read_device_vec(argv[8], m * n);
-        float* dB = read_device_vec(argv[9], n * n);
-        float* dC = read_device_vec(argv[10], m * n);
-        if (cg) k_gemm_t_cg<<<1, THREADS>>>(m, n, k, alpha, dA, dB, beta, dC);
-        else    k_gemm_t_simple<<<1, THREADS>>>(m, n, k, alpha, dA, dB, beta, dC);
+    if (strcmp(op, "gemm_rt") == 0) {
+        // gemm_rt <cg|simple> <threads> <m> <n> <k> <ta> <tb> <rmc> <nb> <alpha> <beta> <A> <B> <C>
+        int th = atoi(argv[3]);
+        int m = atoi(argv[4]), n = atoi(argv[5]), k = atoi(argv[6]);
+        int ta = atoi(argv[7]), tb = atoi(argv[8]), rmc = atoi(argv[9]), nb = atoi(argv[10]);
+        float alpha = atof(argv[11]), beta = atof(argv[12]);
+        float* dA = read_device_vec(argv[13], m * k);   // op(A) is m×k (MK either layout)
+        float* dB = read_device_vec(argv[14], k * n);   // op(B) is k×n (KN either layout)
+        float* dC = read_device_vec(argv[15], m * n);
+        if (cg) {
+            #define L_RT_CG(TA,TB,RMC) k_gemm_rt_cg<TA,TB,RMC><<<1,th>>>(m,n,k,alpha,dA,dB,beta,dC,nb)
+            GEMM_FLAG_DISPATCH(ta, tb, rmc, L_RT_CG);
+        } else {
+            #define L_RT(TA,TB,RMC) k_gemm_rt<TA,TB,RMC><<<1,th>>>(m,n,k,alpha,dA,dB,beta,dC,nb)
+            GEMM_FLAG_DISPATCH(ta, tb, rmc, L_RT);
+        }
         cudaDeviceSynchronize();
         print_device_vec(dC, m * n);
 
+    } else if (strcmp(op, "gemm_ct") == 0 || strcmp(op, "gemm_warp") == 0) {
+        // gemm_ct|gemm_warp <unused> <threads> <shape_id> <ta> <tb> <rmc> <nb> <alpha> <beta> <A> <B> <C>
+        bool warp = (strcmp(op, "gemm_warp") == 0);
+        int th  = warp ? 32 : atoi(argv[3]);
+        int id  = atoi(argv[4]);
+        int ta  = atoi(argv[5]), tb = atoi(argv[6]), rmc = atoi(argv[7]), nb = atoi(argv[8]);
+        float alpha = atof(argv[9]), beta = atof(argv[10]);
+        int M, N, K; ct_shape_dims(id, &M, &N, &K);
+        float* dA = read_device_vec(argv[11], M * K);
+        float* dB = read_device_vec(argv[12], K * N);
+        float* dC = read_device_vec(argv[13], M * N);
+        switch (id) {
+            case 0: launch_gemm_ct< 1, 1, 1>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+            case 1: launch_gemm_ct< 2, 3, 4>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+            case 2: launch_gemm_ct< 4, 2, 3>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+            case 3: launch_gemm_ct< 5, 7, 3>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+            case 4: launch_gemm_ct< 8, 1, 5>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+            case 5: launch_gemm_ct< 9, 4, 7>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+            case 6: launch_gemm_ct< 7, 5, 6>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+            default:launch_gemm_ct<16,16,16>(warp,th,ta,tb,rmc,nb,alpha,dA,dB,beta,dC); break;
+        }
+        cudaDeviceSynchronize();
+        print_device_vec(dC, M * N);
+
     } else if (strcmp(op, "inv") == 0) {
-        int n = atoi(argv[3]);
-        float* dA = read_device_vec(argv[4], 2 * n * n);
+        int threads = atoi(argv[3]);
+        int n = atoi(argv[4]);
+        float* dA = read_device_vec(argv[5], 2 * n * n);
         float* scratch; cudaMalloc(&scratch, (2 * n + 1) * sizeof(float));
-        if (cg) k_inv_cg<<<1, THREADS>>>(n, dA, scratch);
-        else    k_inv_simple<<<1, THREADS>>>(n, dA, scratch);
+        if (cg) k_inv_cg<<<1, threads>>>(n, dA, scratch);
+        else    k_inv_simple<<<1, threads>>>(n, dA, scratch);
         cudaDeviceSynchronize();
         print_device_vec(dA + n * n, n * n);
         cudaFree(scratch);
 
-    } else if (strcmp(op, "inv_pivot") == 0) {  // robust partial-pivoting invert
-        // Usage: inv_pivot simple <threads> <n> <file>
+    } else if (strcmp(op, "inv_pivot") == 0) {
         int threads = atoi(argv[3]);
         int n = atoi(argv[4]);
         float* dA = read_device_vec(argv[5], 2 * n * n);
@@ -221,7 +288,7 @@ int main(int argc, char** argv) {
         print_device_vec(dA + n * n, n * n);
         cudaFree(scratch);
 
-    } else if (strcmp(op, "inv2") == 0) {  // fused 2-matrix invert
+    } else if (strcmp(op, "inv2") == 0) {
         int dimA = atoi(argv[3]); int dimB = atoi(argv[4]); int maxd = atoi(argv[5]);
         float* dA = read_device_vec(argv[6], 2 * dimA * dimA);
         float* dB = read_device_vec(argv[7], 2 * dimB * dimB);
@@ -232,7 +299,7 @@ int main(int argc, char** argv) {
         print_device_vec(dB + dimB * dimB, dimB * dimB);
         cudaFree(scratch);
 
-    } else if (strcmp(op, "inv3") == 0) {  // fused 3-matrix invert (GATO Schur: Q_k, Q_kp1, R_k)
+    } else if (strcmp(op, "inv3") == 0) {
         int dimA = atoi(argv[3]); int dimB = atoi(argv[4]); int dimC = atoi(argv[5]); int maxd = atoi(argv[6]);
         float* dA = read_device_vec(argv[7], 2 * dimA * dimA);
         float* dB = read_device_vec(argv[8], 2 * dimB * dimB);
@@ -262,21 +329,8 @@ int main(int argc, char** argv) {
         cudaDeviceSynchronize();
         print_device_vec(db, n);
 
-    } else if (strcmp(op, "gemm_warp") == 0) {
-        int m = atoi(argv[3]);   // fixed 4×4×4 warp kernel
-        int n = atoi(argv[4]);
-        int k = atoi(argv[5]);
-        float alpha = atof(argv[6]);
-        float beta  = atof(argv[7]);
-        float* dA = read_device_vec(argv[8], m * n);
-        float* dB = read_device_vec(argv[9], n * k);
-        float* dC = read_device_vec(argv[10], m * k);
-        k_gemm_warp_4x4x4<<<1, 32>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, m * k);
-
     } else if (strcmp(op, "posv_warp") == 0) {
-        int n = atoi(argv[3]);   // fixed N=7 warp SPD solve
+        int n = atoi(argv[3]);
         float* dA = read_device_vec(argv[4], n * n);
         float* db = read_device_vec(argv[5], n);
         k_posv_warp_7<<<1, 32>>>(dA, db);
@@ -284,127 +338,58 @@ int main(int argc, char** argv) {
         print_device_vec(db, n);
 
     } else if (strcmp(op, "gemm_tiled") == 0) {
+        // gemm_tiled <cg|simple> <m> <n> <k> <alpha> <beta> <A> <B> <C>
         int m = atoi(argv[3]);
         int n = atoi(argv[4]);
         int k = atoi(argv[5]);
         float alpha = atof(argv[6]);
         float beta  = atof(argv[7]);
-        float* dA = read_device_vec(argv[8], m * n);
-        float* dB = read_device_vec(argv[9], n * k);
-        float* dC = read_device_vec(argv[10], m * k);
-        int smem_bytes = (m * 8 + 8 * k) * sizeof(float);
+        float* dA = read_device_vec(argv[8], m * k);    // A is m×k
+        float* dB = read_device_vec(argv[9], k * n);    // B is k×n
+        float* dC = read_device_vec(argv[10], m * n);
+        int smem_bytes = (m * 8 + 8 * n) * sizeof(float);
         k_gemm_tiled<<<1, THREADS, smem_bytes>>>(m, n, k, alpha, dA, dB, beta, dC);
         cudaDeviceSynchronize();
-        print_device_vec(dC, m * k);
+        print_device_vec(dC, m * n);
 
-    } else if (strcmp(op, "gemm_rowmajor") == 0) {
-        int m = atoi(argv[3]);
-        int n = atoi(argv[4]);
-        int k = atoi(argv[5]);
-        float alpha = atof(argv[6]);
-        float beta  = atof(argv[7]);
-        float* dA = read_device_vec(argv[8], m * n);
-        float* dB = read_device_vec(argv[9], n * k);
-        float* dC = read_device_vec(argv[10], m * k);
-        k_gemm_rowmajor<<<1, THREADS>>>(m, n, k, alpha, dA, dB, beta, dC);
+    } else if (strncmp(op, "rsgemm_", 7) == 0) {
+        // rsgemm_<MxNxK_ARSxBRS> <unused> <threads> <alpha> <beta> <A> <B> <C>
+        int th = atoi(argv[3]);
+        float alpha = atof(argv[4]);
+        float beta  = atof(argv[5]);
+        int M, N, K, ARS, BRS;
+        if      (strcmp(op, "rsgemm_6x6x6_6_6") == 0) { M=6;N=6;K=6;ARS=6;BRS=6; }
+        else if (strcmp(op, "rsgemm_6x6x6_8_8") == 0) { M=6;N=6;K=6;ARS=8;BRS=8; }
+        else if (strcmp(op, "rsgemm_4x4x4_4_4") == 0) { M=4;N=4;K=4;ARS=4;BRS=4; }
+        else if (strcmp(op, "rsgemm_4x4x4_6_6") == 0) { M=4;N=4;K=4;ARS=6;BRS=6; }
+        else if (strcmp(op, "rsgemm_5x7x3_8_6") == 0) { M=5;N=7;K=3;ARS=8;BRS=6; }
+        else { fprintf(stderr, "bad rsgemm op %s\n", op); return 1; }
+        float* dA = read_device_vec(argv[6], ARS * K);   // A is M×K, lead ARS
+        float* dB = read_device_vec(argv[7], BRS * N);   // B is K×N, lead BRS
+        float* dC = read_device_vec(argv[8], M * N);
+        if      (strcmp(op, "rsgemm_6x6x6_6_6") == 0) k_rsgemm_6x6x6_6_6<<<1,th>>>(alpha,dA,dB,beta,dC);
+        else if (strcmp(op, "rsgemm_6x6x6_8_8") == 0) k_rsgemm_6x6x6_8_8<<<1,th>>>(alpha,dA,dB,beta,dC);
+        else if (strcmp(op, "rsgemm_4x4x4_4_4") == 0) k_rsgemm_4x4x4_4_4<<<1,th>>>(alpha,dA,dB,beta,dC);
+        else if (strcmp(op, "rsgemm_4x4x4_6_6") == 0) k_rsgemm_4x4x4_6_6<<<1,th>>>(alpha,dA,dB,beta,dC);
+        else                                          k_rsgemm_5x7x3_8_6<<<1,th>>>(alpha,dA,dB,beta,dC);
         cudaDeviceSynchronize();
-        print_device_vec(dC, m * k);
+        print_device_vec(dC, M * N);
 
-    } else if (strcmp(op, "gemm_ex") == 0) {
-        int m = atoi(argv[3]);
-        int n = atoi(argv[4]);
-        int k = atoi(argv[5]);
-        float alpha = atof(argv[6]);
-        float beta  = atof(argv[7]);
-        float* dA = read_device_vec(argv[8], m * n);
-        float* dB = read_device_vec(argv[9], n * k);
-        float* dC = read_device_vec(argv[10], m * k);
-        k_gemm_ex_mixed<<<1, THREADS>>>(m, n, k, alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, m * k);
-
-    } else if (strcmp(op, "gemm_strided_6x6x6_6_6") == 0) {
+    } else if (strncmp(op, "packed_gemm_4x4x", 16) == 0) {
+        int K = atoi(op + 16);   // 16/32/48/64
         float alpha = atof(argv[3]);
         float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 6 * 6);
-        float* dB = read_device_vec(argv[6], 6 * 6);
-        float* dC = read_device_vec(argv[7], 6 * 6);
-        k_gemm_strided_6x6x6_6_6<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, 6 * 6);
-
-    } else if (strcmp(op, "gemm_strided_6x6x6_8_8") == 0) {
-        float alpha = atof(argv[3]);
-        float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 6 * 8);   // LDA_A=8
-        float* dB = read_device_vec(argv[6], 6 * 8);   // LDA_B=8 (N*B_RS where N=6, B_RS=8)
-        float* dC = read_device_vec(argv[7], 6 * 6);
-        k_gemm_strided_6x6x6_8_8<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, 6 * 6);
-
-    } else if (strcmp(op, "gemm_strided_4x4x4_4_4") == 0) {
-        float alpha = atof(argv[3]);
-        float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 4 * 4);
-        float* dB = read_device_vec(argv[6], 4 * 4);
+        float* dA = read_device_vec(argv[5], 4 * K);   // A is 4×K
+        float* dB = read_device_vec(argv[6], K * 4);   // B is K×4
         float* dC = read_device_vec(argv[7], 4 * 4);
-        k_gemm_strided_4x4x4_4_4<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
+        if      (K == 16) k_packed_gemm_4x4x16<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
+        else if (K == 32) k_packed_gemm_4x4x32<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
+        else if (K == 48) k_packed_gemm_4x4x48<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
+        else              k_packed_gemm_4x4x64<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
         cudaDeviceSynchronize();
         print_device_vec(dC, 4 * 4);
-
-    } else if (strcmp(op, "gemm_strided_4x4x4_6_6") == 0) {
-        float alpha = atof(argv[3]);
-        float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 4 * 6);   // LDA_A=6
-        float* dB = read_device_vec(argv[6], 4 * 6);   // LDA_B=6
-        float* dC = read_device_vec(argv[7], 4 * 4);
-        k_gemm_strided_4x4x4_6_6<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, 4 * 4);
-
-    } else if (strcmp(op, "packed_gemm_4x4x16") == 0) {
-        float alpha = atof(argv[3]);
-        float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 4 * 4);
-        float* dB = read_device_vec(argv[6], 4 * 16);
-        float* dC = read_device_vec(argv[7], 4 * 16);
-        k_packed_gemm_4x4x16<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, 4 * 16);
-
-    } else if (strcmp(op, "packed_gemm_4x4x32") == 0) {
-        float alpha = atof(argv[3]);
-        float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 4 * 4);
-        float* dB = read_device_vec(argv[6], 4 * 32);
-        float* dC = read_device_vec(argv[7], 4 * 32);
-        k_packed_gemm_4x4x32<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, 4 * 32);
-
-    } else if (strcmp(op, "packed_gemm_4x4x48") == 0) {
-        float alpha = atof(argv[3]);
-        float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 4 * 4);
-        float* dB = read_device_vec(argv[6], 4 * 48);
-        float* dC = read_device_vec(argv[7], 4 * 48);
-        k_packed_gemm_4x4x48<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, 4 * 48);
-
-    } else if (strcmp(op, "packed_gemm_4x4x64") == 0) {
-        float alpha = atof(argv[3]);
-        float beta  = atof(argv[4]);
-        float* dA = read_device_vec(argv[5], 4 * 4);
-        float* dB = read_device_vec(argv[6], 4 * 64);
-        float* dC = read_device_vec(argv[7], 4 * 64);
-        k_packed_gemm_4x4x64<<<1, THREADS>>>(alpha, dA, dB, beta, dC);
-        cudaDeviceSynchronize();
-        print_device_vec(dC, 4 * 64);
 
     } else if (strcmp(op, "indexed_bgemm_4") == 0) {
-        // argv: m n k pairs A_mats B_mats C_mats  a_idx b_idx c_idx A B C
         uint32_t pairs = (uint32_t)atoi(argv[6]);
         int A_mats = atoi(argv[7]);
         int B_mats = atoi(argv[8]);
@@ -424,9 +409,6 @@ int main(int argc, char** argv) {
                strcmp(op, "indexed_bgemm_4_tb") == 0 ||
                strcmp(op, "indexed_bgemm_4_atomic") == 0 ||
                strcmp(op, "indexed_bgemm_4_ta_atomic") == 0) {
-        // argv: m n k pairs A_mats B_mats C_mats  a_idx b_idx c_idx A B C
-        // The atomic variants expect C to be PRE-ZEROED here (alloc_device_vec
-        // zero-inits) so the scatter-add reference matches.
         uint32_t pairs = (uint32_t)atoi(argv[6]);
         int A_mats = atoi(argv[7]);
         int B_mats = atoi(argv[8]);

--- a/test/cuda/test_l3_nvidia.cu
+++ b/test/cuda/test_l3_nvidia.cu
@@ -39,8 +39,8 @@ __global__ void k_strided_1d(float alpha, float* A_shared, float* B, float beta,
         alpha, A_shared, B, beta, C);
 }
 
-// Non-default strides: B and C have padding between batches (B_STRIDE > N*K,
-// C_STRIDE > M*K). Exercises the * b * STRIDE indexing inside the kernel.
+// Non-default strides: B and C have padding between batches (B_STRIDE > K*N,
+// C_STRIDE > M*N). Exercises the * b * STRIDE indexing inside the kernel.
 template <int M_, int N_, int K_, int BATCH_, int B_STRIDE_, int C_STRIDE_>
 __global__ void k_strided_1d_padded(float alpha, float* A_shared, float* B, float beta, float* C) {
     glass::nvidia::gemm_strided_batched_1d<float, M_, N_, K_, BATCH_, TC,
@@ -67,13 +67,14 @@ template <int M_, int N_, int K_, int BATCH_>
 static void do_batched(int argc, char** argv, bool row_major) {
     float alpha = atof(argv[3]);
     float beta  = atof(argv[4]);
-    float* dA = read_device_vec(argv[5], BATCH_ * M_ * N_);
-    float* dB = read_device_vec(argv[6], BATCH_ * N_ * K_);
-    float* dC = read_device_vec(argv[7], BATCH_ * M_ * K_);
+    // Standard convention: A is M×K, B is K×N, C is M×N.
+    float* dA = read_device_vec(argv[5], BATCH_ * M_ * K_);
+    float* dB = read_device_vec(argv[6], BATCH_ * K_ * N_);
+    float* dC = read_device_vec(argv[7], BATCH_ * M_ * N_);
 
-    float** dA_ptrs = build_ptr_array(dA, BATCH_, M_ * N_);
-    float** dB_ptrs = build_ptr_array(dB, BATCH_, N_ * K_);
-    float** dC_ptrs = build_ptr_array(dC, BATCH_, M_ * K_);
+    float** dA_ptrs = build_ptr_array(dA, BATCH_, M_ * K_);
+    float** dB_ptrs = build_ptr_array(dB, BATCH_, K_ * N_);
+    float** dC_ptrs = build_ptr_array(dC, BATCH_, M_ * N_);
 
     dim3 block(TC * BATCH_, 1, 1);
     if (row_major)
@@ -81,7 +82,7 @@ static void do_batched(int argc, char** argv, bool row_major) {
     else
         k_batched_1d<M_, N_, K_, BATCH_><<<1, block>>>(alpha, dA_ptrs, dB_ptrs, beta, dC_ptrs);
     cudaDeviceSynchronize();
-    print_device_vec(dC, BATCH_ * M_ * K_);
+    print_device_vec(dC, BATCH_ * M_ * N_);
 
     cudaFree(dA); cudaFree(dB); cudaFree(dC);
     cudaFree(dA_ptrs); cudaFree(dB_ptrs); cudaFree(dC_ptrs);
@@ -93,27 +94,28 @@ template <int M_, int N_, int K_, int BATCH_>
 static void do_strided(int argc, char** argv) {
     float alpha = atof(argv[3]);
     float beta  = atof(argv[4]);
-    float* dAs = read_device_vec(argv[5], M_ * N_);
-    float* dB  = read_device_vec(argv[6], BATCH_ * N_ * K_);
-    float* dC  = read_device_vec(argv[7], BATCH_ * M_ * K_);
+    // Standard convention: shared A is M×K, each B is K×N, each C is M×N.
+    float* dAs = read_device_vec(argv[5], M_ * K_);
+    float* dB  = read_device_vec(argv[6], BATCH_ * K_ * N_);
+    float* dC  = read_device_vec(argv[7], BATCH_ * M_ * N_);
 
     dim3 block(TC * BATCH_, 1, 1);
     k_strided_1d<M_, N_, K_, BATCH_><<<1, block>>>(alpha, dAs, dB, beta, dC);
     cudaDeviceSynchronize();
-    print_device_vec(dC, BATCH_ * M_ * K_);
+    print_device_vec(dC, BATCH_ * M_ * N_);
 
     cudaFree(dAs); cudaFree(dB); cudaFree(dC);
 }
 
 // Strided variant with explicit (non-default) B_STRIDE, C_STRIDE.
 // Caller passes BATCH_ * B_STRIDE_ B-elements and BATCH_ * C_STRIDE_ C-elements;
-// only the first N_*K_ / M_*K_ slots of each batch are used by the kernel
+// only the first K_*N_ / M_*N_ slots of each batch are used by the kernel
 // (padding bytes are read-but-not-written by C and not-read-or-written by B).
 template <int M_, int N_, int K_, int BATCH_, int B_STRIDE_, int C_STRIDE_>
 static void do_strided_padded(int argc, char** argv) {
     float alpha = atof(argv[3]);
     float beta  = atof(argv[4]);
-    float* dAs = read_device_vec(argv[5], M_ * N_);
+    float* dAs = read_device_vec(argv[5], M_ * K_);   // shared A is M×K
     float* dB  = read_device_vec(argv[6], BATCH_ * B_STRIDE_);
     float* dC  = read_device_vec(argv[7], BATCH_ * C_STRIDE_);
 
@@ -143,14 +145,14 @@ int main(int argc, char** argv) {
     if (!strcmp(op, "gemm_batched_1d_4x4x4_b4_row"))  return do_batched<4,4,4,4>(argc, argv, true), 0;
     if (!strcmp(op, "gemm_batched_1d_3x5x7_b3_row"))  return do_batched<3,5,7,3>(argc, argv, true), 0;
 
-    // gemm_strided_batched_1d, col-major (defaults: B_STRIDE=N*K, C_STRIDE=M*K)
+    // gemm_strided_batched_1d, col-major (defaults: B_STRIDE=K*N, C_STRIDE=M*N)
     if (!strcmp(op, "gemm_strided_batched_1d_4x4x4_b1"))  return do_strided<4,4,4,1>(argc, argv), 0;
     if (!strcmp(op, "gemm_strided_batched_1d_4x4x4_b4"))  return do_strided<4,4,4,4>(argc, argv), 0;
     if (!strcmp(op, "gemm_strided_batched_1d_6x6x6_b2"))  return do_strided<6,6,6,2>(argc, argv), 0;
     if (!strcmp(op, "gemm_strided_batched_1d_3x5x7_b3"))  return do_strided<3,5,7,3>(argc, argv), 0;
 
     // Strided variant with non-default (padded) strides. Each batch's B has
-    // B_STRIDE elements (only the first N*K used); same for C with C_STRIDE.
+    // B_STRIDE elements (only the first K*N used); same for C with C_STRIDE.
     // Format: <op> <alpha> <beta> Ashared.bin B_padded.bin C_padded.bin
     if (!strcmp(op, "gemm_strided_padded_4x4x4_b4_bs24_cs20"))
         return do_strided_padded<4,4,4,4,/*B_STRIDE=*/24,/*C_STRIDE=*/20>(argc, argv), 0;

--- a/test/cuda/test_ldlt.cu
+++ b/test/cuda/test_ldlt.cu
@@ -33,6 +33,17 @@ __global__ void k_ldlt_solve(uint32_t n, float* A, float* s_temp, float* b,
     glass::ldlt_solve<float>(n, A, b, pivot != 0 ? piv : nullptr);
 }
 
+// ─── warp forms (compile-time N, non-pivoted) ─────────────────────────────────
+template <uint32_t N, bool CHECK>
+__global__ void k_ldlt_warp(float* A, int* s_fail, int* s_inertia) {
+    glass::warp::ldlt<float, N, CHECK>(A, s_fail, s_inertia);
+}
+template <uint32_t N>
+__global__ void k_ldlt_solve_warp(float* A, float* b) {
+    glass::warp::ldlt<float, N>(A);
+    glass::warp::ldlt_solve<float, N>(A, b);
+}
+
 // Print n device uint32 values (the pivot array) as space-separated ints.
 __global__ void print_piv_kernel(uint32_t* d, int n) {
     for (int i = 0; i < n; i++) {
@@ -71,6 +82,40 @@ int main(int argc, char** argv) {
         if (argc < 7) { fprintf(stderr, "ldlt_solve needs <b.bin>\n"); return 1; }
         float* db = read_device_vec(argv[6], n);
         k_ldlt_solve<<<1, threads>>>((uint32_t)n, dA, dscr, db, pivot, dpiv);
+        cudaDeviceSynchronize();
+        print_device_vec(db, n);
+    } else if (strcmp(op, "ldlt_warp") == 0) {
+        // factor only; prints n*n factored buffer (D diag, unit-L strict-lower).
+#define MAC(N) k_ldlt_warp<N,false><<<1,threads>>>(dA, nullptr, nullptr)
+        switch (n) { case 3:MAC(3);break; case 4:MAC(4);break; case 5:MAC(5);break;
+                     case 6:MAC(6);break; case 7:MAC(7);break; case 8:MAC(8);break;
+                     default: fprintf(stderr,"warp ldlt: n must be 3..8\n"); return 1; }
+#undef MAC
+        cudaDeviceSynchronize();
+        print_device_vec(dA, n * n);
+    } else if (strcmp(op, "ldlt_warp_check") == 0) {
+        // CHECK path: prints factor (line 1), then "s_fail pos neg zero" (line 2).
+        int *d_fail, *d_inertia;
+        cudaMalloc(&d_fail, sizeof(int)); cudaMalloc(&d_inertia, 3*sizeof(int));
+#define MAC(N) k_ldlt_warp<N,true><<<1,threads>>>(dA, d_fail, d_inertia)
+        switch (n) { case 3:MAC(3);break; case 4:MAC(4);break; case 5:MAC(5);break;
+                     case 6:MAC(6);break; case 7:MAC(7);break; case 8:MAC(8);break;
+                     default: fprintf(stderr,"warp ldlt: n must be 3..8\n"); return 1; }
+#undef MAC
+        cudaDeviceSynchronize();
+        print_device_vec(dA, n * n);
+        int h_fail, h_in[3];
+        cudaMemcpy(&h_fail, d_fail, sizeof(int), cudaMemcpyDeviceToHost);
+        cudaMemcpy(h_in, d_inertia, 3*sizeof(int), cudaMemcpyDeviceToHost);
+        printf("%d %d %d %d\n", h_fail, h_in[0], h_in[1], h_in[2]);
+    } else if (strcmp(op, "ldlt_solve_warp") == 0) {
+        if (argc < 7) { fprintf(stderr, "ldlt_solve_warp needs <b.bin>\n"); return 1; }
+        float* db = read_device_vec(argv[6], n);
+#define MAC(N) k_ldlt_solve_warp<N><<<1,threads>>>(dA, db)
+        switch (n) { case 3:MAC(3);break; case 4:MAC(4);break; case 5:MAC(5);break;
+                     case 6:MAC(6);break; case 7:MAC(7);break; case 8:MAC(8);break;
+                     default: fprintf(stderr,"warp ldlt: n must be 3..8\n"); return 1; }
+#undef MAC
         cudaDeviceSynchronize();
         print_device_vec(db, n);
     } else {

--- a/test/cuda/test_nvidia_dispatch.cu
+++ b/test/cuda/test_nvidia_dispatch.cu
@@ -3,8 +3,8 @@
 // Companion to test_l3_nvidia.cu (which exercises the SIMT-only batched APIs).
 // This file targets the round-2 additions:
 //   * Gap A — glass::nvidia::gemv<>     auto-dispatches SIMT vs cuBLASDx
-//   * Gap B — row_strided_gemv<>        auto-dispatches; uses stride directly on SIMT
-//   * Gap C — row_strided_gemm<>        auto-dispatches; skips compact-pack on SIMT
+//   * Gap B — gemv_strided<>        auto-dispatches; uses stride directly on SIMT
+//   * Gap C — gemm_strided<>        auto-dispatches; skips compact-pack on SIMT
 //   * Gap D — gemm<T,...,col,row,col>   maps onto SIMT TRANSPOSE_B=true
 //   * print_dispatch<>                  query helper from query_simt.cuh
 //
@@ -58,7 +58,7 @@ __global__ void k_gemm_6x6x6_transb(float* A, float* B, float* C) {
 }
 
 __global__ void k_gemm_6x6x6_transb_simt(float* A, float* B, float* C) {
-    ::glass::gemm<float, 6, 6, 6, /*TRANSPOSE_B=*/true>(1.f, A, B, 0.f, C);
+    ::glass::gemm<float, 6, 6, 6, /*TA=*/false, /*TRANSPOSE_B=*/true>(1.f, A, B, 0.f, C);
 }
 
 __global__ void k_gemv_5x5(float* A, float* x, float* y) {
@@ -69,12 +69,12 @@ __global__ void k_gemv_5x5(float* A, float* x, float* y) {
 
 __global__ void k_strided_gemv_5x5_rs8(float* A, float* x, float* y) {
     // Gap B: SIMT uses stride directly, no smem packing.
-    glass::nvidia::row_strided_gemv<float, 5, 5, 8>(1.f, A, x, 0.f, y, nullptr);
+    glass::nvidia::gemv_strided<float, 5, 5, 8>(1.f, A, x, 0.f, y, nullptr);
 }
 
 __global__ void k_strided_gemm_6x6x6_rs8(float* A, float* B, float* C) {
     // Gap C: SIMT uses A_RS=8, B_RS=8 directly.
-    glass::nvidia::row_strided_gemm<float, 6, 6, 6, 8, 8>(1.f, A, B, 0.f, C, nullptr);
+    glass::nvidia::gemm_strided<float, 6, 6, 6, 8, 8>(1.f, A, B, 0.f, C, nullptr);
 }
 
 // ─── ops ────────────────────────────────────────────────────────────────────
@@ -108,7 +108,7 @@ static int op_gemm_cublas() {
     for (int i = 0; i < M*N; i++) A[i] = 0.01f * (i+1);
     for (int i = 0; i < N*K; i++) B[i] = 0.02f * (i+1);
     float *dA,*dB,*dC,*dCref;
-    constexpr size_t smemsz = glass::nvidia::gemm_smem_size<float, 16, 16, 16>();
+    constexpr size_t smemsz = glass::nvidia::gemm_scratch_bytes<float, 16, 16, 16>();
     constexpr uint32_t tc = glass::nvidia::gemm_threads<float, 16, 16, 16>();
     CUDA_CHECK(cudaMalloc(&dA, M*N*4)); CUDA_CHECK(cudaMalloc(&dB, N*K*4));
     CUDA_CHECK(cudaMalloc(&dC, M*K*4)); CUDA_CHECK(cudaMalloc(&dCref, M*K*4));

--- a/test/cuda/test_nvidia_f64.cu
+++ b/test/cuda/test_nvidia_f64.cu
@@ -59,18 +59,18 @@ template<int N> static void run(const char* op) {
     cudaMemcpy(db,hb,N*8,cudaMemcpyHostToDevice);
     int nout=N;
     if (!strcmp(op,"posv")) {
-        size_t sm=glass::nvidia::posv_smem_size<double,N,1,256>();
+        size_t sm=glass::nvidia::posv_scratch_bytes<double,N,1,256>();
         cudaFuncSetAttribute(k_posv<N>,cudaFuncAttributeMaxDynamicSharedMemorySize,(int)sm);
         k_posv<N><<<1,256,sm>>>(dA,db); cudaDeviceSynchronize();
         cudaMemcpy(hout,db,N*8,cudaMemcpyDeviceToHost); nout=N;
     } else if (!strcmp(op,"gemm")) {
-        size_t sm=glass::nvidia::gemm_smem_size<double,N,N,N>();
+        size_t sm=glass::nvidia::gemm_scratch_bytes<double,N,N,N>();
         int tb=(int)glass::nvidia::gemm_threads<double,N,N,N>();
         cudaFuncSetAttribute(k_gemm<N>,cudaFuncAttributeMaxDynamicSharedMemorySize,(int)sm);
         k_gemm<N><<<1,tb,sm>>>(dA,dB,dC); cudaDeviceSynchronize();
         cudaMemcpy(hout,dC,N*N*8,cudaMemcpyDeviceToHost); nout=N*N;
     } else { // gemv
-        size_t sm=glass::nvidia::gemv_smem_size<double,N,N>();
+        size_t sm=glass::nvidia::gemv_scratch_bytes<double,N,N>();
         int tb=(int)glass::nvidia::gemv_threads<double,N,N>();
         cudaFuncSetAttribute(k_gemv<N>,cudaFuncAttributeMaxDynamicSharedMemorySize,(int)sm);
         k_gemv<N><<<1,tb,sm>>>(dA,db,dC); cudaDeviceSynchronize();

--- a/test/cuda/test_pcg.cu
+++ b/test/cuda/test_pcg.cu
@@ -57,8 +57,7 @@ int main(int argc, char** argv) {
     size_t smem = 0;
 #define DISPATCH(SS_, KP_)                                                        \
     if (SS == SS_ && KP == KP_) {                                                 \
-        smem = (size_t)glass::pcg_smem_size<float, SS_, KP_>((uint32_t)threads) \
-               * sizeof(float);                                                   \
+        smem = (size_t)glass::pcg_scratch_bytes<float, SS_, KP_>((uint32_t)threads); \
         k_pcg_##SS_##_##KP_<<<1, threads, smem>>>(dx, dS, dPinv, db,              \
             max_iters, rel_tol, abs_tol, d_iters);                               \
     }

--- a/test/cuda/test_posv.cu
+++ b/test/cuda/test_posv.cu
@@ -32,6 +32,19 @@ __global__ void k_potrs_m(uint32_t n, uint32_t nrhs, const float* L, float* B) {
     glass::potrs<float>(n, nrhs, L, B);
 }
 
+// ─── flagged solves (compile-time N=7, NRHS=1) — REGULARIZE/CHECK/REG_DIAG ─────
+// b is an n×1 column-major B, so the single-RHS flagged solve is the multi-RHS
+// overload with NRHS=1. Block (thread-count invariant) + warp (single-warp).
+static constexpr uint32_t FN = 7;
+template <bool REG, bool CHK, bool DIAG>
+__global__ void k_posv_flag(float* A, float* b, float rho, int* s_fail) {
+    glass::posv<float, FN, 1, REG, CHK, DIAG>(A, b, rho, s_fail);
+}
+template <bool REG, bool CHK, bool DIAG>
+__global__ void k_posv_warp_flag(float* A, float* b, float rho, int* s_fail) {
+    glass::warp::posv<float, FN, 1, REG, CHK, DIAG>(A, b, rho, s_fail);
+}
+
 int main(int argc, char** argv) {
     if (argc < 6) {
         fprintf(stderr,
@@ -41,6 +54,39 @@ int main(int argc, char** argv) {
         return 1;
     }
     const char* op = argv[1];
+
+    // Flagged path: <flagop> <n=7> <threads> <A.bin> <b.bin> <rho>
+    //   prints x (length 7) on line 1 and s_fail (0/1) on line 2.
+    //   flagops: posv_reg / posv_regdiag / posv_check  (block)
+    //            posv_warp_reg / posv_warp_regdiag / posv_warp_check  (warp)
+    if (strncmp(op, "posv_reg", 8) == 0 || strncmp(op, "posv_check", 10) == 0 ||
+        strncmp(op, "posv_warp_", 10) == 0) {
+        if (argc < 7) { fprintf(stderr, "flagged needs <n=7> <threads> <A.bin> <b.bin> <rho>\n"); return 1; }
+        uint32_t n  = (uint32_t)atoi(argv[2]);
+        int THREADS = atoi(argv[3]);
+        if (n != FN) { fprintf(stderr, "flagged kernels are compiled for n=%u only\n", FN); return 1; }
+        float* dA = read_device_vec(argv[4], n * n);
+        float* db = read_device_vec(argv[5], n);
+        float rho = (float)atof(argv[6]);
+        int* d_fail; cudaMalloc(&d_fail, sizeof(int));
+        cudaMemset(d_fail, 0, sizeof(int));
+        bool warp = (strncmp(op, "posv_warp_", 10) == 0);
+        const char* tail = warp ? op + 10 : op + 5;   // strip "posv_warp_" / "posv_"
+        // tail ∈ {reg, regdiag, check}
+        if      (strcmp(tail, "reg") == 0)     { warp ? k_posv_warp_flag<true,false,false><<<1,THREADS>>>(dA,db,rho,d_fail)
+                                                      : k_posv_flag<true,false,false><<<1,THREADS>>>(dA,db,rho,d_fail); }
+        else if (strcmp(tail, "regdiag") == 0) { warp ? k_posv_warp_flag<true,false,true><<<1,THREADS>>>(dA,db,rho,d_fail)
+                                                      : k_posv_flag<true,false,true><<<1,THREADS>>>(dA,db,rho,d_fail); }
+        else if (strcmp(tail, "check") == 0)   { warp ? k_posv_warp_flag<false,true,false><<<1,THREADS>>>(dA,db,rho,d_fail)
+                                                      : k_posv_flag<false,true,false><<<1,THREADS>>>(dA,db,rho,d_fail); }
+        else { fprintf(stderr, "bad flag op '%s'\n", op); return 1; }
+        cudaDeviceSynchronize();
+        print_device_vec(db, n);
+        int h_fail = 0; cudaMemcpy(&h_fail, d_fail, sizeof(int), cudaMemcpyDeviceToHost);
+        printf("%d\n", h_fail);
+        cudaFree(d_fail);
+        return 0;
+    }
 
     // Multi-RHS path: posv_m / potrs_m take an extra <nrhs> arg before <threads>.
     if (strcmp(op, "posv_m") == 0 || strcmp(op, "potrs_m") == 0) {

--- a/test/cuda/test_qp.cu
+++ b/test/cuda/test_qp.cu
@@ -76,7 +76,7 @@ static int run(int n, int threads, int max_iter, double tol,
     T *dx = read_device_vec<T>(px0, n);
 
     T *dscratch, *dinfo;
-    cudaMalloc(&dscratch, glass::internal::box_qp_scratch_size<T>(n) * sizeof(T));
+    cudaMalloc(&dscratch, glass::internal::box_qp_scratch_bytes<T>(n));
     cudaMalloc(&dinfo, 3 * sizeof(T));
 
     run_box_qp<T><<<1, threads>>>(n, dP, dq, dl, du, dx, dscratch, dinfo,

--- a/test/cuda/test_reduced.cu
+++ b/test/cuda/test_reduced.cu
@@ -2,16 +2,18 @@
 // print float32 C. Validates the contraction-parallel engine vs the serial gemm
 // oracle and across thread counts.
 //
-// Usage:
-//   ./test_reduced <surface> <THREADS> <M> <N> <K> <TRANSPOSE_B> <ROW_MAJOR>
-//                  <alpha> <beta> <A.bin> <B.bin> <C.bin>
-//     surface     : block | warp | cgrps
-//     THREADS     : block thread count (launched as <<<1, THREADS>>>)
-//     M,N,K       : A is M*N, B is N*K (N*N when TRANSPOSE_B), C is M*(TRANSPOSE_B?N:K)
-//     TRANSPOSE_B : 0 | 1   (1 requires N == K)
-//     ROW_MAJOR   : 0 | 1
+// Standard BLAS convention: C is M×N, contraction K; op(A) is M×K (TRANSPOSE_A ⇒
+// A stored K×M), op(B) is K×N (TRANSPOSE_B ⇒ B stored N×K).
 //
-// Prints C (M * Ccols) on one line, where Ccols = TRANSPOSE_B ? N : K.
+// Usage:
+//   ./test_reduced <surface> <THREADS> <M> <N> <K> <TRANSPOSE_A> <TRANSPOSE_B>
+//                  <alpha> <beta> <A.bin> <B.bin> <C.bin>
+//     surface : block | warp | cgrps
+//     THREADS : block thread count (launched as <<<1, THREADS>>>)
+//     M,N,K   : C is M×N, contraction K (lanes split K — long K exercises the
+//               multi-iteration lane loop + the sub-warp register fallback)
+//
+// Prints C (M * N) on one line.
 
 #include <cstdio>
 #include <cstdlib>
@@ -26,50 +28,50 @@ enum { SURF_BLOCK = 0, SURF_WARP = 1, SURF_CGRPS = 2 };
 // has_beta selects the overload at runtime: true -> 4-arg (reads C, C = a*AB +
 // beta*C); false -> 3-arg (overwrites C, never reads it). The python harness
 // passes has_beta = (beta != 0) so beta=0 genuinely exercises the skip-C path.
-template <int SURF, uint32_t M, uint32_t N, uint32_t K, bool TB, bool RM>
+template <int SURF, uint32_t M, uint32_t N, uint32_t K, bool TA, bool TB>
 __global__ void k_reduced(float alpha, float* A, float* B, float beta, float* C, bool has_beta) {
     if (SURF == SURF_BLOCK) {
-        if (has_beta) glass::gemm_reduced<float, M, N, K, TB, RM>(alpha, A, B, beta, C);
-        else          glass::gemm_reduced<float, M, N, K, TB, RM>(alpha, A, B, C);
+        if (has_beta) glass::gemm_reduced<float, M, N, K, TA, TB>(alpha, A, B, beta, C);
+        else          glass::gemm_reduced<float, M, N, K, TA, TB>(alpha, A, B, C);
     } else if (SURF == SURF_WARP) {
-        if (has_beta) glass::warp::gemm_reduced<float, M, N, K, TB, RM>(alpha, A, B, beta, C);
-        else          glass::warp::gemm_reduced<float, M, N, K, TB, RM>(alpha, A, B, C);
+        if (has_beta) glass::warp::gemm_reduced<float, M, N, K, TA, TB>(alpha, A, B, beta, C);
+        else          glass::warp::gemm_reduced<float, M, N, K, TA, TB>(alpha, A, B, C);
     } else {
-        if (has_beta) glass::cgrps::gemm_reduced<float, M, N, K, TB, RM>(alpha, A, B, beta, C);
-        else          glass::cgrps::gemm_reduced<float, M, N, K, TB, RM>(alpha, A, B, C);
+        if (has_beta) glass::cgrps::gemm_reduced<float, M, N, K, TA, TB>(alpha, A, B, beta, C);
+        else          glass::cgrps::gemm_reduced<float, M, N, K, TA, TB>(alpha, A, B, C);
     }
 }
 
-template <uint32_t M, uint32_t N, uint32_t K, bool TB, bool RM>
+template <uint32_t M, uint32_t N, uint32_t K, bool TA, bool TB>
 static void launch(int surf, int threads, float alpha, float* dA, float* dB, float beta, float* dC, bool hb) {
-    if      (surf == SURF_BLOCK) k_reduced<SURF_BLOCK, M, N, K, TB, RM><<<1, threads>>>(alpha, dA, dB, beta, dC, hb);
-    else if (surf == SURF_WARP)  k_reduced<SURF_WARP,  M, N, K, TB, RM><<<1, threads>>>(alpha, dA, dB, beta, dC, hb);
-    else                         k_reduced<SURF_CGRPS, M, N, K, TB, RM><<<1, threads>>>(alpha, dA, dB, beta, dC, hb);
+    if      (surf == SURF_BLOCK) k_reduced<SURF_BLOCK, M, N, K, TA, TB><<<1, threads>>>(alpha, dA, dB, beta, dC, hb);
+    else if (surf == SURF_WARP)  k_reduced<SURF_WARP,  M, N, K, TA, TB><<<1, threads>>>(alpha, dA, dB, beta, dC, hb);
+    else                         k_reduced<SURF_CGRPS, M, N, K, TA, TB><<<1, threads>>>(alpha, dA, dB, beta, dC, hb);
 }
 
 template <uint32_t M, uint32_t N, uint32_t K>
-static bool launch_flags(int surf, int threads, bool tb, bool rm,
+static bool launch_flags(int surf, int threads, bool ta, bool tb,
                          float alpha, float* dA, float* dB, float beta, float* dC, bool hb) {
-    if (!tb && !rm)      launch<M, N, K, false, false>(surf, threads, alpha, dA, dB, beta, dC, hb);
-    else if (!tb && rm)  launch<M, N, K, false, true >(surf, threads, alpha, dA, dB, beta, dC, hb);
-    else if (tb && !rm)  launch<M, N, K, true,  false>(surf, threads, alpha, dA, dB, beta, dC, hb);
+    if (!ta && !tb)      launch<M, N, K, false, false>(surf, threads, alpha, dA, dB, beta, dC, hb);
+    else if (!ta && tb)  launch<M, N, K, false, true >(surf, threads, alpha, dA, dB, beta, dC, hb);
+    else if (ta && !tb)  launch<M, N, K, true,  false>(surf, threads, alpha, dA, dB, beta, dC, hb);
     else                 launch<M, N, K, true,  true >(surf, threads, alpha, dA, dB, beta, dC, hb);
     return true;
 }
 
 // Compile-time shapes the runner understands. Includes consumer dims (14/7/21),
-// partial-warp output counts, and contraction lengths spanning the 32 boundary
-// (N = 33, 64) to exercise the multi-iteration lane loop + register fallback.
+// partial-warp output counts, and CONTRACTION lengths spanning the 32 boundary
+// (K = 33, 64) to exercise the multi-iteration lane loop + register fallback.
 #define SHAPES(_) \
     _(1,1,1)   _(3,5,4)   _(5,3,6)   _(7,2,9)   _(8,8,8) \
-    _(14,14,14) _(21,21,21) _(14,21,7) _(21,14,21) _(7,14,7) \
-    _(2,33,2)  _(4,64,4)
+    _(14,14,14) _(21,21,21) _(14,7,21) _(21,21,14) _(7,7,14) \
+    _(2,2,33)  _(4,4,64)
 
 int main(int argc, char** argv) {
     if (argc < 13) {
         fprintf(stderr,
-            "Usage: %s <block|warp|cgrps> <THREADS> <M> <N> <K> <TRANSPOSE_B> "
-            "<ROW_MAJOR> <alpha> <beta> <A.bin> <B.bin> <C.bin>\n", argv[0]);
+            "Usage: %s <block|warp|cgrps> <THREADS> <M> <N> <K> <TRANSPOSE_A> "
+            "<TRANSPOSE_B> <alpha> <beta> <A.bin> <B.bin> <C.bin>\n", argv[0]);
         return 1;
     }
     const char* surf_s = argv[1];
@@ -79,28 +81,26 @@ int main(int argc, char** argv) {
     uint32_t M   = (uint32_t)atoi(argv[3]);
     uint32_t N   = (uint32_t)atoi(argv[4]);
     uint32_t K   = (uint32_t)atoi(argv[5]);
-    bool tb      = atoi(argv[6]) != 0;
-    bool rm      = atoi(argv[7]) != 0;
+    bool ta      = atoi(argv[6]) != 0;
+    bool tb      = atoi(argv[7]) != 0;
     float alpha  = atof(argv[8]);
     float beta   = atof(argv[9]);
 
-    uint32_t Ccols = tb ? N : K;
-    uint32_t b_len = tb ? N * N : N * K;
-    float* dA = read_device_vec(argv[10], M * N);
-    float* dB = read_device_vec(argv[11], b_len);
-    float* dC = read_device_vec(argv[12], M * Ccols);
+    float* dA = read_device_vec(argv[10], M * K);   // op(A) is M×K
+    float* dB = read_device_vec(argv[11], K * N);   // op(B) is K×N
+    float* dC = read_device_vec(argv[12], M * N);
 
     bool has_beta = (beta != 0.0f);
     bool ok = false;
     #define DISPATCH(MM,NN,KK) \
         if (!ok && M==MM && N==NN && K==KK) \
-            ok = launch_flags<MM,NN,KK>(surf, threads, tb, rm, alpha, dA, dB, beta, dC, has_beta);
+            ok = launch_flags<MM,NN,KK>(surf, threads, ta, tb, alpha, dA, dB, beta, dC, has_beta);
     SHAPES(DISPATCH)
     #undef DISPATCH
 
     if (!ok) { fprintf(stderr, "unsupported shape %u %u %u\n", M, N, K); return 1; }
     cudaError_t err = cudaDeviceSynchronize();
     if (err != cudaSuccess) { fprintf(stderr, "kernel error: %s\n", cudaGetErrorString(err)); return 1; }
-    print_device_vec(dC, M * Ccols);
+    print_device_vec(dC, M * N);
     return 0;
 }

--- a/test/cuda/test_reduced_blas.cu
+++ b/test/cuda/test_reduced_blas.cu
@@ -2,8 +2,8 @@
 // (block / warp / cgrps) and print the float32 result.
 //
 // Usage:
-//   gemv <surface> <THREADS> <M> <N> <TRANS> <alpha> <beta> <A> <x> <y>  -> y (TRANS?N:M)
-//   syrk <surface> <THREADS> <ROWS> <COLS> <TRANS> <alpha> <beta> <A> <C> -> C (OUT*OUT)
+//   gemv <surface> <THREADS> <M> <N> <TRANSPOSE> <alpha> <beta> <A> <x> <y>  -> y (TRANSPOSE?N:M)
+//   syrk <surface> <THREADS> <ROWS> <COLS> <TRANSPOSE> <alpha> <beta> <A> <C> -> C (OUT*OUT)
 
 #include <cstdio>
 #include <cstdlib>

--- a/test/cuda/test_solve.cu
+++ b/test/cuda/test_solve.cu
@@ -32,6 +32,13 @@ __global__ void k_riccati(const float* P, const float* A, const float* B, const 
     glass::riccati_gain<float, NX, NU, REG>(P, A, B, R, K, st, rho, fail);
 }
 
+template <uint32_t NX, uint32_t NU, bool REG>
+__global__ void k_riccati_warp(const float* P, const float* A, const float* B, const float* R,
+                               float* K, float rho, int* fail) {
+    extern __shared__ float st[];
+    glass::warp::riccati_gain<float, NX, NU, REG>(P, A, B, R, K, st, rho, fail);
+}
+
 #define POSV_SHAPES(_) _(7,7) _(8,5) _(14,7) _(5,1) _(3,3) _(7,14)
 #define RIC_SHAPES(_)  _(14,7) _(8,4) _(6,3) _(10,5) _(4,2)
 
@@ -58,7 +65,8 @@ int main(int argc, char** argv) {
         int fail; cudaMemcpy(&fail,dFail,sizeof(int),cudaMemcpyDeviceToHost);
         printf("%d\n", fail);
         print_device_vec(dB, N*NRHS);
-    } else if (strcmp(op, "riccati") == 0) {
+    } else if (strcmp(op, "riccati") == 0 || strcmp(op, "riccati_warp") == 0) {
+        bool warp = (strcmp(op, "riccati_warp") == 0);
         uint32_t NX = atoi(argv[3]), NU = atoi(argv[4]); bool reg = atoi(argv[5]) != 0;
         float rho = atof(argv[6]);
         float* dP = read_device_vec(argv[7], NX*NX);
@@ -70,8 +78,10 @@ int main(int argc, char** argv) {
         bool ok = false;
         #define DR(XX,UU) if(!ok && NX==XX && NU==UU){ \
             int sm = glass::riccati_smem_count<XX,UU>()*sizeof(float); \
-            if(reg) k_riccati<XX,UU,true><<<1,th,sm>>>(dP,dA,dB,dR,dK,rho,dFail); \
-            else    k_riccati<XX,UU,false><<<1,th,sm>>>(dP,dA,dB,dR,dK,rho,dFail); ok=true; }
+            if(warp){ if(reg) k_riccati_warp<XX,UU,true><<<1,32,sm>>>(dP,dA,dB,dR,dK,rho,dFail); \
+                      else    k_riccati_warp<XX,UU,false><<<1,32,sm>>>(dP,dA,dB,dR,dK,rho,dFail); } \
+            else    { if(reg) k_riccati<XX,UU,true><<<1,th,sm>>>(dP,dA,dB,dR,dK,rho,dFail); \
+                      else    k_riccati<XX,UU,false><<<1,th,sm>>>(dP,dA,dB,dR,dK,rho,dFail); } ok=true; }
         RIC_SHAPES(DR)
         #undef DR
         if(!ok){fprintf(stderr,"bad riccati shape\n");return 1;}

--- a/test/cuda/test_syrk.cu
+++ b/test/cuda/test_syrk.cu
@@ -1,13 +1,13 @@
 // test_syrk.cu — dispatch glass::syrk / glass::syr2k and print float32 C.
 //
 // Usage:
-//   ./test_syrk <op> <THREADS> <n> <k> <FILL> <TRANS> <ROW_MAJOR> <alpha> <beta> <A.bin> [<B.bin>] <C.bin>
+//   ./test_syrk <op> <THREADS> <n> <k> <FILL> <TRANSPOSE> <ROW_MAJOR> <alpha> <beta> <A.bin> [<B.bin>] <C.bin>
 //     op        : syrk | syr2k
 //     THREADS   : block thread count (launched as <<<1, THREADS>>>)
 //     FILL      : 0=Lower 1=Upper 2=Full
-//     TRANS     : 0 | 1
+//     TRANSPOSE     : 0 | 1
 //     ROW_MAJOR : 0 | 1
-//   syrk  : A is n*k (TRANS=0) or k*n (TRANS=1); C is n*n. files: A C
+//   syrk  : A is n*k (TRANSPOSE=0) or k*n (TRANSPOSE=1); C is n*n. files: A C
 //   syr2k : same shapes for A and B; C is n*n.       files: A B C
 //
 // Prints C (n*n) on one line.
@@ -21,14 +21,24 @@
 #include "../../glass.cuh"
 
 // ─── syrk kernel (runtime n,k; flags as template params) ─────────────────────
-template <glass::FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <glass::FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __global__ void k_syrk(uint32_t n, uint32_t k, float alpha, float* A, float beta, float* C) {
-    glass::syrk<float, FILL, TRANS, ROW_MAJOR>(n, k, alpha, A, beta, C);
+    glass::syrk<float, FILL, TRANSPOSE, ROW_MAJOR>(n, k, alpha, A, beta, C);
 }
 
-template <glass::FillMode FILL, bool TRANS, bool ROW_MAJOR>
+template <glass::FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
 __global__ void k_syr2k(uint32_t n, uint32_t k, float alpha, float* A, float* B, float beta, float* C) {
-    glass::syr2k<float, FILL, TRANS, ROW_MAJOR>(n, k, alpha, A, B, beta, C);
+    glass::syr2k<float, FILL, TRANSPOSE, ROW_MAJOR>(n, k, alpha, A, B, beta, C);
+}
+
+// ─── warp forms (compile-time N,K; one 32-lane warp) ─────────────────────────
+template <uint32_t N, uint32_t K, glass::FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
+__global__ void k_syrk_warp(float alpha, float* A, float beta, float* C) {
+    glass::warp::syrk<float, N, K, FILL, TRANSPOSE, ROW_MAJOR>(alpha, A, beta, C);
+}
+template <uint32_t N, uint32_t K, glass::FillMode FILL, bool TRANSPOSE, bool ROW_MAJOR>
+__global__ void k_syr2k_warp(float alpha, float* A, float* B, float beta, float* C) {
+    glass::warp::syr2k<float, N, K, FILL, TRANSPOSE, ROW_MAJOR>(alpha, A, B, beta, C);
 }
 
 // ─── flag dispatch: select template instantiation from runtime ints ──────────
@@ -55,10 +65,21 @@ static glass::FillMode fill_of(int f) {
     MACRO(glass::FillMode::Full,  false, false) MACRO(glass::FillMode::Full,  false, true)        \
     MACRO(glass::FillMode::Full,  true,  false) MACRO(glass::FillMode::Full,  true,  true)
 
+// warp dispatch: compile-time (N,K) from a fixed set, always one 32-lane warp.
+#define WSHAPES(KER, FE, TR, RM, ...)                                              \
+    if      (n==4 && k==6) KER<4,6,FE,TR,RM><<<1,32>>>(__VA_ARGS__);               \
+    else if (n==6 && k==4) KER<6,4,FE,TR,RM><<<1,32>>>(__VA_ARGS__);               \
+    else if (n==7 && k==6) KER<7,6,FE,TR,RM><<<1,32>>>(__VA_ARGS__);               \
+    else { fprintf(stderr,"warp shape n=%u k=%u unsupported (use 4x6,6x4,7x6)\n",n,k); return 1; }
+#define SYRKW_CASE(FE, TR, RM)                                                      \
+    if (fill==FE && trans==(TR) && rowmajor==(RM)) { WSHAPES(k_syrk_warp,FE,TR,RM,alpha,dA,beta,dC);  dispatched=true; }
+#define SYR2KW_CASE(FE, TR, RM)                                                     \
+    if (fill==FE && trans==(TR) && rowmajor==(RM)) { WSHAPES(k_syr2k_warp,FE,TR,RM,alpha,dA,dB,beta,dC); dispatched=true; }
+
 int main(int argc, char** argv) {
     if (argc < 11) {
         fprintf(stderr,
-            "Usage: %s <syrk|syr2k> <THREADS> <n> <k> <FILL> <TRANS> <ROW_MAJOR> "
+            "Usage: %s <syrk|syr2k> <THREADS> <n> <k> <FILL> <TRANSPOSE> <ROW_MAJOR> "
             "<alpha> <beta> <A.bin> [<B.bin>] <C.bin>\n", argv[0]);
         return 1;
     }
@@ -72,13 +93,14 @@ int main(int argc, char** argv) {
     float alpha    = atof(argv[8]);
     float beta     = atof(argv[9]);
 
-    bool is2 = (strcmp(op, "syr2k") == 0);
+    bool is2  = (strcmp(op, "syr2k") == 0 || strcmp(op, "syr2k_warp") == 0);
+    bool warp = (strstr(op, "_warp") != nullptr);
     bool dispatched = false;
 
     if (!is2) {
         float* dA = read_device_vec(argv[10], n * k);
         float* dC = read_device_vec(argv[11], n * n);
-        FOR_ALL_FLAGS(SYRK_CASE)
+        if (warp) { FOR_ALL_FLAGS(SYRKW_CASE) } else { FOR_ALL_FLAGS(SYRK_CASE) }
         if (!dispatched) { fprintf(stderr, "bad flags\n"); return 1; }
         cudaDeviceSynchronize();
         print_device_vec(dC, n * n);
@@ -86,7 +108,7 @@ int main(int argc, char** argv) {
         float* dA = read_device_vec(argv[10], n * k);
         float* dB = read_device_vec(argv[11], n * k);
         float* dC = read_device_vec(argv[12], n * n);
-        FOR_ALL_FLAGS(SYR2K_CASE)
+        if (warp) { FOR_ALL_FLAGS(SYR2KW_CASE) } else { FOR_ALL_FLAGS(SYR2K_CASE) }
         if (!dispatched) { fprintf(stderr, "bad flags\n"); return 1; }
         cudaDeviceSynchronize();
         print_device_vec(dC, n * n);

--- a/test/cuda/test_trailing_sync.cu
+++ b/test/cuda/test_trailing_sync.cu
@@ -242,7 +242,7 @@ static int op_l3_cublasdx_gemm()
     CUDA_CHECK(cudaMemcpy(dA, hA.data(), M*N*sizeof(float), cudaMemcpyHostToDevice));
     CUDA_CHECK(cudaMemcpy(dB, hB.data(), N*K*sizeof(float), cudaMemcpyHostToDevice));
 
-    auto smem_bytes = glass::nvidia::gemm_smem_size<float, M, N, K>();
+    auto smem_bytes = glass::nvidia::gemm_scratch_bytes<float, M, N, K>();
     auto threads    = glass::nvidia::gemm_threads<float, M, N, K>();
 
     k_l3_cublasdx_gemm<true ><<<1, threads, smem_bytes>>>(dA, dB, dC_t); CUDA_CHECK(cudaDeviceSynchronize());

--- a/test/cuda/test_trsv.cu
+++ b/test/cuda/test_trsv.cu
@@ -15,16 +15,16 @@
 #include "../../glass.cuh"
 
 // ── trsv kernels (templated over the 3 flags) ─────────────────────────────────
-template <bool LOWER, bool UNIT, bool TRANS>
+template <bool LOWER, bool UNIT, bool TRANSPOSE>
 __global__ void k_trsv(uint32_t n, const float* A, float* x) {
-    glass::trsv<float, LOWER, UNIT, TRANS>(n, A, x);
+    glass::trsv<float, LOWER, UNIT, TRANSPOSE>(n, A, x);
 }
 
 // ── trmv in-place kernels (templated over the 3 flags) ────────────────────────
-template <bool LOWER, bool UNIT, bool TRANS>
+template <bool LOWER, bool UNIT, bool TRANSPOSE>
 __global__ void k_trmv(uint32_t n, const float* A, float* x) {
     extern __shared__ float scratch[];
-    glass::trmv<float, LOWER, UNIT, TRANS>(n, A, x, scratch);
+    glass::trmv<float, LOWER, UNIT, TRANSPOSE>(n, A, x, scratch);
 }
 
 int main(int argc, char** argv) {

--- a/test/cuda/test_warp.cu
+++ b/test/cuda/test_warp.cu
@@ -68,10 +68,10 @@ __global__ void k_scal_warp(int n, int W, float alpha, float* x) {
 
 // ─── L3 trsv (flagged) + posv kernels (compile-time N; __restrict__ params) ──
 #define DEFINE_TRI_KERNEL(Nc)                                                              \
-    template <bool LOWER, bool UNIT, bool TRANS>                                           \
+    template <bool LOWER, bool UNIT, bool TRANSPOSE>                                           \
     __global__ void k_trsv_warp_##Nc(int W, float* __restrict__ A, float* __restrict__ b){\
         int w = threadIdx.y; if (w >= W) return;                                          \
-        glass::warp::trsv<float, Nc, LOWER, UNIT, TRANS>(A + w*Nc*Nc, b + w*Nc);          \
+        glass::warp::trsv<float, Nc, LOWER, UNIT, TRANSPOSE>(A + w*Nc*Nc, b + w*Nc);          \
     }                                                                                       \
     __global__ void k_posv_warp_##Nc(int W, float* __restrict__ A, float* __restrict__ b){\
         int w = threadIdx.y; if (w >= W) return;                                          \

--- a/test/test_block_access.py
+++ b/test/test_block_access.py
@@ -1,0 +1,164 @@
+"""store_block / load_block — dense d×d ↔ [L|D|R] strip movers (Phase F).
+
+Replaces GATO's hand-rolled Schur remap loops. The index map (verified against
+bdmv.cuh's row-major strip and GATO schur_linsys.cuh):
+    strip[y*band_width + slot*d + x] = scale * src[(TRANSPOSE? x*d+y : y*d+x)]
+with band_width = 3*d, slots LEFT=0 / MAIN=1 / RIGHT=2.
+
+Each (y,x) is written once (no reduction) → byte-identical across the full thread
+sweep. Warp forms validated at one 32-lane warp.
+"""
+
+import os
+import subprocess
+import tempfile
+
+import numpy as np
+import pytest
+
+from conftest import THREAD_SWEEP
+
+WARP = 32
+DIMS = [3, 6, 7]
+SLOTS = [0, 1, 2]  # LEFT, MAIN, RIGHT
+
+
+def _write(arr):
+    f = tempfile.NamedTemporaryFile(suffix=".bin", delete=False)
+    np.asarray(arr, dtype=np.float32).tofile(f)
+    f.close()
+    return f.name
+
+
+def _run(bins, args):
+    cmd = [str(bins["block_access"])] + [str(a) for a in args]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        raise RuntimeError(f"runner failed:\n{res.stderr}")
+    return np.fromstring(res.stdout.strip(), sep=" ").astype(np.float32)
+
+
+def _expected_strip(src, d, slot, transpose, scale):
+    bw = 3 * d
+    out = np.zeros((d, bw), dtype=np.float32)
+    for k in range(d * d):
+        x, y = k % d, k // d
+        out[y, slot * d + x] = scale * src[(x * d + y) if transpose else (y * d + x)]
+    return out.ravel()
+
+
+def _expected_dense(strip, d, slot, transpose, scale):
+    bw = 3 * d
+    s = strip.reshape(d, bw)
+    out = np.zeros(d * d, dtype=np.float32)
+    for k in range(d * d):
+        x, y = k % d, k // d
+        out[(x * d + y) if transpose else (y * d + x)] = scale * s[y, slot * d + x]
+    return out
+
+
+@pytest.mark.parametrize("d", DIMS)
+@pytest.mark.parametrize("slot", SLOTS)
+@pytest.mark.parametrize("transpose", [0, 1])
+@pytest.mark.parametrize("scale", [1.0, -1.0])
+def test_store_block_sweep(bins, d, slot, transpose, scale):
+    """store_block matches the index-map oracle and is byte-identical across the sweep."""
+    src = (np.arange(d * d, dtype=np.float32) + 1.0)
+    sf = _write(src)
+    try:
+        expected = _expected_strip(src, d, slot, transpose, scale)
+        ref = None
+        for t in THREAD_SWEEP:
+            out = _run(bins, ["store", t, d, slot, transpose, scale, sf])
+            assert np.allclose(out, expected, atol=1e-6), f"d={d} slot={slot} tr={transpose} t={t}"
+            if ref is None:
+                ref = out
+            else:
+                assert np.array_equal(out, ref), f"d={d} t={t}: non-invariant"
+    finally:
+        os.unlink(sf)
+
+
+@pytest.mark.parametrize("d", DIMS)
+@pytest.mark.parametrize("slot", SLOTS)
+@pytest.mark.parametrize("transpose", [0, 1])
+def test_load_block_sweep(bins, d, slot, transpose):
+    """load_block (strip → dense) matches the oracle, byte-identical across the sweep."""
+    bw = 3 * d
+    rng = np.random.default_rng(d * 10 + slot)
+    strip = rng.standard_normal(d * bw).astype(np.float32)
+    sf = _write(strip)
+    scale = -1.0 if (slot == 1) else 1.0
+    try:
+        expected = _expected_dense(strip, d, slot, transpose, scale)
+        ref = None
+        for t in THREAD_SWEEP:
+            out = _run(bins, ["load", t, d, slot, transpose, scale, sf])
+            assert np.allclose(out, expected, atol=1e-6), f"d={d} slot={slot} tr={transpose} t={t}"
+            if ref is None:
+                ref = out
+            else:
+                assert np.array_equal(out, ref), f"d={d} t={t}: non-invariant"
+    finally:
+        os.unlink(sf)
+
+
+@pytest.mark.parametrize("d", DIMS)
+@pytest.mark.parametrize("slot", SLOTS)
+def test_roundtrip_identity(bins, d, slot):
+    """load_block ∘ store_block == identity (same TRANSPOSE, scale 1)."""
+    src = np.random.default_rng(d).standard_normal(d * d).astype(np.float32)
+    sf = _write(src)
+    try:
+        strip = _run(bins, ["store", 64, d, slot, 0, 1.0, sf])
+        stf = _write(strip)
+        try:
+            back = _run(bins, ["load", 64, d, slot, 0, 1.0, stf])
+            assert np.allclose(back, src, atol=1e-6)
+        finally:
+            os.unlink(stf)
+    finally:
+        os.unlink(sf)
+
+
+@pytest.mark.parametrize("d", DIMS)
+@pytest.mark.parametrize("slot", SLOTS)
+@pytest.mark.parametrize("transpose", [0, 1])
+@pytest.mark.parametrize("op", ["store", "load"])
+def test_warp_matches_block(bins, op, d, slot, transpose):
+    """Warp store/load_block == block form at one warp."""
+    bw = 3 * d
+    rng = np.random.default_rng(100 + d + slot)
+    n_in = d * bw if op == "load" else d * d
+    src = rng.standard_normal(n_in).astype(np.float32)
+    sf = _write(src)
+    scale = -1.0
+    try:
+        block = _run(bins, [op, 64, d, slot, transpose, scale, sf])
+        warp = _run(bins, [op + "_warp", WARP, d, slot, transpose, scale, sf])
+        assert np.array_equal(block, warp), f"{op} d={d} slot={slot} tr={transpose}: warp != block"
+    finally:
+        os.unlink(sf)
+
+
+def test_gato_schur_patterns(bins):
+    """The exact GATO patterns: phi_kᵀ (direct), phi_k (transpose), theta negate.
+    d=STATE_SIZE arbitrary here (7); mirrors schur_linsys.cuh's three writes."""
+    d = 7
+    src = np.random.default_rng(0).standard_normal(d * d).astype(np.float32)
+    sf = _write(src)
+    try:
+        # phi_kᵀ → RIGHT slot, direct
+        right = _run(bins, ["store", 33, d, 2, 0, 1.0, sf]).reshape(d, 3 * d)
+        # phi_k → LEFT slot, transpose
+        left = _run(bins, ["store", 33, d, 0, 1, 1.0, sf]).reshape(d, 3 * d)
+        # -theta → MAIN slot, transpose + negate
+        main = _run(bins, ["store", 33, d, 1, 1, -1.0, sf]).reshape(d, 3 * d)
+        # rtol covers the harness's %.8g text round-trip (device values are exact).
+        for y in range(d):
+            for x in range(d):
+                assert np.isclose(right[y, 2 * d + x], src[y * d + x], rtol=1e-6, atol=1e-7)
+                assert np.isclose(left[y, x], src[x * d + y], rtol=1e-6, atol=1e-7)
+                assert np.isclose(main[y, d + x], -src[x * d + y], rtol=1e-6, atol=1e-7)
+    finally:
+        os.unlink(sf)

--- a/test/test_congruence.py
+++ b/test/test_congruence.py
@@ -109,3 +109,36 @@ def test_bilinear_thread_invariance(bins, N, P, Qd):
     outs = [_bil(bins["congruence"], "block", t, N, P, Qd, True, X, M, Y, R0.copy()) for t in THREADS_SWEEP]
     for t, r in zip(THREADS_SWEEP[1:], outs[1:]):
         assert np.array_equal(outs[0], r), f"thread-count non-invariance at {t}"
+
+
+# ─── congruence_accum: C = alpha G M Gᵀ + beta C  (G is P×Q; GATO B·R⁻¹·Bᵀ) ───
+CACC = [(5, 3), (14, 7), (7, 7), (8, 4), (6, 5), (3, 3)]
+
+
+def _cacc(binary, surf, th, P, Q, acc, G, M, C):
+    return _run(binary, ["cacc", surf, str(th), str(P), str(Q), str(int(acc)), str(ALPHA), str(BETA)],
+                [G, M, C], P, P)
+
+
+@pytest.mark.parametrize("P,Q", CACC)
+@pytest.mark.parametrize("acc", [False, True])
+def test_congruence_accum(bins, P, Q, acc):
+    G = RNG.random((P, Q)).astype(np.float32)
+    M = _sym(Q)
+    C0 = _sym(P)
+    expected = (ALPHA * (G @ M @ G.T) + (BETA * C0 if acc else 0)).astype(np.float32)
+    block = _cacc(bins["congruence"], "block", 128, P, Q, acc, G, M, C0.copy())
+    assert np.allclose(block, expected, rtol=RTOL, atol=ATOL), f"\n{block}\nvs\n{expected}"
+    assert np.allclose(block, block.T, rtol=1e-4, atol=1e-5), "C not symmetric"
+    r = _cacc(bins["congruence"], "warp", 32, P, Q, acc, G, M, C0.copy())
+    assert np.allclose(r, block, rtol=RTOL, atol=ATOL), "warp disagrees with block"
+
+
+@pytest.mark.parametrize("P,Q", [(14, 7), (8, 4), (5, 3)])
+def test_congruence_accum_thread_invariance(bins, P, Q):
+    G = RNG.random((P, Q)).astype(np.float32)
+    M = _sym(Q)
+    C0 = _sym(P)
+    outs = [_cacc(bins["congruence"], "block", t, P, Q, True, G, M, C0.copy()) for t in THREADS_SWEEP]
+    for t, r in zip(THREADS_SWEEP[1:], outs[1:]):
+        assert np.array_equal(outs[0], r), f"thread-count non-invariance at {t}"

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,0 +1,53 @@
+"""Smoke test: every pure-SIMT example in examples/ compiles and runs (exit 0).
+
+Keeps the worked examples (which document the standard BLAS/Eigen GEMM
+convention, `row-major == transpose`, nrm2, strided GEMM, …) from bit-rotting as
+the API evolves. The host-verified examples return non-zero on a numeric
+mismatch, so a clean exit is a real correctness check, not just "it linked".
+
+The one MathDx/cuBLASDx example (06_nvidia_gemm) is skipped unless MATHDX_ROOT is
+present, mirroring how conftest gates the nvidia binaries.
+"""
+
+import os
+import pathlib
+import subprocess
+
+import pytest
+
+from conftest import GLASS_DIR, CUDA_ARCH
+
+EXAMPLES_DIR = GLASS_DIR / "examples"
+
+# Pure-SIMT examples (no MathDx). 06_nvidia_gemm is handled separately.
+SIMT_EXAMPLES = sorted(
+    p.name for p in EXAMPLES_DIR.glob("*.cu") if not p.name.startswith("06_")
+)
+
+
+def _compile_and_run(tmp_path, src_name, extra_flags=None):
+    src = EXAMPLES_DIR / src_name
+    out = tmp_path / (src.stem)
+    cmd = ["nvcc", "-std=c++17", f"-arch={CUDA_ARCH}", "-I", str(GLASS_DIR),
+           str(src), "-o", str(out)] + (extra_flags or [])
+    cp = subprocess.run(cmd, capture_output=True, text=True)
+    if cp.returncode != 0:
+        pytest.fail(f"compile failed for {src_name}:\n{cp.stderr}")
+    rp = subprocess.run([str(out)], capture_output=True, text=True)
+    assert rp.returncode == 0, f"{src_name} exited {rp.returncode}:\n{rp.stdout}\n{rp.stderr}"
+
+
+@pytest.mark.parametrize("src_name", SIMT_EXAMPLES)
+def test_simt_example(tmp_path, src_name):
+    _compile_and_run(tmp_path, src_name)
+
+
+def test_nvidia_example(tmp_path):
+    mathdx = os.environ.get("MATHDX_ROOT")
+    if not (mathdx and (pathlib.Path(mathdx) / "include" / "cublasdx.hpp").exists()):
+        pytest.skip("06_nvidia_gemm needs MATHDX_ROOT (cuBLASDx)")
+    _compile_and_run(tmp_path, "06_nvidia_gemm.cu", extra_flags=[
+        "--expt-relaxed-constexpr", "-DGLASS_BENCH_CUBLASDX", "-DSMS=860",
+        "-I", str(pathlib.Path(mathdx) / "include"),
+        "-I", str(pathlib.Path(mathdx) / "external" / "cutlass" / "include"),
+    ])

--- a/test/test_fused.py
+++ b/test/test_fused.py
@@ -12,6 +12,8 @@ import tempfile
 import numpy as np
 import pytest
 
+from conftest import make_spd  # shared; pass rng=RNG for varied draws
+
 RNG = np.random.default_rng(7)
 
 RTOL = 1e-2
@@ -30,11 +32,6 @@ CASES = [
     (3, [12, 12, 6]),
     (5, [8, 3, 8, 2, 5]),
 ]
-
-
-def make_spd(n):
-    A = RNG.random((n, n)).astype(np.float32)
-    return (A @ A.T + n * np.eye(n, dtype=np.float32)).astype(np.float32)
 
 
 def _aug(M, d):
@@ -78,7 +75,7 @@ def fused_bin(bins):
 @pytest.mark.parametrize("K,dims", CASES)
 @pytest.mark.parametrize("threads", THREAD_SWEEP)
 def test_fused_inv(fused_bin, K, dims, threads):
-    mats = [make_spd(d) for d in dims]
+    mats = [make_spd(d, rng=RNG) for d in dims]
     inputs = [_aug(M, d) for M, d in zip(mats, dims)]
     res = _run(fused_bin, "inv", threads, dims, inputs)
     assert len(res) == K
@@ -92,7 +89,7 @@ def test_fused_inv(fused_bin, K, dims, threads):
 @pytest.mark.parametrize("K,dims", CASES)
 @pytest.mark.parametrize("threads", THREAD_SWEEP)
 def test_fused_chol(fused_bin, K, dims, threads):
-    mats = [make_spd(d) for d in dims]
+    mats = [make_spd(d, rng=RNG) for d in dims]
     inputs = [np.asfortranarray(M).ravel(order="F") for M in mats]
     res = _run(fused_bin, "chol", threads, dims, inputs)
     assert len(res) == K

--- a/test/test_l1.py
+++ b/test/test_l1.py
@@ -128,13 +128,13 @@ def test_reduce_partial_warp(bins, n):
     assert np.allclose(float(result[0]), expected, rtol=1e-3, atol=1e-4)
 
 
-# ─── l2norm ───────────────────────────────────────────────────────────────────
+# ─── nrm2 ───────────────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("n", SIZES)
 @pytest.mark.parametrize("version", CG_LM_HS)
-def test_l2norm(bins, n, version):
+def test_nrm2(bins, n, version):
     x = RNG.random(n).astype(np.float32)
-    result = run_op(bins["l1"], "l2norm", version, args=[n], inputs=[x])
+    result = run_op(bins["l1"], "nrm2", version, args=[n], inputs=[x])
     expected = float(np.linalg.norm(x.astype(np.float64)))
     assert np.allclose(float(result[0]), expected, rtol=1e-3, atol=1e-4)
 

--- a/test/test_l1_round2.py
+++ b/test/test_l1_round2.py
@@ -1,0 +1,181 @@
+"""Round-2 L1 ops: nrm1_diff (‖x−y‖₁), warp norms (asum / nrm2), and the
+row-strided AXPY / COPY block movers.
+
+Thread discipline (see test_hardening_thread_sweep_2026-06-24.md):
+  • block elementwise / serial-tail ops  → full THREAD_SWEEP, byte-identical.
+  • block warp-shuffle reductions (nrm1_hs) → full sweep, oracle-close (the
+    reduction order varies with blockDim, so not byte-identical across counts).
+  • warp ops                              → exactly one 32-lane warp.
+Varied inputs: normal (mixed sign), mixed-magnitude (stresses the 1-norm/L2
+accumulation), and strictly-positive draws.
+"""
+
+import os
+import subprocess
+import tempfile
+
+import numpy as np
+import pytest
+
+from conftest import THREAD_SWEEP, make_vec
+
+RTOL, ATOL = 1e-4, 1e-4
+WARP = 32
+
+
+def _write(arr):
+    f = tempfile.NamedTemporaryFile(suffix=".bin", delete=False)
+    np.asarray(arr, dtype=np.float32).tofile(f)
+    f.close()
+    return f.name
+
+
+def _run(bins, args):
+    cmd = [str(bins["l1_round2"])] + [str(a) for a in args]
+    res = subprocess.run(cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        raise RuntimeError(f"runner failed:\n{res.stderr}")
+    return [np.fromstring(l, sep=" ").astype(np.float32)
+            for l in res.stdout.strip().split("\n") if l.strip()]
+
+
+# ─── nrm1_diff ────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("kind", ["normal", "mixed", "pos"])
+@pytest.mark.parametrize("n", [7, 20, 65])
+def test_nrm1_diff_lowmem(bins, n, kind):
+    """low_memory ‖x−y‖₁: oracle-correct and byte-identical across the full sweep."""
+    x, y = make_vec(n, seed=1, kind=kind), make_vec(n, seed=2, kind=kind)
+    xf, yf = _write(x), _write(y)
+    try:
+        expected = np.abs(x - y).sum()
+        ref = None
+        for t in THREAD_SWEEP:
+            out = _run(bins, ["nrm1_lm", t, n, xf, yf])[0][0]
+            assert np.allclose(out, expected, rtol=RTOL, atol=ATOL), f"t={t}: {out} vs {expected}"
+            if ref is None:
+                ref = out
+            else:
+                assert out == ref, f"t={t}: non-invariant ({out} vs {ref})"
+    finally:
+        os.unlink(xf); os.unlink(yf)
+
+
+@pytest.mark.parametrize("kind", ["normal", "mixed"])
+@pytest.mark.parametrize("n", [7, 20, 65])
+def test_nrm1_diff_highspeed(bins, n, kind):
+    """high_speed ‖x−y‖₁: oracle-correct across the full sweep (warp-shuffle reduce
+    order varies with blockDim → close, not byte-identical)."""
+    x, y = make_vec(n, seed=3, kind=kind), make_vec(n, seed=4, kind=kind)
+    xf, yf = _write(x), _write(y)
+    try:
+        expected = np.abs(x - y).sum()
+        for t in THREAD_SWEEP:
+            out = _run(bins, ["nrm1_hs", t, n, xf, yf])[0][0]
+            assert np.allclose(out, expected, rtol=1e-3, atol=1e-3), f"t={t}: {out} vs {expected}"
+    finally:
+        os.unlink(xf); os.unlink(yf)
+
+
+@pytest.mark.parametrize("kind", ["normal", "mixed", "pos"])
+@pytest.mark.parametrize("n", [7, 33, 65])
+def test_nrm1_diff_warp(bins, n, kind):
+    """warp ‖x−y‖₁ at one warp, matching the oracle."""
+    x, y = make_vec(n, seed=5, kind=kind), make_vec(n, seed=6, kind=kind)
+    xf, yf = _write(x), _write(y)
+    try:
+        out = _run(bins, ["nrm1_warp", WARP, n, xf, yf])[0][0]
+        assert np.allclose(out, np.abs(x - y).sum(), rtol=1e-3, atol=1e-3)
+    finally:
+        os.unlink(xf); os.unlink(yf)
+
+
+# ─── warp norms ───────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("kind", ["normal", "mixed", "pos"])
+@pytest.mark.parametrize("n", [7, 33, 65])
+def test_warp_asum(bins, n, kind):
+    x = make_vec(n, seed=7, kind=kind)
+    xf = _write(x)
+    try:
+        out = _run(bins, ["warp_asum", WARP, n, xf])[0][0]
+        assert np.allclose(out, np.abs(x).sum(), rtol=1e-3, atol=1e-3)
+    finally:
+        os.unlink(xf)
+
+
+@pytest.mark.parametrize("kind", ["normal", "mixed", "pos"])
+@pytest.mark.parametrize("n", [7, 33, 65])
+def test_warp_nrm2(bins, n, kind):
+    x = make_vec(n, seed=8, kind=kind)
+    xf = _write(x)
+    try:
+        out = _run(bins, ["warp_nrm2", WARP, n, xf])[0][0]
+        assert np.allclose(out, np.linalg.norm(x), rtol=1e-3, atol=1e-3)
+    finally:
+        os.unlink(xf)
+
+
+# ─── row-strided AXPY / COPY ──────────────────────────────────────────────────
+# Shapes match the harness table: 0=(14,14,21,14) PDDP, 1=(6,5,8,6), 2=(4,4,4,4).
+SHAPES = {0: (14, 14, 21, 14), 1: (6, 5, 8, 6), 2: (4, 4, 4, 4)}
+
+
+def _rs_io(shape_id, seed):
+    M, N, YRS, XRS = SHAPES[shape_id]
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((XRS, N)).astype(np.float32)
+    Y = rng.standard_normal((YRS, N)).astype(np.float32)
+    return M, N, YRS, XRS, X, Y
+
+
+@pytest.mark.parametrize("shape_id", [0, 1, 2])
+@pytest.mark.parametrize("op,copy", [("rsaxpy", False), ("rscopy", True)])
+def test_row_strided_block(bins, op, copy, shape_id):
+    """Block row-strided AXPY/COPY: oracle-correct, byte-identical across the full
+    sweep (each (r,c) written once → no reduction, exact invariance)."""
+    M, N, YRS, XRS, X, Y = _rs_io(shape_id, seed=10 + shape_id)
+    alpha = 0.5
+    expected = Y.copy()
+    if copy:
+        expected[:M, :N] = alpha * X[:M, :N]
+    else:
+        expected[:M, :N] += alpha * X[:M, :N]
+    Xf = _write(np.asfortranarray(X).ravel(order="F"))
+    try:
+        ref = None
+        for t in THREAD_SWEEP:
+            Yf = _write(np.asfortranarray(Y).ravel(order="F"))
+            try:
+                flat = _run(bins, [op, t, shape_id, alpha, Xf, Yf])[0]
+                got = flat.reshape((YRS, N), order="F")
+                assert np.allclose(got, expected, rtol=1e-5, atol=1e-5), f"{op} shape={shape_id} t={t}"
+                if ref is None:
+                    ref = flat
+                else:
+                    assert np.array_equal(flat, ref), f"{op} t={t}: non-invariant"
+            finally:
+                os.unlink(Yf)
+    finally:
+        os.unlink(Xf)
+
+
+@pytest.mark.parametrize("shape_id", [0, 1, 2])
+@pytest.mark.parametrize("op,copy", [("rsaxpy_warp", False), ("rscopy_warp", True)])
+def test_row_strided_warp(bins, op, copy, shape_id):
+    """Warp row-strided AXPY/COPY at one warp, matching the block/oracle."""
+    M, N, YRS, XRS, X, Y = _rs_io(shape_id, seed=20 + shape_id)
+    alpha = -1.5
+    expected = Y.copy()
+    if copy:
+        expected[:M, :N] = alpha * X[:M, :N]
+    else:
+        expected[:M, :N] += alpha * X[:M, :N]
+    Xf = _write(np.asfortranarray(X).ravel(order="F"))
+    Yf = _write(np.asfortranarray(Y).ravel(order="F"))
+    try:
+        flat = _run(bins, [op, WARP, shape_id, alpha, Xf, Yf])[0]
+        got = flat.reshape((YRS, N), order="F")
+        assert np.allclose(got, expected, rtol=1e-5, atol=1e-5), f"{op} shape={shape_id}"
+    finally:
+        os.unlink(Xf); os.unlink(Yf)

--- a/test/test_l2.py
+++ b/test/test_l2.py
@@ -65,21 +65,6 @@ def test_gemv_rowmajor(bins, m, n):
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-@pytest.mark.parametrize("m,n", [(8, 6), (12, 4), (16, 12)])
-def test_gemv_ex(bins, m, n):
-    """gemv_ex per-matrix flag (ROW_MAJOR_A=true) — same result as gemv_rowmajor."""
-    alpha, beta = 2.0, 0.5
-    A = RNG.random((m, n)).astype(np.float32)
-    x = RNG.random(n).astype(np.float32)
-    y = RNG.random(m).astype(np.float32)
-    y0 = y.copy()
-    result = run_op(bins["l2"], "gemv_ex", "simple",
-                    args=[m, n, alpha, beta],
-                    inputs=[A.ravel(), x, y])
-    expected = (alpha * A @ x + beta * y0).astype(np.float32)
-    assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
-
-
 # ─── gemv_strided ─────────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("alpha,beta", [(1.5, 0.3), (1.0, 0.0)])
@@ -104,7 +89,7 @@ def test_gemv_strided(bins, op, m, n, rs, alpha, beta):
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── segmented_row_strided_gemv ──────────────────────────────────────────────
+# ─── gemv_segmented ──────────────────────────────────────────────
 # `segments` independent 6x6 col-major (LDA=6) GEMVs computed concurrently.
 # Descriptor arrays give per-segment base element offsets into packed buffers.
 # numpy does each GEMV independently as the reference.
@@ -144,7 +129,7 @@ def _build_segmented(segments, m, n, rs, rng, with_S=False):
 
 @pytest.mark.parametrize("segments", [1, 3, 5])
 @pytest.mark.parametrize("alpha,beta", [(1.5, 0.3), (1.0, 0.0)])
-def test_segmented_row_strided_gemv_nofuse(bins, segments, alpha, beta):
+def test_gemv_segmented_nofuse(bins, segments, alpha, beta):
     m, n, rs = 6, 6, 6
     d = _build_segmented(segments, m, n, rs, RNG)
     y0 = d["y"].copy()
@@ -162,7 +147,7 @@ def test_segmented_row_strided_gemv_nofuse(bins, segments, alpha, beta):
 
 @pytest.mark.parametrize("segments", [1, 3, 5])
 @pytest.mark.parametrize("alpha,beta", [(1.5, 0.3), (1.0, 0.0)])
-def test_segmented_row_strided_gemv_fuse(bins, segments, alpha, beta):
+def test_gemv_segmented_fuse(bins, segments, alpha, beta):
     m, n, rs = 6, 6, 6
     d = _build_segmented(segments, m, n, rs, RNG, with_S=True)
     scalar = (RNG.random(segments) - 0.5).astype(np.float32)
@@ -181,14 +166,14 @@ def test_segmented_row_strided_gemv_fuse(bins, segments, alpha, beta):
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── segmented_row_strided_gemv: TRANSPOSE ───────────────────────────────────
+# ─── gemv_segmented: TRANSPOSE ───────────────────────────────────
 # Per segment y_seg(N) = alpha * Aᵀ_seg(N×M) * x_seg(M) + beta*y_seg(N).
 # A_seg is M×N col-major LDA=rs; the kernel binds M=6,N=4,ROW_STRIDE=6.
 # Segments keep DISJOINT y ranges (non-atomic), checked vs a per-segment Aᵀ·x.
 
 @pytest.mark.parametrize("segments", [1, 3, 5])
 @pytest.mark.parametrize("alpha,beta", [(1.5, 0.3), (1.0, 0.0)])
-def test_segmented_row_strided_gemv_transpose(bins, segments, alpha, beta):
+def test_gemv_segmented_transpose(bins, segments, alpha, beta):
     m, n, rs = 6, 4, 6
     A_list, x_list, y_list = [], [], []
     a_off, x_off, y_off = [], [], []
@@ -219,13 +204,13 @@ def test_segmented_row_strided_gemv_transpose(bins, segments, alpha, beta):
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── segmented_row_strided_gemv: ATOMIC_Y (overlapping y) ─────────────────────
+# ─── gemv_segmented: ATOMIC_Y (overlapping y) ─────────────────────
 # Per segment y_seg(M) += alpha * A_seg(M×N) * x_seg(N). Multiple segments share
 # the SAME y range (a parent), so the atomic path must SCATTER-ADD them. Caller
 # pre-zeros y; reference is a numpy scatter-add. M=6,N=6,rs=6.
 
 @pytest.mark.parametrize("alpha", [1.0, 1.5])
-def test_segmented_row_strided_gemv_atomic(bins, alpha):
+def test_gemv_segmented_atomic(bins, alpha):
     m, n, rs = 6, 6, 6
     # 3 parents, several child segments each accumulating into a shared parent.
     parent_of = [0, 1, 1, 2, 2, 2]   # seg -> parent index (overlap by design)
@@ -260,13 +245,13 @@ def test_segmented_row_strided_gemv_atomic(bins, alpha):
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── segmented_row_strided_gemv: TRANSPOSE + ATOMIC_Y (backward pass) ─────────
+# ─── gemv_segmented: TRANSPOSE + ATOMIC_Y (backward pass) ─────────
 # The leaf→root case: each child segment computes Aᵀ_seg·x_seg (the Xᵀ·f map)
 # and atomically accumulates it into a SHARED parent y range. M=6,N=6,rs=6 so
 # y_seg also has length 6 (square X). Reference is a transposed scatter-add.
 
 @pytest.mark.parametrize("alpha", [1.0, 1.5])
-def test_segmented_row_strided_gemv_transpose_atomic(bins, alpha):
+def test_gemv_segmented_transpose_atomic(bins, alpha):
     m, n, rs = 6, 6, 6
     parent_of = [0, 1, 1, 2, 2, 2]
     n_parents = 3

--- a/test/test_l3.py
+++ b/test/test_l3.py
@@ -1,8 +1,18 @@
-"""L3 GLASS function tests — compare GPU results to NumPy/SciPy reference."""
+"""L3 GLASS function tests — compare GPU results to NumPy/SciPy reference.
+
+GEMM uses the standard BLAS convention: C is M×N, contraction K;
+op(A) is M×K (TRANSPOSE_A ⇒ A stored K×M), op(B) is K×N (TRANSPOSE_B ⇒ B stored
+N×K), ROW_MAJOR_C selects row-major output. The test net is deliberately wide:
+non-square + all-distinct M,N,K (the contraction→last-dim convention swap is
+SILENT on square matrices), all four transpose combos, ROW_MAJOR_C, an
+alpha/beta grid, the beta=0 no-read (NaN-poison) overload, a row-major==transpose
+equivalence check, a hand-written triple-loop reference, and the thread sweep.
+"""
 
 import numpy as np
 import pytest
-from conftest import run_op
+from conftest import run_op, THREAD_SWEEP, THREAD_SWEEP_CORE
+from conftest import make_spd, make_lower_triangular  # shared; pass rng=RNG for varied draws
 
 # bin_l3_nvidia fixture is defined in conftest.py — re-import for pytest discovery.
 from conftest import bin_l3_nvidia  # noqa: F401
@@ -14,105 +24,209 @@ RTOL = 1e-3
 
 CG_SIMPLE = ["cg", "simple"]
 
-
-def make_spd(n):
-    """Generate a random n x n symmetric positive definite matrix."""
-    A = RNG.random((n, n)).astype(np.float32)
-    return (A @ A.T + n * np.eye(n, dtype=np.float32))
-
-
-def make_lower_triangular(n):
-    """Generate a random n x n lower triangular matrix with positive diagonal."""
-    L = np.tril(RNG.random((n, n)).astype(np.float32))
-    np.fill_diagonal(L, np.abs(L.diagonal()) + 0.5)
-    return L
+# ─── gemm shapes: deliberately non-square + all-distinct M,N,K + edge rows/cols ──
+GEMM_SHAPES = [
+    (1, 1, 1), (2, 3, 4), (4, 2, 3), (3, 4, 2), (5, 7, 3), (7, 5, 6),
+    (8, 1, 5), (1, 8, 5), (5, 8, 1), (6, 6, 6), (9, 4, 7), (16, 16, 16),
+]
+# Compile-time shape ids in test_l3.cu's ct_shape_dims() table.
+GEMM_CT_IDS = {0: (1, 1, 1), 1: (2, 3, 4), 2: (4, 2, 3), 3: (5, 7, 3),
+               4: (8, 1, 5), 5: (9, 4, 7), 6: (7, 5, 6), 7: (16, 16, 16)}
+TRANSPOSE_COMBOS = [(0, 0), (1, 0), (0, 1), (1, 1)]
 
 
-# ─── gemm ─────────────────────────────────────────────────────────────────────
+def _gemm_storage(m, n, k, ta, tb, seed):
+    """Return (opA, opB, A_flat, B_flat): the LOGICAL op(A) (m×k) and op(B) (k×n)
+    plus the PHYSICAL column-major storage the kernel reads. A row-major operand
+    is a transposed column-major operand, so TRANSPOSE stores op(_)ᵀ col-major."""
+    rng = np.random.default_rng(seed)
+    opA = rng.standard_normal((m, k)).astype(np.float32)
+    opB = rng.standard_normal((k, n)).astype(np.float32)
+    A_phys = opA.T if ta else opA          # (k×m) when transposed, else (m×k)
+    B_phys = opB.T if tb else opB          # (n×k) when transposed, else (k×n)
+    A_flat = np.asfortranarray(A_phys).ravel(order='F')
+    B_flat = np.asfortranarray(B_phys).ravel(order='F')
+    return opA, opB, A_flat, B_flat
 
-@pytest.mark.parametrize("m,n,k", [(4, 6, 5), (8, 8, 8), (12, 4, 6)])
+
+def _c_flat(C0, rmc):
+    return np.ascontiguousarray(C0).ravel() if rmc else np.asfortranarray(C0).ravel(order='F')
+
+
+def _decode(result, m, n, rmc):
+    return result.reshape(m, n) if rmc else result.reshape(m, n, order='F')
+
+
+def _gemm_ref_triple(alpha, opA, opB, beta, C0):
+    """Hand-written triple-loop reference, independent of numpy `@` — the
+    migration-safety net that would catch a wrong dim mapping even if `@` and the
+    kernel shared a bug."""
+    m, k = opA.shape
+    _, n = opB.shape
+    out = np.array(C0, dtype=np.float64)
+    for i in range(m):
+        for j in range(n):
+            s = 0.0
+            for t in range(k):
+                s += float(opA[i, t]) * float(opB[t, j])
+            out[i, j] = alpha * s + beta * float(C0[i, j])
+    return out.astype(np.float32)
+
+
+# ─── gemm: runtime, full shape × transpose × ROW_MAJOR_C matrix ────────────────
+
+@pytest.mark.parametrize("m,n,k", GEMM_SHAPES)
+@pytest.mark.parametrize("ta,tb", TRANSPOSE_COMBOS)
+@pytest.mark.parametrize("rmc", [0, 1])
 @pytest.mark.parametrize("version", CG_SIMPLE)
-def test_gemm(bins, m, n, k, version):
+def test_gemm_rt(bins, m, n, k, ta, tb, rmc, version):
+    """Runtime gemm across non-square shapes, all 4 transpose combos, both C
+    layouts, oracle = alpha*op(A)@op(B)+beta*C. Thread-invariant (byte-identical)
+    over the core sweep."""
     alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)
-    B = RNG.random((n, k)).astype(np.float32)
-    C = RNG.random((m, k)).astype(np.float32)
-    C0 = C.copy()
-    result = run_op(bins["l3"], "gemm", version,
-                    args=[m, n, k, alpha, beta],
-                    inputs=[np.asfortranarray(A).ravel(order='F'),
-                            np.asfortranarray(B).ravel(order='F'),
-                            np.asfortranarray(C).ravel(order='F')])
-    expected = (alpha * A @ B + beta * C0).astype(np.float32)
-    mat = result.reshape(m, k, order='F')
-    assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
+    seed = 1000 + m * 100 + n * 10 + k + ta * 3 + tb * 7 + rmc * 11
+    opA, opB, A_flat, B_flat = _gemm_storage(m, n, k, ta, tb, seed)
+    C0 = np.random.default_rng(seed + 1).standard_normal((m, n)).astype(np.float32)
+    expected = (alpha * (opA @ opB) + beta * C0).astype(np.float32)
+    ref = None
+    for th in THREAD_SWEEP_CORE:
+        result = run_op(bins["l3"], "gemm_rt", version,
+                        args=[th, m, n, k, ta, tb, rmc, 0, alpha, beta],
+                        inputs=[A_flat, B_flat, _c_flat(C0, rmc)])
+        got = _decode(result, m, n, rmc)
+        assert np.allclose(got, expected, rtol=RTOL, atol=ATOL), \
+            f"m,n,k={m},{n},{k} ta,tb={ta},{tb} rmc={rmc} th={th}"
+        if ref is None:
+            ref = result
+        else:
+            assert np.array_equal(result, ref), \
+                f"non-invariant: m,n,k={m},{n},{k} ta,tb={ta},{tb} rmc={rmc} th={th}"
 
 
-@pytest.mark.parametrize("m,n", [(4, 6), (8, 8)])
-@pytest.mark.parametrize("version", CG_SIMPLE)
-def test_gemm_t(bins, m, n, version):
-    # GLASS gemm_t computes C(m×n) = alpha * A(m×n) * B(n×n)^T + beta * C(m×n)
-    # B must be square n×n (this is how the GLASS coop-groups implementation works).
+@pytest.mark.parametrize("m,n,k", [(5, 7, 3), (7, 5, 6), (8, 1, 5), (9, 4, 7)])
+@pytest.mark.parametrize("ta,tb", TRANSPOSE_COMBOS)
+def test_gemm_rt_full_sweep(bins, m, n, k, ta, tb):
+    """Dedicated thread-invariance over the FULL sweep (1,7,31,32,33,57,64,96,128,256)
+    at representative non-square shapes — byte-identical at every block size."""
+    alpha, beta = -1.25, 0.5
+    seed = 2000 + m * 13 + n * 5 + k + ta + tb
+    opA, opB, A_flat, B_flat = _gemm_storage(m, n, k, ta, tb, seed)
+    C0 = np.random.default_rng(seed + 1).standard_normal((m, n)).astype(np.float32)
+    expected = (alpha * (opA @ opB) + beta * C0).astype(np.float32)
+    ref = None
+    for th in THREAD_SWEEP:
+        result = run_op(bins["l3"], "gemm_rt", "simple",
+                        args=[th, m, n, k, ta, tb, 0, 0, alpha, beta],
+                        inputs=[A_flat, B_flat, _c_flat(C0, 0)])
+        assert np.allclose(result.reshape(m, n, order='F'), expected, rtol=RTOL, atol=ATOL)
+        if ref is None:
+            ref = result
+        else:
+            assert np.array_equal(result, ref), f"non-invariant th={th}"
+
+
+@pytest.mark.parametrize("alpha,beta", [(1, 0), (1, 1), (0, 1), (1.5, 0.3), (-1.25, 0.5), (0, 0)])
+def test_gemm_rt_alpha_beta(bins, alpha, beta):
+    """alpha/beta grid at a non-square shape (beta!=0 reads C)."""
+    m, n, k = 5, 7, 3
+    opA, opB, A_flat, B_flat = _gemm_storage(m, n, k, 0, 0, seed=77)
+    C0 = np.random.default_rng(78).standard_normal((m, n)).astype(np.float32)
+    expected = (alpha * (opA @ opB) + beta * C0).astype(np.float32)
+    result = run_op(bins["l3"], "gemm_rt", "simple",
+                    args=[64, m, n, k, 0, 0, 0, 0, alpha, beta],
+                    inputs=[A_flat, B_flat, _c_flat(C0, 0)])
+    assert np.allclose(result.reshape(m, n, order='F'), expected, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("m,n,k", [(5, 7, 3), (8, 1, 5), (6, 6, 6)])
+@pytest.mark.parametrize("ta,tb", TRANSPOSE_COMBOS)
+def test_gemm_rt_beta0_no_read(bins, m, n, k, ta, tb):
+    """The no-beta overload (nb=1) must OVERWRITE C and never read it: a
+    NaN-poisoned C must not contaminate the result."""
+    alpha = 1.5
+    opA, opB, A_flat, B_flat = _gemm_storage(m, n, k, ta, tb, seed=303)
+    C_poison = np.full((m, n), np.nan, dtype=np.float32)
+    expected = (alpha * (opA @ opB)).astype(np.float32)
+    result = run_op(bins["l3"], "gemm_rt", "simple",
+                    args=[64, m, n, k, ta, tb, 0, 1, alpha, 0.0],
+                    inputs=[A_flat, B_flat, _c_flat(C_poison, 0)])
+    assert not np.any(np.isnan(result)), "beta=0 no-read overload read the NaN-poisoned C"
+    assert np.allclose(result.reshape(m, n, order='F'), expected, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("m,n,k", [(5, 7, 3), (8, 1, 5), (9, 4, 7)])
+def test_gemm_rowmajor_is_transpose(bins, m, n, k):
+    """Row-major == transpose, bit-for-bit: feeding op(A) as a row-major M×K buffer
+    (read with TRANSPOSE_A over its col-major K×M view) yields output IDENTICAL to
+    the plain col-major NN call. Proves pruning per-operand ROW_MAJOR is loss-free."""
+    rng = np.random.default_rng(404)
+    opA = rng.standard_normal((m, k)).astype(np.float32)
+    opB = rng.standard_normal((k, n)).astype(np.float32)
+    C0 = rng.standard_normal((m, n)).astype(np.float32)
+    alpha, beta = 1.3, 0.4
+    # Path 1: NN — A stored col-major (m×k).
+    A_nn = np.asfortranarray(opA).ravel(order='F')
+    r_nn = run_op(bins["l3"], "gemm_rt", "simple",
+                  args=[64, m, n, k, 0, 0, 0, 0, alpha, beta],
+                  inputs=[A_nn, np.asfortranarray(opB).ravel(order='F'), _c_flat(C0, 0)])
+    # Path 2: TA — same opA but stored row-major (== col-major (k×m)), read transposed.
+    A_ta = np.ascontiguousarray(opA).ravel()        # row-major M×K bytes
+    r_ta = run_op(bins["l3"], "gemm_rt", "simple",
+                  args=[64, m, n, k, 1, 0, 0, 0, alpha, beta],
+                  inputs=[A_ta, np.asfortranarray(opB).ravel(order='F'), _c_flat(C0, 0)])
+    assert np.array_equal(r_nn, r_ta), "row-major-via-transpose differs from col-major NN"
+
+
+# ─── gemm: compile-time (magic-multiply) path + hand-written reference ─────────
+
+@pytest.mark.parametrize("shape_id", list(GEMM_CT_IDS.keys()))
+@pytest.mark.parametrize("ta,tb", TRANSPOSE_COMBOS)
+def test_gemm_ct(bins, shape_id, ta, tb):
+    """Compile-time-size gemm across the non-square shape table, all transpose
+    combos, vs a hand-written triple-loop reference; thread-invariant."""
+    m, n, k = GEMM_CT_IDS[shape_id]
     alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)
-    B = RNG.random((n, n)).astype(np.float32)
-    C = RNG.random((m, n)).astype(np.float32)
-    C0 = C.copy()
-    result = run_op(bins["l3"], "gemm_t", version,
-                    args=[m, n, n, alpha, beta],
-                    inputs=[np.asfortranarray(A).ravel(order='F'),
-                            np.asfortranarray(B).ravel(order='F'),
-                            np.asfortranarray(C).ravel(order='F')])
-    expected = (alpha * A @ B.T + beta * C0).astype(np.float32)
-    mat = result.reshape(m, n, order='F')
-    assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
+    opA, opB, A_flat, B_flat = _gemm_storage(m, n, k, ta, tb, seed=500 + shape_id)
+    C0 = np.random.default_rng(600 + shape_id).standard_normal((m, n)).astype(np.float32)
+    expected = _gemm_ref_triple(alpha, opA, opB, beta, C0)
+    ref = None
+    for th in THREAD_SWEEP_CORE:
+        result = run_op(bins["l3"], "gemm_ct", "simple",
+                        args=[th, shape_id, ta, tb, 0, 0, alpha, beta],
+                        inputs=[A_flat, B_flat, _c_flat(C0, 0)])
+        assert np.allclose(result.reshape(m, n, order='F'), expected, rtol=RTOL, atol=ATOL), \
+            f"shape_id={shape_id} ({m},{n},{k}) ta,tb={ta},{tb} th={th}"
+        if ref is None:
+            ref = result
+        else:
+            assert np.array_equal(result, ref), f"non-invariant shape_id={shape_id} th={th}"
 
 
-# ─── gemm row-major ───────────────────────────────────────────────────────────
+# ─── gemm: single-warp (one warp, launched <<<1,32>>>) ────────────────────────
 
-@pytest.mark.parametrize("m,n,k", [(4, 6, 5), (8, 8, 8), (12, 4, 6)])
-def test_gemm_rowmajor(bins, m, n, k):
-    """All matrices row-major (C-contiguous): C = alpha*A*B + beta*C."""
+@pytest.mark.parametrize("shape_id", [0, 1, 2, 3, 4, 5, 6])  # skip 16×16×16 (warp = 256 outputs serial-K, slow but fine)
+@pytest.mark.parametrize("ta,tb", TRANSPOSE_COMBOS)
+def test_gemm_warp(bins, shape_id, ta, tb):
+    """Single-warp compile-time gemm == hand reference at one warp."""
+    m, n, k = GEMM_CT_IDS[shape_id]
     alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)   # C-order = row-major
-    B = RNG.random((n, k)).astype(np.float32)
-    C = RNG.random((m, k)).astype(np.float32)
-    C0 = C.copy()
-    result = run_op(bins["l3"], "gemm_rowmajor", "simple",
-                    args=[m, n, k, alpha, beta],
-                    inputs=[A.ravel(), B.ravel(), C.ravel()])
-    expected = (alpha * A @ B + beta * C0).astype(np.float32)
-    # result is row-major flat: reshape with C order
-    mat = result.reshape(m, k)
-    assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
+    opA, opB, A_flat, B_flat = _gemm_storage(m, n, k, ta, tb, seed=700 + shape_id)
+    C0 = np.random.default_rng(800 + shape_id).standard_normal((m, n)).astype(np.float32)
+    expected = _gemm_ref_triple(alpha, opA, opB, beta, C0)
+    result = run_op(bins["l3"], "gemm_warp", "warp",
+                    args=[0, shape_id, ta, tb, 0, 0, alpha, beta],
+                    inputs=[A_flat, B_flat, _c_flat(C0, 0)])
+    assert np.allclose(result.reshape(m, n, order='F'), expected, rtol=RTOL, atol=ATOL)
 
 
-@pytest.mark.parametrize("m,n,k", [(4, 6, 5), (8, 8, 8)])
-def test_gemm_ex(bins, m, n, k):
-    """gemm_ex mixed layout: row-major A, col-major B, row-major C."""
-    alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)       # row-major
-    B_col = RNG.random((n, k)).astype(np.float32)   # will be passed col-major
-    C = RNG.random((m, k)).astype(np.float32)       # row-major
-    C0 = C.copy()
-    result = run_op(bins["l3"], "gemm_ex", "simple",
-                    args=[m, n, k, alpha, beta],
-                    inputs=[A.ravel(),
-                            np.asfortranarray(B_col).ravel(order='F'),  # col-major flat
-                            C.ravel()])
-    expected = (alpha * A @ B_col + beta * C0).astype(np.float32)
-    mat = result.reshape(m, k)
-    assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
-
-
-# ─── gemm_tiled ───────────────────────────────────────────────────────────────
+# ─── gemm_tiled (no transpose; A m×k, B k×n, C m×n) ──────────────────────────
 
 @pytest.mark.parametrize("m,n,k", [(4, 6, 5), (8, 8, 8), (12, 4, 6), (6, 10, 7), (4, 3, 4)])
 def test_gemm_tiled(bins, m, n, k):
     alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)
-    B = RNG.random((n, k)).astype(np.float32)
-    C = RNG.random((m, k)).astype(np.float32)
+    A = RNG.random((m, k)).astype(np.float32)   # A is m×k
+    B = RNG.random((k, n)).astype(np.float32)   # B is k×n
+    C = RNG.random((m, n)).astype(np.float32)
     C0 = C.copy()
     result = run_op(bins["l3"], "gemm_tiled", "simple",
                     args=[m, n, k, alpha, beta],
@@ -120,39 +234,46 @@ def test_gemm_tiled(bins, m, n, k):
                             np.asfortranarray(B).ravel(order='F'),
                             np.asfortranarray(C).ravel(order='F')])
     expected = (alpha * A @ B + beta * C0).astype(np.float32)
-    mat = result.reshape(m, k, order='F')
+    mat = result.reshape(m, n, order='F')
     assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── gemm_strided ─────────────────────────────────────────────────────────────
+# ─── gemm_strided (standard convention, explicit leading dims) ────────────
 
 @pytest.mark.parametrize("alpha,beta", [(1.5, 0.3), (1.0, 0.0)])
 @pytest.mark.parametrize("op,m,n,k,a_rs,b_rs", [
-    ("gemm_strided_6x6x6_6_6", 6, 6, 6, 6, 6),
-    ("gemm_strided_6x6x6_8_8", 6, 6, 6, 8, 8),
-    ("gemm_strided_4x4x4_4_4", 4, 4, 4, 4, 4),
-    ("gemm_strided_4x4x4_6_6", 4, 4, 4, 6, 6),
+    ("rsgemm_6x6x6_6_6", 6, 6, 6, 6, 6),
+    ("rsgemm_6x6x6_8_8", 6, 6, 6, 8, 8),
+    ("rsgemm_4x4x4_4_4", 4, 4, 4, 4, 4),
+    ("rsgemm_4x4x4_6_6", 4, 4, 4, 6, 6),
+    ("rsgemm_5x7x3_8_6", 5, 7, 3, 8, 6),
 ])
 def test_gemm_strided(bins, op, m, n, k, a_rs, b_rs, alpha, beta):
-    # A[i][j] = A_flat[i + j*a_rs]; B[j][l] = B_flat[j + l*b_rs]; C standard col-major.
-    A_storage = np.zeros((a_rs, n), dtype=np.float32)
-    A_storage[:m, :] = RNG.random((m, n)).astype(np.float32)
-    B_storage = np.zeros((b_rs, k), dtype=np.float32)
-    B_storage[:n, :] = RNG.random((n, k)).astype(np.float32)
-    C = RNG.random((m, k)).astype(np.float32)
+    # A is M×K, lead A_RS: A[m][k] = A_flat[m + k*a_rs].
+    # B is K×N, lead B_RS: B[k][n] = B_flat[k + n*b_rs].  C standard col-major.
+    A_storage = np.zeros((a_rs, k), dtype=np.float32)
+    A_storage[:m, :] = RNG.random((m, k)).astype(np.float32)
+    B_storage = np.zeros((b_rs, n), dtype=np.float32)
+    B_storage[:k, :] = RNG.random((k, n)).astype(np.float32)
+    C = RNG.random((m, n)).astype(np.float32)
     C0 = C.copy()
     A_flat = np.asfortranarray(A_storage).ravel(order='F')
     B_flat = np.asfortranarray(B_storage).ravel(order='F')
     C_flat = np.asfortranarray(C).ravel(order='F')
-    # gemm_strided dispatch uses args=[alpha, beta] directly (no m/n/k positional args)
-    result = run_op(bins["l3"], op, "simple",
-                    args=[alpha, beta], inputs=[A_flat, B_flat, C_flat])
-    expected = (alpha * A_storage[:m, :] @ B_storage[:n, :] + beta * C0).astype(np.float32)
-    mat = result.reshape(m, k, order='F')
-    assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
+    ref = None
+    for th in THREAD_SWEEP_CORE:
+        result = run_op(bins["l3"], op, "simple",
+                        args=[th, alpha, beta], inputs=[A_flat, B_flat, C_flat])
+        expected = (alpha * A_storage[:m, :] @ B_storage[:k, :] + beta * C0).astype(np.float32)
+        mat = result.reshape(m, n, order='F')
+        assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL), f"{op} th={th}"
+        if ref is None:
+            ref = result
+        else:
+            assert np.array_equal(result, ref), f"{op} non-invariant th={th}"
 
 
-# ─── packed_gemm ──────────────────────────────────────────────────────────────
+# ─── packed_gemm (compile-time 4×K) ───────────────────────────────────────────
 
 def _make_packed_vec(size, case):
     if case == "positive": return RNG.random(size).astype(np.float32)
@@ -166,12 +287,12 @@ def _make_packed_vec(size, case):
 @pytest.mark.parametrize("case", ["positive", "negative", "mixed", "zero", "tiny"])
 @pytest.mark.parametrize("k", [16, 32, 48, 64])
 def test_packed_gemm(bins, k, case):
-    # glass::gemm<float,4,4,K>: C(4×K) = alpha * A(4×4) * B(4×K) + beta * C(4×K), col-major
+    # glass::gemm<float,4,4,K>: C(4×4) = alpha * A(4×K) * B(K×4) + beta * C(4×4).
     m, n = 4, 4
     alpha, beta = 1.5, 0.3
-    A = _make_packed_vec(m * n, case).reshape(m, n)
-    B = _make_packed_vec(n * k, case).reshape(n, k)
-    C = _make_packed_vec(m * k, case).reshape(m, k)
+    A = _make_packed_vec(m * k, case).reshape(m, k)   # A is 4×K
+    B = _make_packed_vec(k * n, case).reshape(k, n)   # B is K×4
+    C = _make_packed_vec(m * n, case).reshape(m, n)
     C0 = C.copy()
     result = run_op(bins["l3"], f"packed_gemm_4x4x{k}", "simple",
                     args=[alpha, beta],
@@ -179,23 +300,41 @@ def test_packed_gemm(bins, k, case):
                             np.asfortranarray(B).ravel(order='F'),
                             np.asfortranarray(C).ravel(order='F')])
     expected = (alpha * A @ B + beta * C0).astype(np.float32)
-    mat = result.reshape(m, k, order='F')
+    mat = result.reshape(m, n, order='F')
     assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
+
+
 
 
 # ─── inv ──────────────────────────────────────────────────────────────────────
 
 @pytest.mark.parametrize("n", [3, 4, 6])
+@pytest.mark.parametrize("cond", [None, 1e4])  # well-conditioned + ill-conditioned
 @pytest.mark.parametrize("version", CG_SIMPLE)
-def test_inv(bins, n, version):
-    A = make_spd(n)
+def test_inv(bins, n, cond, version):
+    """invertMatrix across the canonical thread sweep (incl. partial/odd/non-warp
+    counts), two input conditionings. The augmented-row save loop must be
+    grid-strided (`ind += size`); a non-strided `ind++` is a write-write race that
+    compute-sanitizer racecheck flags even though every racing write stores the same
+    value (so it is invisible at 32/256 — see test_hardening doc). Output must be
+    byte-for-byte identical at every block size."""
+    A = make_spd(n, seed=n, cond=cond)
     # invertMatrix expects [A | I] layout (n*2n) column-major
     AI = np.hstack([A, np.eye(n, dtype=np.float32)])   # row layout (n x 2n)
     AI_col = np.asfortranarray(AI).ravel(order='F')
-    result = run_op(bins["l3"], "inv", version, args=[n], inputs=[AI_col])
-    Ainv = result.reshape(n, n, order='F')
     expected = np.linalg.inv(A).astype(np.float32)
-    assert np.allclose(Ainv, expected, rtol=1e-2, atol=1e-3)
+    rtol, atol = (1e-2, 1e-3) if cond is None else (5e-2, 5e-3)
+    ref = None
+    for threads in THREAD_SWEEP:
+        result = run_op(bins["l3"], "inv", version, args=[threads, n], inputs=[AI_col])
+        Ainv = result.reshape(n, n, order='F')
+        assert np.allclose(Ainv, expected, rtol=rtol, atol=atol), \
+            f"n={n} cond={cond} threads={threads}: mismatch vs np.linalg.inv"
+        if ref is None:
+            ref = result
+        else:
+            assert np.array_equal(result, ref), \
+                f"n={n} cond={cond} threads={threads}: output differs from threads=1"
 
 
 def _aug(M, d):
@@ -218,7 +357,7 @@ def _near_singular_leading(n):
     """Invertible matrix whose UNPIVOTED Gauss-Jordan hits a tiny/zero leading
     pivot: a tiny A[0,0] with a large entry lower in column 0 (the partial-pivot
     path swaps it up; the plain path divides by ~0)."""
-    A = make_spd(n)
+    A = make_spd(n, rng=RNG)
     A[0, 0] = 1e-7                 # tiny leading pivot
     A[n - 1, 0] = 5.0             # large later entry in column 0 → must pivot up
     A[0, n - 1] = 5.0            # keep it reasonably conditioned / nonsymmetric
@@ -228,7 +367,7 @@ def _near_singular_leading(n):
 def _zero_diagonal_perm(n):
     """Invertible matrix with a literal ZERO on the (0,0) diagonal — the plain
     path divides by exactly 0; partial pivoting swaps a nonzero row up."""
-    A = make_spd(n)
+    A = make_spd(n, rng=RNG)
     # Swap rows 0 and 1 of an SPD matrix then zero the (0,0) entry: still
     # invertible, but A[0,0] == 0 breaks the unpivoted divide.
     A[[0, 1], :] = A[[1, 0], :]
@@ -241,7 +380,7 @@ def test_inv_pivot(bins, n):
     """Robust partial-pivoting inverse matches np.linalg.inv on well-conditioned
     SPD matrices, across a thread-count sweep (1, 7, 33, 256) with identical
     output at every block size."""
-    A = make_spd(n)
+    A = make_spd(n, rng=RNG)
     expected = np.linalg.inv(A).astype(np.float32)
     ref = None
     for threads in (1, 7, 33, 256):
@@ -279,7 +418,7 @@ def test_inv_pivot_near_singular(bins, n, maker):
 @pytest.mark.parametrize("dimA,dimB", [(4, 4), (6, 4), (3, 6)])
 def test_inv2(bins, dimA, dimB):
     # fused 2-matrix invert: same augmented [A|I] convention, interleaved sweep
-    A = make_spd(dimA); B = make_spd(dimB)
+    A = make_spd(dimA, rng=RNG); B = make_spd(dimB, rng=RNG)
     res = run_op(bins["l3"], "inv2", "simple", args=[dimA, dimB, max(dimA, dimB)],
                  inputs=[_aug(A, dimA), _aug(B, dimB)])
     assert np.allclose(res[0].reshape(dimA, dimA, order='F'), np.linalg.inv(A), rtol=1e-2, atol=1e-3)
@@ -289,7 +428,7 @@ def test_inv2(bins, dimA, dimB):
 # (12,12,6) mirrors GATO's Schur fused-3 (STATE_SIZE=12, CONTROL_SIZE=6 for indy7)
 @pytest.mark.parametrize("dimA,dimB,dimC", [(12, 12, 6), (6, 6, 6), (4, 6, 3)])
 def test_inv3(bins, dimA, dimB, dimC):
-    A = make_spd(dimA); B = make_spd(dimB); C = make_spd(dimC)
+    A = make_spd(dimA, rng=RNG); B = make_spd(dimB, rng=RNG); C = make_spd(dimC, rng=RNG)
     res = run_op(bins["l3"], "inv3", "simple", args=[dimA, dimB, dimC, max(dimA, dimB, dimC)],
                  inputs=[_aug(A, dimA), _aug(B, dimB), _aug(C, dimC)])
     for M, d, r in [(A, dimA, res[0]), (B, dimB, res[1]), (C, dimC, res[2])]:
@@ -301,7 +440,7 @@ def test_inv3(bins, dimA, dimB, dimC):
 @pytest.mark.parametrize("n", [3, 4, 6])
 @pytest.mark.parametrize("version", CG_SIMPLE)
 def test_chol(bins, n, version):
-    A = make_spd(n)
+    A = make_spd(n, rng=RNG)
     A_col = np.asfortranarray(A).ravel(order='F')
     result = run_op(bins["l3"], "chol", version, args=[n], inputs=[A_col])
     L_gpu = result.reshape(n, n, order='F')
@@ -316,7 +455,7 @@ def test_chol(bins, n, version):
 @pytest.mark.parametrize("n", [3, 4, 6, 8])
 @pytest.mark.parametrize("version", CG_SIMPLE)
 def test_trsm(bins, n, version):
-    L = make_lower_triangular(n)
+    L = make_lower_triangular(n, rng=RNG)
     b = RNG.random(n).astype(np.float32)
     L_col = np.asfortranarray(L).ravel(order='F')
     result = run_op(bins["l3"], "trsm", version, args=[n], inputs=[L_col, b])
@@ -327,28 +466,11 @@ def test_trsm(bins, n, version):
 
 # ─── warp:: (single warp, launched <<<1,32>>>) ────────────────────────────────
 
-def test_gemm_warp_4x4x4(bins):
-    # glass::warp::gemm<float,4,4,4>: C = alpha*A@B + beta*C, col-major, one warp.
-    m, n, k = 4, 4, 4
-    alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)
-    B = RNG.random((n, k)).astype(np.float32)
-    C = RNG.random((m, k)).astype(np.float32)
-    C0 = C.copy()
-    result = run_op(bins["l3"], "gemm_warp", "warp",
-                    args=[m, n, k, alpha, beta],
-                    inputs=[np.asfortranarray(A).ravel(order='F'),
-                            np.asfortranarray(B).ravel(order='F'),
-                            np.asfortranarray(C).ravel(order='F')])
-    expected = (alpha * A @ B + beta * C0).astype(np.float32)
-    mat = result.reshape(m, k, order='F')
-    assert np.allclose(mat, expected, rtol=RTOL, atol=ATOL)
-
 
 def test_posv_warp_7(bins):
     # Single-warp SPD solve A x = b via warp:: chol + trsm + trsm_transpose (N=7).
     n = 7
-    A = make_spd(n)
+    A = make_spd(n, rng=RNG)
     b = RNG.random(n).astype(np.float32)
     A_col = np.asfortranarray(A).ravel(order='F')
     result = run_op(bins["l3"], "posv_warp", "warp", args=[n], inputs=[A_col, b])
@@ -376,9 +498,9 @@ def _flatten_row(mats):
 def test_gemm_batched_1d_colmajor(bin_l3_nvidia, op, m, n, k, batch):
     """SIMT batched 1D-launch GEMM: BATCH independent (M×N)·(N×K) GEMMs, col-major."""
     alpha, beta = 1.5, 0.3
-    As = [RNG.random((m, n)).astype(np.float32) for _ in range(batch)]
-    Bs = [RNG.random((n, k)).astype(np.float32) for _ in range(batch)]
-    Cs = [RNG.random((m, k)).astype(np.float32) for _ in range(batch)]
+    As = [RNG.random((m, k)).astype(np.float32) for _ in range(batch)]
+    Bs = [RNG.random((k, n)).astype(np.float32) for _ in range(batch)]
+    Cs = [RNG.random((m, n)).astype(np.float32) for _ in range(batch)]
     C0s = [c.copy() for c in Cs]
     result = run_op(bin_l3_nvidia, op, "simple",
                     args=[alpha, beta],
@@ -398,9 +520,9 @@ def test_gemm_batched_1d_colmajor(bin_l3_nvidia, op, m, n, k, batch):
 def test_gemm_batched_1d_rowmajor(bin_l3_nvidia, op, m, n, k, batch):
     """SIMT batched 1D-launch GEMM: row-major layout for all of A, B, C."""
     alpha, beta = 1.5, 0.3
-    As = [RNG.random((m, n)).astype(np.float32) for _ in range(batch)]
-    Bs = [RNG.random((n, k)).astype(np.float32) for _ in range(batch)]
-    Cs = [RNG.random((m, k)).astype(np.float32) for _ in range(batch)]
+    As = [RNG.random((m, k)).astype(np.float32) for _ in range(batch)]
+    Bs = [RNG.random((k, n)).astype(np.float32) for _ in range(batch)]
+    Cs = [RNG.random((m, n)).astype(np.float32) for _ in range(batch)]
     C0s = [c.copy() for c in Cs]
     result = run_op(bin_l3_nvidia, op, "simple",
                     args=[alpha, beta],
@@ -423,9 +545,9 @@ def test_gemm_batched_1d_rowmajor(bin_l3_nvidia, op, m, n, k, batch):
 def test_gemm_strided_batched_1d(bin_l3_nvidia, op, m, n, k, batch):
     """Shared-A batched GEMM: one A applied to BATCH packed (B,C) pairs."""
     alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)
-    Bs = [RNG.random((n, k)).astype(np.float32) for _ in range(batch)]
-    Cs = [RNG.random((m, k)).astype(np.float32) for _ in range(batch)]
+    A = RNG.random((m, k)).astype(np.float32)
+    Bs = [RNG.random((k, n)).astype(np.float32) for _ in range(batch)]
+    Cs = [RNG.random((m, n)).astype(np.float32) for _ in range(batch)]
     C0s = [c.copy() for c in Cs]
     result = run_op(bin_l3_nvidia, op, "simple",
                     args=[alpha, beta],
@@ -439,29 +561,28 @@ def test_gemm_strided_batched_1d(bin_l3_nvidia, op, m, n, k, batch):
 
 
 @pytest.mark.parametrize("op,m,n,k,batch,b_stride,c_stride", [
-    # 4×4×4, B padded N*K=16 -> 24 (8 floats slack), C padded M*K=16 -> 20 (4 floats slack)
+    # 4×4×4, B padded K*N=16 -> 24 (8 floats slack), C padded M*N=16 -> 20 (4 floats slack)
     ("gemm_strided_padded_4x4x4_b4_bs24_cs20", 4, 4, 4, 4, 24, 20),
-    # 3×5×7, B packed N*K=35 -> 50, C packed M*K=21 -> 28
+    # 3×5×7 (standard: A 3×7, B 7×5, C 3×5), B packed K*N=35 -> 50, C packed M*N=15 -> 28
     ("gemm_strided_padded_3x5x7_b3_bs50_cs28", 3, 5, 7, 3, 50, 28),
 ])
 def test_gemm_strided_batched_1d_padded(bin_l3_nvidia, op, m, n, k, batch,
                                          b_stride, c_stride):
     """Strided variant with non-default B_STRIDE / C_STRIDE — verifies the
-    `b * STRIDE` indexing inside the kernel, not just the tightly-packed default."""
+    `b * STRIDE` indexing inside the kernel, not just the tightly-packed default.
+    Standard convention: shared A is m×k, each B is k×n, each C is m×n."""
     alpha, beta = 1.5, 0.3
-    A = RNG.random((m, n)).astype(np.float32)
+    A = RNG.random((m, k)).astype(np.float32)
 
-    # Build padded B: each batch occupies b_stride floats; only first n*k matter.
+    # Build padded B: each batch occupies b_stride floats; only first k*n matter.
     B_padded = RNG.random(batch * b_stride).astype(np.float32)
-    # Build padded C: each batch occupies c_stride floats; only first m*k matter.
+    # Build padded C: each batch occupies c_stride floats; only first m*n matter.
     C_padded = RNG.random(batch * c_stride).astype(np.float32)
 
-    # Extract packed col-major B[b] and C[b] for the reference computation.
-    # The kernel reads col-major M×N B from B[b*b_stride : b*b_stride + n*k]
-    # and writes col-major M×K C to C[b*c_stride : b*c_stride + m*k].
-    Bs = [B_padded[b*b_stride : b*b_stride + n*k].reshape(n, k, order='F')
+    # Extract packed col-major B[b] (k×n) and C[b] (m×n) for the reference.
+    Bs = [B_padded[b*b_stride : b*b_stride + k*n].reshape(k, n, order='F')
           for b in range(batch)]
-    Cs0 = [C_padded[b*c_stride : b*c_stride + m*k].reshape(m, k, order='F').copy()
+    Cs0 = [C_padded[b*c_stride : b*c_stride + m*n].reshape(m, n, order='F').copy()
            for b in range(batch)]
 
     result = run_op(bin_l3_nvidia, op, "simple",
@@ -473,7 +594,7 @@ def test_gemm_strided_batched_1d_padded(bin_l3_nvidia, op, m, n, k, batch,
     expected = C_padded.copy()
     for b in range(batch):
         new_C = (alpha * A @ Bs[b] + beta * Cs0[b]).astype(np.float32)
-        expected[b*c_stride : b*c_stride + m*k] = \
+        expected[b*c_stride : b*c_stride + m*n] = \
             np.asfortranarray(new_C).ravel(order='F')
 
     # Result has length batch*c_stride (we print the full padded buffer so we
@@ -482,7 +603,7 @@ def test_gemm_strided_batched_1d_padded(bin_l3_nvidia, op, m, n, k, batch,
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── indexed_batched_gemm ─────────────────────────────────────────────────────
+# ─── gemm_batched_indexed ─────────────────────────────────────────────────────
 # C[c_idx[p]] = A[a_idx[p]] @ B[b_idx[p]], 4x4 col-major, selected by index lists.
 # numpy does each indexed product independently as the reference.
 
@@ -491,7 +612,7 @@ def test_gemm_strided_batched_1d_padded(bin_l3_nvidia, op, m, n, k, batch,
     (4, 2, 3, 4),    # repeated/aliased a_idx,b_idx; distinct c_idx
     (8, 5, 5, 8),
 ])
-def test_indexed_batched_gemm(bins, pairs, a_mats, b_mats, c_mats):
+def test_gemm_batched_indexed(bins, pairs, a_mats, b_mats, c_mats):
     DIM = 4
     rng = RNG
     A_mats = [rng.random((DIM, DIM)).astype(np.float32) for _ in range(a_mats)]
@@ -518,7 +639,7 @@ def test_indexed_batched_gemm(bins, pairs, a_mats, b_mats, c_mats):
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── indexed_batched_gemm: TRANSPOSE_A / TRANSPOSE_B ──────────────────────────
+# ─── gemm_batched_indexed: TRANSPOSE_A / TRANSPOSE_B ──────────────────────────
 # Distinct c_idx, plain overwrite, but the left and/or right factor is read
 # transposed. Reference applies .T to the corresponding numpy operand.
 
@@ -531,7 +652,7 @@ def test_indexed_batched_gemm(bins, pairs, a_mats, b_mats, c_mats):
     (4, 2, 3, 4),
     (8, 5, 5, 8),
 ])
-def test_indexed_batched_gemm_transpose(bins, op, ta, tb, pairs, a_mats, b_mats, c_mats):
+def test_gemm_batched_indexed_transpose(bins, op, ta, tb, pairs, a_mats, b_mats, c_mats):
     DIM = 4
     rng = RNG
     A_mats = [rng.random((DIM, DIM)).astype(np.float32) for _ in range(a_mats)]
@@ -560,7 +681,7 @@ def test_indexed_batched_gemm_transpose(bins, op, ta, tb, pairs, a_mats, b_mats,
     assert np.allclose(result, expected, rtol=RTOL, atol=ATOL)
 
 
-# ─── indexed_batched_gemm: ATOMIC_C (overlapping c_idx) ───────────────────────
+# ─── gemm_batched_indexed: ATOMIC_C (overlapping c_idx) ───────────────────────
 # Several pairs SHARE a c_idx slot (a parent block); the atomic path must
 # scatter-ADD their products. Caller pre-zeros C; reference is a numpy
 # scatter-add into the shared C slots. parent_of maps pair -> c slot.
@@ -569,7 +690,7 @@ def test_indexed_batched_gemm_transpose(bins, op, ta, tb, pairs, a_mats, b_mats,
     ("indexed_bgemm_4_atomic", False),     # C += A · B
     ("indexed_bgemm_4_ta_atomic", True),   # C += Aᵀ · B  (backward Xᵀ·M·X→parent)
 ])
-def test_indexed_batched_gemm_atomic(bins, op, ta):
+def test_gemm_batched_indexed_atomic(bins, op, ta):
     DIM = 4
     rng = RNG
     # 6 child pairs accumulating into 3 shared parent C slots (overlap by design).

--- a/test/test_ldlt.py
+++ b/test/test_ldlt.py
@@ -14,6 +14,8 @@ import tempfile
 import numpy as np
 import pytest
 
+from conftest import make_spd  # shared; pass rng=RNG for varied draws
+
 RNG = np.random.default_rng(7)
 
 ATOL = 1e-3
@@ -21,11 +23,6 @@ RTOL = 1e-3
 
 NS = [1, 2, 3, 4, 6, 8]
 THREADS = [1, 7, 33, 256]
-
-
-def make_spd(n):
-    A = RNG.random((n, n)).astype(np.float32)
-    return (A @ A.T + n * np.eye(n, dtype=np.float32)).astype(np.float32)
 
 
 def make_indefinite(n):
@@ -102,7 +99,7 @@ def ldlt_bin(bins):
 @pytest.mark.parametrize("n", NS)
 @pytest.mark.parametrize("threads", THREADS)
 def test_ldlt_factor(ldlt_bin, kind, n, threads):
-    A = make_spd(n) if kind == "spd" else make_indefinite(n)
+    A = make_spd(n, rng=RNG) if kind == "spd" else make_indefinite(n)
     out = _run(ldlt_bin, "ldlt", n, threads, [A])[0]
     L, D = _split_LD(out, n)
     recon = L @ np.diag(D) @ L.T
@@ -117,7 +114,7 @@ def test_ldlt_factor(ldlt_bin, kind, n, threads):
 @pytest.mark.parametrize("kind", ["spd", "indef"])
 @pytest.mark.parametrize("n", NS)
 def test_ldlt_factor_thread_invariant(ldlt_bin, kind, n):
-    A = make_spd(n) if kind == "spd" else make_indefinite(n)
+    A = make_spd(n, rng=RNG) if kind == "spd" else make_indefinite(n)
     ref = _run(ldlt_bin, "ldlt", n, THREADS[0], [A])[0]
     for t in THREADS[1:]:
         cur = _run(ldlt_bin, "ldlt", n, t, [A])[0]
@@ -131,7 +128,7 @@ def test_ldlt_factor_thread_invariant(ldlt_bin, kind, n):
 @pytest.mark.parametrize("n", NS)
 @pytest.mark.parametrize("threads", THREADS)
 def test_ldlt_solve(ldlt_bin, kind, n, threads):
-    A = make_spd(n) if kind == "spd" else make_indefinite(n)
+    A = make_spd(n, rng=RNG) if kind == "spd" else make_indefinite(n)
     b = RNG.random(n).astype(np.float32)
     x = _run(ldlt_bin, "ldlt_solve", n, threads, [A, b])[0]
     x_ref = np.linalg.solve(A.astype(np.float64), b.astype(np.float64))
@@ -197,7 +194,7 @@ def test_ldlt_pivot_solve(ldlt_bin, n, threads):
 @pytest.mark.parametrize("threads", THREADS)
 def test_ldlt_pivot_solve_general(ldlt_bin, kind, n, threads):
     """Pivoted solve also works on the ordinary SPD / indefinite matrices."""
-    A = make_spd(n) if kind == "spd" else make_indefinite(n)
+    A = make_spd(n, rng=RNG) if kind == "spd" else make_indefinite(n)
     b = RNG.random(n).astype(np.float32)
     x = _run(ldlt_bin, "ldlt_solve", n, threads, [A, b], pivot=1)[0]
     x_ref = np.linalg.solve(A.astype(np.float64), b.astype(np.float64))
@@ -271,3 +268,49 @@ def test_ldlt_zero_diag_block_needs_2x2(ldlt_bin):
     assert bad, (
         f"1×1-pivoted LDLᵀ unexpectedly handled a zero diagonal BLOCK: x={x} "
         "(would require 2×2 Bunch–Kaufman — if this passes, 2×2 may have landed)")
+
+
+# ─── warp forms (non-pivoted; one 32-lane warp) ───────────────────────────────
+
+WARP = 32
+WARP_NS = [3, 4, 5, 6, 7, 8]   # harness instantiates warp::ldlt for these N
+
+
+@pytest.mark.parametrize("kind", ["spd", "indef"])
+@pytest.mark.parametrize("n", WARP_NS)
+def test_ldlt_warp_factor(ldlt_bin, kind, n):
+    """warp::ldlt non-pivoted factor reconstructs A = L·diag(D)·Lᵀ and matches the
+    block factor (run at one warp)."""
+    A = make_spd(n, rng=RNG) if kind == "spd" else make_indefinite(n)
+    buf = _run(ldlt_bin, "ldlt_warp", n, WARP, [A])[0]
+    L, D = _split_LD(buf, n)
+    recon = (L @ np.diag(D) @ L.T)
+    assert np.allclose(recon, A, rtol=RTOL, atol=ATOL), f"{kind} n={n}: A != L D Lᵀ"
+    # cross-check vs the block factor (same algorithm, different scope)
+    block = _run(ldlt_bin, "ldlt", n, 64, [A])[0]
+    assert np.allclose(buf, block, rtol=1e-2, atol=1e-3), f"{kind} n={n}: warp != block factor"
+
+
+@pytest.mark.parametrize("kind", ["spd", "indef"])
+@pytest.mark.parametrize("n", WARP_NS)
+def test_ldlt_warp_solve(ldlt_bin, kind, n):
+    """warp::ldlt + warp::ldlt_solve recovers x = A⁻¹ b (one warp)."""
+    A = make_spd(n, rng=RNG) if kind == "spd" else make_indefinite(n)
+    b = RNG.standard_normal(n).astype(np.float32)
+    x = _run(ldlt_bin, "ldlt_solve_warp", n, WARP, [A, b])[0]
+    expected = np.linalg.solve(A.astype(np.float64), b.astype(np.float64))
+    assert np.allclose(x, expected, rtol=RTOL, atol=ATOL), f"{kind} n={n}: solve mismatch"
+    assert np.allclose(A.astype(np.float64) @ x.astype(np.float64), b, rtol=RTOL, atol=ATOL)
+
+
+@pytest.mark.parametrize("n", WARP_NS)
+def test_ldlt_warp_inertia(ldlt_bin, n):
+    """CHECK path: inertia {n_pos, n_neg, n_zero} matches the eigenvalue signs of A;
+    s_fail stays 0 for a nonsingular indefinite matrix."""
+    A = make_indefinite(n)
+    lines = _run(ldlt_bin, "ldlt_warp_check", n, WARP, [A])
+    s_fail, n_pos, n_neg, n_zero = [int(round(v)) for v in lines[1]]
+    ev = np.linalg.eigvalsh(A.astype(np.float64))
+    assert (n_pos, n_neg, n_zero) == (int((ev > 0).sum()), int((ev < 0).sum()), 0), \
+        f"n={n}: inertia {(n_pos, n_neg, n_zero)} != eig signs"
+    assert s_fail == 0, f"n={n}: nonsingular indefinite flagged s_fail=1"

--- a/test/test_nvidia_dispatch.py
+++ b/test/test_nvidia_dispatch.py
@@ -4,8 +4,8 @@ Companion to test_l3_nvidia.py (which tests the SIMT batched APIs from
 l3_simt.cuh). This module targets the round-2 additions:
 
   * Gap A — glass::nvidia::gemv<>     auto-dispatches SIMT vs cuBLASDx
-  * Gap B — row_strided_gemv<>        auto-dispatches; SIMT uses stride directly
-  * Gap C — row_strided_gemm<>        auto-dispatches; SIMT skips compact-pack
+  * Gap B — gemv_strided<>        auto-dispatches; SIMT uses stride directly
+  * Gap C — gemm_strided<>        auto-dispatches; SIMT skips compact-pack
   * Gap D — gemm<...,LB=row_major,...> maps onto SIMT TRANSPOSE_B=true
 
 The test binary requires cuBLASDx for the gemm_cublas op (compiles via DEFINE),

--- a/test/test_posv.py
+++ b/test/test_posv.py
@@ -11,13 +11,15 @@ import tempfile
 import numpy as np
 import pytest
 
+from conftest import THREAD_SWEEP, make_spd
+
 RNG = np.random.default_rng(11)
 RTOL, ATOL = 1e-2, 1e-3
 
-
-def _make_spd(n):
-    A = RNG.standard_normal((n, n)).astype(np.float32)
-    return (A @ A.T + n * np.eye(n, dtype=np.float32)).astype(np.float32)
+# warp ops occupy exactly one 32-lane warp on shared per-problem data; launching
+# more than a warp would have every warp race on the same A/b, fewer would break
+# the full-mask shfl. So warp solves are validated at exactly 32 threads.
+WARP = 32
 
 
 def _run(binary, op, n, threads, M, b):
@@ -61,7 +63,7 @@ def _run_m(binary, op, n, nrhs, threads, M, B):
 
 @pytest.mark.parametrize("n", [3, 4, 6, 8])
 def test_posv(bins, n):
-    A = _make_spd(n)
+    A = make_spd(n, rng=RNG)
     b = RNG.standard_normal(n).astype(np.float32)
     x = _run(bins["posv"], "posv", n, 256, A, b)
     expected = np.linalg.solve(A, b)
@@ -73,7 +75,7 @@ def test_posv(bins, n):
 @pytest.mark.parametrize("n", [3, 4, 6, 8])
 def test_potrs(bins, n):
     """Precomputed-factor path: pass the host Cholesky L, never the full A."""
-    A = _make_spd(n)
+    A = make_spd(n, rng=RNG)
     L = np.linalg.cholesky(A).astype(np.float32)   # lower
     b = RNG.standard_normal(n).astype(np.float32)
     x = _run(bins["posv"], "potrs", n, 256, L, b)
@@ -85,7 +87,7 @@ def test_potrs(bins, n):
 @pytest.mark.parametrize("nrhs", [1, 2, 3, 5])
 def test_posv_multirhs(bins, n, nrhs):
     """Multi-RHS factor+solve: X (n×nrhs col-major) == np.linalg.solve(A, B)."""
-    A = _make_spd(n)
+    A = make_spd(n, rng=RNG)
     B = RNG.standard_normal((n, nrhs)).astype(np.float32)
     X = _run_m(bins["posv"], "posv_m", n, nrhs, 256, A, B)
     expected = np.linalg.solve(A, B)
@@ -98,7 +100,7 @@ def test_posv_multirhs(bins, n, nrhs):
 @pytest.mark.parametrize("nrhs", [1, 2, 3, 5])
 def test_potrs_multirhs(bins, n, nrhs):
     """Multi-RHS precomputed-factor path: pass host Cholesky L, solve n×nrhs B."""
-    A = _make_spd(n)
+    A = make_spd(n, rng=RNG)
     L = np.linalg.cholesky(A).astype(np.float32)   # lower
     B = RNG.standard_normal((n, nrhs)).astype(np.float32)
     X = _run_m(bins["posv"], "potrs_m", n, nrhs, 256, L, B)
@@ -111,12 +113,12 @@ def test_potrs_multirhs(bins, n, nrhs):
 @pytest.mark.parametrize("nrhs", [1, 3, 5])
 def test_posv_multirhs_thread_invariance(bins, op, n, nrhs):
     """Barrier correctness: identical X at 1/7/33/256 threads, matching the oracle."""
-    A = _make_spd(n)
+    A = make_spd(n, rng=RNG)
     B = RNG.standard_normal((n, nrhs)).astype(np.float32)
     M = np.linalg.cholesky(A).astype(np.float32) if op == "potrs_m" else A
     expected = np.linalg.solve(A, B)
     outs = []
-    for threads in (1, 7, 33, 256):
+    for threads in THREAD_SWEEP:
         X = _run_m(bins["posv"], op, n, nrhs, threads, M, B)
         assert np.allclose(X, expected, rtol=RTOL, atol=ATOL), f"threads={threads} mismatch"
         outs.append(X)
@@ -128,14 +130,109 @@ def test_posv_multirhs_thread_invariance(bins, op, n, nrhs):
 @pytest.mark.parametrize("n", [4, 6, 8])
 def test_posv_thread_invariance(bins, op, n):
     """Barrier correctness: identical x at 1/7/33/256 threads, matching the oracle."""
-    A = _make_spd(n)
+    A = make_spd(n, rng=RNG)
     b = RNG.standard_normal(n).astype(np.float32)
     M = np.linalg.cholesky(A).astype(np.float32) if op == "potrs" else A
     expected = np.linalg.solve(A, b)
     outs = []
-    for threads in (1, 7, 33, 256):
+    for threads in THREAD_SWEEP:
         x = _run(bins["posv"], op, n, threads, M, b)
         assert np.allclose(x, expected, rtol=RTOL, atol=ATOL), f"threads={threads} mismatch"
         outs.append(x)
     for x in outs[1:]:
         assert np.array_equal(outs[0], x), "thread-count non-invariance"
+
+
+# ─── flagged solves: REGULARIZE (rho·I) / REG_DIAG (Levenberg) / CHECK ─────────
+#
+# The flagged kernels are compiled for n=7 (HJCD's LM DIM); b is an n×1 RHS routed
+# through the multi-RHS overload (NRHS=1). The runner prints x on line 1 and the
+# CHECK s_fail flag (0/1) on line 2.
+FN = 7
+
+
+def _run_flag(binary, op, threads, A, b, rho):
+    """Run a flagged posv (block or warp). Returns (x[7], s_fail:int)."""
+    tmp = []
+    try:
+        for arr in (np.asfortranarray(A).ravel(order="F"), b):
+            f = tempfile.NamedTemporaryFile(suffix=".bin", delete=False)
+            arr.astype(np.float32).tofile(f); f.close(); tmp.append(f.name)
+        cmd = [str(binary), op, str(FN), str(threads), tmp[0], tmp[1], repr(float(rho))]
+        res = subprocess.run(cmd, capture_output=True, text=True)
+        if res.returncode != 0:
+            raise RuntimeError(f"runner failed:\n{res.stderr}")
+        lines = [l for l in res.stdout.strip().split("\n") if l.strip()]
+        x = np.fromstring(lines[0], sep=" ").astype(np.float32)
+        s_fail = int(lines[1].strip())
+        return x, s_fail
+    finally:
+        for f in tmp:
+            os.unlink(f)
+
+
+@pytest.mark.parametrize("mode", ["reg", "regdiag"])
+@pytest.mark.parametrize("seed", [0, 1])
+def test_posv_flag_block(bins, mode, seed):
+    """Block REGULARIZE (rho·I) / REG_DIAG (rho·diag(A)) shift, swept over the full
+    thread set with byte-identical output. Oracle solves the shifted system."""
+    rho = 0.5
+    A = make_spd(FN, seed=seed)
+    b = np.random.default_rng(100 + seed).standard_normal(FN).astype(np.float32)
+    if mode == "reg":
+        Ashift = A + rho * np.eye(FN, dtype=np.float32)
+    else:  # Levenberg: A + rho*diag(A)
+        Ashift = A + rho * np.diag(np.diag(A)).astype(np.float32)
+    expected = np.linalg.solve(Ashift, b)
+    op = f"posv_{mode}"
+    ref = None
+    for threads in THREAD_SWEEP:
+        x, s_fail = _run_flag(bins["posv"], op, threads, A, b, rho)
+        assert np.allclose(x, expected, rtol=RTOL, atol=ATOL), \
+            f"{op} seed={seed} threads={threads}: mismatch vs shifted-solve"
+        assert s_fail == 0, "no CHECK flag requested; s_fail must stay 0"
+        if ref is None:
+            ref = x
+        else:
+            assert np.array_equal(x, ref), f"{op} threads={threads}: non-invariant"
+
+
+def test_posv_flag_check_block(bins):
+    """Block CHECK: s_fail=0 on SPD (and x correct), s_fail=1 on a non-PD matrix."""
+    b = RNG.standard_normal(FN).astype(np.float32)
+    # SPD → flag stays 0, solve is correct.
+    A = make_spd(FN, seed=7)
+    for threads in THREAD_SWEEP:
+        x, s_fail = _run_flag(bins["posv"], "posv_check", threads, A, b, 0.0)
+        assert s_fail == 0, f"SPD threads={threads}: s_fail should be 0"
+        assert np.allclose(x, np.linalg.solve(A, b), rtol=RTOL, atol=ATOL)
+    # Non-PD (negative-definite) → first pivot ≤ 0 → flag 1.
+    Aneg = (-make_spd(FN, seed=8)).astype(np.float32)
+    for threads in THREAD_SWEEP:
+        _, s_fail = _run_flag(bins["posv"], "posv_check", threads, Aneg, b, 0.0)
+        assert s_fail == 1, f"non-PD threads={threads}: s_fail should be 1"
+
+
+@pytest.mark.parametrize("mode", ["reg", "regdiag", "check"])
+def test_posv_flag_warp(bins, mode):
+    """Warp parity: warp::posv flagged forms match the block/oracle at one warp."""
+    b = RNG.standard_normal(FN).astype(np.float32)
+    rho = 0.5
+    if mode == "check":
+        A = make_spd(FN, seed=9)
+        x, s_fail = _run_flag(bins["posv"], "posv_warp_check", WARP, A, b, 0.0)
+        assert s_fail == 0
+        assert np.allclose(x, np.linalg.solve(A, b), rtol=RTOL, atol=ATOL)
+        Aneg = (-make_spd(FN, seed=10)).astype(np.float32)
+        _, s_fail = _run_flag(bins["posv"], "posv_warp_check", WARP, Aneg, b, 0.0)
+        assert s_fail == 1
+        return
+    A = make_spd(FN, seed=3)
+    if mode == "reg":
+        Ashift = A + rho * np.eye(FN, dtype=np.float32)
+    else:
+        Ashift = A + rho * np.diag(np.diag(A)).astype(np.float32)
+    expected = np.linalg.solve(Ashift, b)
+    x, s_fail = _run_flag(bins["posv"], f"posv_warp_{mode}", WARP, A, b, rho)
+    assert s_fail == 0
+    assert np.allclose(x, expected, rtol=RTOL, atol=ATOL), f"warp {mode}: mismatch"

--- a/test/test_reduced.py
+++ b/test/test_reduced.py
@@ -5,8 +5,9 @@ is thread-count invariant: bit-identical across the 32-thread boundary (the
 register fallback below 32 threads reproduces the warp-shuffle reduction order
 exactly), and that the warp / cgrps surfaces match the block surface bit-for-bit.
 
-The CUDA runner (test_reduced.cu) has its own CLI:
-    <surface> <THREADS> <M> <N> <K> <TRANSPOSE_B> <ROW_MAJOR> <alpha> <beta> <A> <B> <C>
+Standard BLAS convention: C is M×N, contraction K; op(A) is M×K (TRANSPOSE_A ⇒ A
+stored K×M), op(B) is K×N (TRANSPOSE_B ⇒ B stored N×K). The CUDA runner CLI:
+    <surface> <THREADS> <M> <N> <K> <TRANSPOSE_A> <TRANSPOSE_B> <alpha> <beta> <A> <B> <C>
 """
 
 import os
@@ -22,100 +23,84 @@ RTOL = 1e-2
 ATOL = 1e-3
 
 # (M, N, K) shapes the runner compiles — consumer dims, partial-warp output
-# counts, and contraction lengths spanning the 32-lane boundary (N = 33, 64).
+# counts, and CONTRACTION lengths spanning the 32-lane boundary (K = 33, 64).
 SHAPES = [
     (1, 1, 1), (3, 5, 4), (5, 3, 6), (7, 2, 9), (8, 8, 8),
-    (14, 14, 14), (21, 21, 21), (14, 21, 7), (21, 14, 21), (7, 14, 7),
-    (2, 33, 2), (4, 64, 4),
+    (14, 14, 14), (21, 21, 21), (14, 7, 21), (21, 21, 14), (7, 7, 14),
+    (2, 2, 33), (4, 4, 64),
 ]
-# Square shapes only for TRANSPOSE_B (B must be N x N).
-SQUARE = [(m, n, k) for (m, n, k) in SHAPES if n == k]
+TRANSPOSE_COMBOS = [(0, 0), (1, 0), (0, 1), (1, 1)]
 
 # Full thread-invariance sweep for the block surface — spans the 32 boundary;
 # 31 & 57 are the load-bearing partial-warp cases.
 THREADS_SWEEP = (1, 7, 31, 32, 33, 57, 64, 96, 128, 256)
 
 
-def _ravel(mat, row_major):
-    if row_major:
-        return np.ascontiguousarray(mat).ravel(order="C")
-    return np.asfortranarray(mat).ravel(order="F")
+def _storage(M, N, K, ta, tb, seed):
+    """Logical op(A) (M×K), op(B) (K×N) + physical col-major storage (transpose
+    stores op(_)ᵀ col-major)."""
+    rng = np.random.default_rng(seed)
+    opA = rng.standard_normal((M, K)).astype(np.float32)
+    opB = rng.standard_normal((K, N)).astype(np.float32)
+    A_phys = opA.T if ta else opA
+    B_phys = opB.T if tb else opB
+    return opA, opB, A_phys, B_phys
 
 
-def _reshape(flat, m, ccols, row_major):
-    return flat.reshape(m, ccols, order="C" if row_major else "F")
-
-
-def _run(binary, surface, threads, M, N, K, tb, rm, alpha, beta, A, B, C):
-    ccols = N if tb else K
+def _run(binary, surface, threads, M, N, K, ta, tb, alpha, beta, A_phys, B_phys, C):
     tmp = []
     try:
-        for arr in (_ravel(A, rm), _ravel(B, rm), _ravel(C, rm)):
+        for arr in (np.asfortranarray(A_phys).ravel(order="F"),
+                    np.asfortranarray(B_phys).ravel(order="F"),
+                    np.asfortranarray(C).ravel(order="F")):
             f = tempfile.NamedTemporaryFile(suffix=".bin", delete=False)
             arr.astype(np.float32).tofile(f)
             f.close()
             tmp.append(f.name)
         cmd = [str(binary), surface, str(threads), str(M), str(N), str(K),
-               str(int(tb)), str(int(rm)), str(alpha), str(beta)] + tmp
+               str(int(ta)), str(int(tb)), str(alpha), str(beta)] + tmp
         res = subprocess.run(cmd, capture_output=True, text=True)
         if res.returncode != 0:
             raise RuntimeError(f"runner failed:\n{res.stderr}")
         line = res.stdout.strip().split("\n")[0]
         flat = np.fromstring(line, sep=" ").astype(np.float32)
-        return _reshape(flat, M, ccols, rm)
+        return flat.reshape(M, N, order="F")
     finally:
         for f in tmp:
             os.unlink(f)
 
 
-def _oracle(alpha, A, B, beta, C0, tb):
-    prod = (A @ B.T) if tb else (A @ B)
-    return (alpha * prod + beta * C0).astype(np.float32)
+def _oracle(alpha, opA, opB, beta, C0):
+    return (alpha * (opA @ opB) + beta * C0).astype(np.float32)
 
 
-def _make(M, N, K, tb):
-    A = RNG.random((M, N)).astype(np.float32)
-    B = RNG.random((N, N) if tb else (N, K)).astype(np.float32)
-    ccols = N if tb else K
-    C = RNG.random((M, ccols)).astype(np.float32)
-    return A, B, C
-
-
-# ─── correctness vs NumPy oracle, all 3 surfaces ─────────────────────────────
+# ─── correctness vs NumPy oracle, all transpose combos ───────────────────────
 
 @pytest.mark.parametrize("M,N,K", SHAPES)
+@pytest.mark.parametrize("ta,tb", TRANSPOSE_COMBOS)
 @pytest.mark.parametrize("alpha,beta", [(1.5, 0.3), (1.0, 0.0)])
-@pytest.mark.parametrize("row_major", [False, True])
-def test_reduced_block(bins, M, N, K, alpha, beta, row_major):
-    A, B, C = _make(M, N, K, False)
-    expected = _oracle(alpha, A, B, beta, C, False)
-    r = _run(bins["reduced"], "block", 256, M, N, K, False, row_major, alpha, beta, A, B, C.copy())
+def test_reduced_block(bins, M, N, K, ta, tb, alpha, beta):
+    opA, opB, A_phys, B_phys = _storage(M, N, K, ta, tb, seed=M * 100 + N * 10 + K + ta + tb)
+    C = RNG.random((M, N)).astype(np.float32)
+    expected = _oracle(alpha, opA, opB, beta, C)
+    r = _run(bins["reduced"], "block", 256, M, N, K, ta, tb, alpha, beta, A_phys, B_phys, C.copy())
     assert np.allclose(r, expected, rtol=RTOL, atol=ATOL), f"\nresult=\n{r}\nexpected=\n{expected}"
-
-
-@pytest.mark.parametrize("M,N,K", SQUARE)
-@pytest.mark.parametrize("row_major", [False, True])
-def test_reduced_transpose_b(bins, M, N, K, row_major):
-    alpha, beta = 1.5, 0.3
-    A, B, C = _make(M, N, K, True)
-    expected = _oracle(alpha, A, B, beta, C, True)
-    r = _run(bins["reduced"], "block", 256, M, N, K, True, row_major, alpha, beta, A, B, C.copy())
-    assert np.allclose(r, expected, rtol=RTOL, atol=ATOL)
 
 
 # ─── thread-count invariance: bit-identical across the 32 boundary ───────────
 
-@pytest.mark.parametrize("M,N,K", [(8, 8, 8), (14, 14, 14), (7, 2, 9), (2, 33, 2), (4, 64, 4)])
+@pytest.mark.parametrize("M,N,K", [(8, 8, 8), (14, 14, 14), (7, 2, 9), (2, 2, 33), (4, 4, 64)])
 def test_reduced_thread_invariance(bins, M, N, K):
     """Block surface: bit-identical at 1/7/31/32/33/57/64/96/128/256 threads
     (the <32 register path must match the warp-shuffle rounding), all matching
     the oracle."""
     alpha, beta = 1.5, 0.3
-    A, B, C = _make(M, N, K, False)
-    expected = _oracle(alpha, A, B, beta, C, False)
+    opA, opB, A_phys, B_phys = _storage(M, N, K, 0, 0, seed=M + N + K)
+    C = RNG.random((M, N)).astype(np.float32)
+    expected = _oracle(alpha, opA, opB, beta, C)
     outs = []
     for t in THREADS_SWEEP:
-        r = _run(bins["reduced"], "block", t, M, N, K, False, False, alpha, beta, A, B, C.copy())
+        r = _run(bins["reduced"], "block", t, M, N, K, 0, 0, alpha, beta, A_phys, B_phys, C.copy())
         assert np.allclose(r, expected, rtol=RTOL, atol=ATOL), f"threads={t} mismatch vs oracle"
         outs.append(r)
     for t, r in zip(THREADS_SWEEP[1:], outs[1:]):
@@ -124,15 +109,16 @@ def test_reduced_thread_invariance(bins, M, N, K):
 
 # ─── cross-surface agreement: warp / cgrps == block, bit-for-bit ─────────────
 
-@pytest.mark.parametrize("M,N,K", [(8, 8, 8), (14, 14, 14), (21, 14, 21), (4, 64, 4)])
+@pytest.mark.parametrize("M,N,K", [(8, 8, 8), (14, 14, 14), (21, 21, 14), (4, 4, 64)])
 def test_reduced_surfaces_agree(bins, M, N, K):
     alpha, beta = 1.5, 0.3
-    A, B, C = _make(M, N, K, False)
-    block = _run(bins["reduced"], "block", 256, M, N, K, False, False, alpha, beta, A, B, C.copy())
-    warp = _run(bins["reduced"], "warp", 32, M, N, K, False, False, alpha, beta, A, B, C.copy())
+    opA, opB, A_phys, B_phys = _storage(M, N, K, 0, 0, seed=M * 7 + N * 3 + K)
+    C = RNG.random((M, N)).astype(np.float32)
+    block = _run(bins["reduced"], "block", 256, M, N, K, 0, 0, alpha, beta, A_phys, B_phys, C.copy())
+    warp = _run(bins["reduced"], "warp", 32, M, N, K, 0, 0, alpha, beta, A_phys, B_phys, C.copy())
     assert np.array_equal(block, warp), "warp surface != block surface"
     for t in (32, 64, 128, 256):
-        cg = _run(bins["reduced"], "cgrps", t, M, N, K, False, False, alpha, beta, A, B, C.copy())
+        cg = _run(bins["reduced"], "cgrps", t, M, N, K, 0, 0, alpha, beta, A_phys, B_phys, C.copy())
         assert np.array_equal(block, cg), f"cgrps surface != block surface at {t} threads"
 
 
@@ -141,8 +127,8 @@ def test_reduced_surfaces_agree(bins, M, N, K):
 @pytest.mark.parametrize("M,N,K", [(8, 8, 8), (14, 14, 14)])
 def test_reduced_beta0_skips_C(bins, M, N, K):
     alpha = 1.0
-    A, B, _ = _make(M, N, K, False)
-    C = np.full((M, K), np.nan, dtype=np.float32)
-    r = _run(bins["reduced"], "block", 256, M, N, K, False, False, alpha, 0.0, A, B, C)
-    expected = (alpha * (A @ B)).astype(np.float32)
+    opA, opB, A_phys, B_phys = _storage(M, N, K, 0, 0, seed=M + N + K + 1)
+    C = np.full((M, N), np.nan, dtype=np.float32)
+    r = _run(bins["reduced"], "block", 256, M, N, K, 0, 0, alpha, 0.0, A_phys, B_phys, C)
+    expected = (alpha * (opA @ opB)).astype(np.float32)
     assert np.allclose(r, expected, rtol=RTOL, atol=ATOL), "beta=0 path read NaN-poisoned C"

--- a/test/test_solve.py
+++ b/test/test_solve.py
@@ -42,10 +42,10 @@ def _posv(binary, th, N, NRHS, reg, rho, A, B):
             os.unlink(f)
 
 
-def _ricc(binary, th, NX, NU, reg, rho, P, A, B, R):
+def _ricc(binary, th, NX, NU, reg, rho, P, A, B, R, op="riccati"):
     t = [_w(P), _w(A), _w(B), _w(R)]
     try:
-        r = subprocess.run([str(binary), "riccati", str(th), str(NX), str(NU),
+        r = subprocess.run([str(binary), op, str(th), str(NX), str(NU),
                             str(int(reg)), str(rho)] + t, capture_output=True, text=True)
         if r.returncode != 0:
             raise RuntimeError(r.stderr)
@@ -102,3 +102,25 @@ def test_riccati_thread_invariance(bins, NX, NU):
     outs = [_ricc(bins["solve"], t, NX, NU, False, 0.0, P, A, B, R)[1] for t in THREADS_SWEEP]
     for t, r in zip(THREADS_SWEEP[1:], outs[1:]):
         assert np.array_equal(outs[0], r), f"thread-count non-invariance at {t}"
+
+
+# ─── warp riccati_gain (one 32-lane warp; parity with the block form) ─────────
+
+@pytest.mark.parametrize("NX,NU", RIC)
+@pytest.mark.parametrize("reg", [False, True])
+def test_riccati_gain_warp(bins, NX, NU, reg):
+    """warp::riccati_gain matches the analytic K = (R+BᵀPB)⁻¹(BᵀPA) and the block
+    form, at one warp (composes warp congruence_sym + bilinear + flagged posv)."""
+    P = _spd(NX)
+    A = RNG.random((NX, NX)).astype(np.float32)
+    B = RNG.random((NX, NU)).astype(np.float32)
+    R = _spd(NU)
+    rho = 0.5 if reg else 0.0
+    fail, K = _ricc(bins["solve"], 32, NX, NU, reg, rho, P, A, B, R, op="riccati_warp")
+    S = R + B.T @ P @ B + rho * np.eye(NU)
+    expK = np.linalg.solve(S, B.T @ P @ A)
+    assert fail == 0
+    assert np.allclose(K, expK, rtol=RTOL, atol=ATOL), f"warp err {np.abs(K-expK).max()}"
+    # parity with the block form
+    _, Kb = _ricc(bins["solve"], 128, NX, NU, reg, rho, P, A, B, R, op="riccati")
+    assert np.allclose(K, Kb, rtol=1e-3, atol=1e-4), "warp riccati != block riccati"

--- a/test/test_syrk.py
+++ b/test/test_syrk.py
@@ -1,7 +1,7 @@
 """SYRK / SYR2K GLASS function tests — compare GPU results to a NumPy oracle.
 
 The CUDA runner (test_syrk.cu) has its own CLI:
-    <op> <THREADS> <n> <k> <FILL> <TRANS> <ROW_MAJOR> <alpha> <beta> <A.bin> [<B.bin>] <C.bin>
+    <op> <THREADS> <n> <k> <FILL> <TRANSPOSE> <ROW_MAJOR> <alpha> <beta> <A.bin> [<B.bin>] <C.bin>
 so we invoke it directly rather than via conftest.run_op (whose fixed
 `op version args... files...` shape doesn't match).
 """
@@ -40,7 +40,7 @@ def _run(binary, op, threads, n, k, fill, trans, row_major,
     tmp = []
     try:
         arrays = [_ravel(A, row_major)]
-        if op == "syr2k":
+        if op.startswith("syr2k"):
             arrays.append(_ravel(B, row_major))
         arrays.append(_ravel(C, row_major))
         for arr in arrays:
@@ -75,7 +75,7 @@ def _oracle_syr2k(alpha, A, B, beta, C0, trans):
 
 
 def _shapes(n, k, trans):
-    """Shape of A (and B) given n,k and TRANS. TRANS=false → n x k; true → k x n."""
+    """Shape of A (and B) given n,k and TRANSPOSE. TRANSPOSE=false → n x k; true → k x n."""
     return (k, n) if trans else (n, k)
 
 
@@ -172,3 +172,34 @@ def test_syrk_thread_invariance(bins, op, n, k, trans):
         outs.append(r)
     for r in outs[1:]:
         assert np.array_equal(outs[0], r), "thread-count non-invariance"
+
+
+# ─── warp forms (compile-time N,K; one 32-lane warp) ──────────────────────────
+# warp::syrk/syr2k reuse the SAME validated syrk_impl_ct/syr2k_impl_ct as the block
+# form (just (lane,32) striping), so the warp output must equal the block output
+# bit-for-bit AND satisfy the oracle. Harness instantiates these (n,k) shapes only.
+WARP_PAIRS = [(4, 6), (6, 4), (7, 6)]
+WARP = 32
+
+
+@pytest.mark.parametrize("op", ["syrk_warp", "syr2k_warp"])
+@pytest.mark.parametrize("n,k", WARP_PAIRS)
+@pytest.mark.parametrize("fill", FILLS, ids=lambda f: FILL_IDS[f])
+@pytest.mark.parametrize("trans", TRANSES)
+@pytest.mark.parametrize("row_major", [False, True])
+def test_syrk_warp(bins, op, n, k, fill, trans, row_major):
+    block_op = op.replace("_warp", "")
+    alpha, beta = 1.5, 0.3
+    sh = _shapes(n, k, trans)
+    A = RNG.random(sh).astype(np.float32)
+    B = RNG.random(sh).astype(np.float32) if block_op == "syr2k" else None
+    C = RNG.random((n, n)).astype(np.float32)
+    C0 = C.copy()
+    warp = _run(bins["syrk"], op, WARP, n, k, fill, trans, row_major, alpha, beta, A, B, C)
+    block = _run(bins["syrk"], block_op, 64, n, k, fill, trans, row_major, alpha, beta, A, B, C)
+    # warp == block bit-for-bit (same impl, restricted to one warp)
+    assert np.array_equal(warp, block), f"{op} n={n} k={k} fill={fill}: warp != block"
+    # and matches the oracle per FILL semantics
+    expected = (_oracle_syrk(alpha, A, beta, C0, trans) if block_op == "syrk"
+                else _oracle_syr2k(alpha, A, B, beta, C0, trans))
+    _check(warp, expected, n, fill, C0)


### PR DESCRIPTION
Project-wide API uniformity pass. Clean-break, no back-compat aliases (internal-only consumers). Full suite **2703 passed / 0 failed** (clean rebuild), matching baseline exactly.

## What changed
- **TRAILING_SYNC everywhere** — every public op takes a final `bool TRAILING_SYNC = true` and ends on a barrier so the result is valid for all threads by default. Byte-identical where the op already ended on a barrier; adds a safe one where it didn't. Uniformity as a primary design decision. (Structural-barrier ops chol/inv/trsm/trsv/posv/ldlt and `warp::` lockstep ops are documented exceptions.)
- **cgrps dedup via barrier policy** — `glass::cgrps::` no longer copies op bodies; every op delegates to a shared `glass::*_impl(Bar bar, …)` body via a `BlockBarrier`/`GroupBarrier` policy. One behavioral fix: `cgrps::nrm2`/`cholDecomp_InPlace` now use type-generic `sqrt` (was `sqrtf`) so `double` no longer truncates.
- **Batching renames** → `operation_qualifier`: `gemv_strided`/`gemm_strided`/`gemv_segmented`/`gemm_batched_indexed`/`axpy_strided`/`copy_strided`.
- **Workspace-size helpers unified** → `<op>_scratch_bytes` returning `std::size_t` **bytes** (was a mix of `_smem_size`/`_scratch_size`/`_temp_size`, some bytes/some elements). Scratch param unified to `s_scratch`.
- **const-correctness** — `const T*` on read-only inputs of `gemm`/`gemv`/`syrk`/`syr2k`/`ger` (non-breaking).
- **`TRANS` → `TRANSPOSE`** flag token; `l2norm` → `nrm2`.
- New concept pages (`trailing_sync`, `batching`) + consumer migration note (`docs/open-tasks/consumer_migration_2026-06-25.md`).

## Perf validation
Post-wave `bench_mega_sweep` (sm_120, quiet GPU) vs the pre-wave sweep: **5 of 6 backend ladders byte-identical**; the only delta (`gemv` N≥48) is tie-band noise (1.00–1.01× three-way ties), not a real shift. **TRAILING_SYNC-everywhere is perf-neutral** — no `ideal_sm120` change needed.

## Known follow-ups (non-blocking; docs build is green)
- Doxygen `@param` warnings: the `_scratch_bytes` helpers in `inv.cuh`/`ldlt.cuh` sit between a sibling's doc-comment and its function → doc block mis-attaches (reorder fix). Plus ~24 cosmetic "undocumented `bar` param" notes on the internal `_impl` helpers.
- Consumer migration note to send to GRiD/GATO/PDDP/HJCD.
- Unified autotune effort (separate branch): consolidate the three perf-table tools + add a tie margin + cover the new families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)